### PR TITLE
Fixed issue #6 - Duplicate Class (Flow)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ ext {
     buildToolsVersion = '30.0.1'
     minSdkVersion = 21
     targetSdkVersion = 30
-    versionCode = 1
-    versionName = "1.0.0"
+    versionCode = 2
+    versionName = "1.0.1"
     ndk = "21.3.6528147"
 
     ANNOTATIONS = 'org.jetbrains:annotations-java5:17.0.0'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,11 +17,6 @@ android {
 		}
 	}
 
-//	buildFeatures {
-//		dataBinding true
-//		viewBinding true
-//	}
-
 	lintOptions {
 		abortOnError false
 	}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -31,10 +31,6 @@ android {
 	}
 }
 
-configurations.all {
-	exclude group: 'org.jetbrains', module: 'annotations-java5'
-}
-
 dependencies {
 	implementation fileTree(dir: "libs", include: ["*.jar"])
 	implementation project(':stylar')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,37 +1,36 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion rootProject.ext.buildToolsVersion
-	defaultConfig {
-		applicationId "com.zeoflow.stylar"
-		minSdkVersion rootProject.ext.minSdkVersion
-		targetSdkVersion rootProject.ext.targetSdkVersion
-		versionCode rootProject.ext.versionCode
-		versionName rootProject.ext.versionName
-	}
-	buildTypes {
-		release {
-			minifyEnabled false
-			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-		}
-	}
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+    defaultConfig {
+        applicationId "com.zeoflow.stylar"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName rootProject.ext.versionName
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
 
-	lintOptions {
-		abortOnError false
-	}
-	compileOptions {
-		sourceCompatibility JavaVersion.VERSION_1_8
-		targetCompatibility JavaVersion.VERSION_1_8
-	}
+    lintOptions {
+        abortOnError false
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
-	implementation fileTree(dir: "libs", include: ["*.jar"])
-	implementation project(':stylar')
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation project(':stylar')
 
-	implementation 'androidx.appcompat:appcompat:1.2.0'
-	implementation 'com.atlassian.commonmark:commonmark:0.13.0'
-	implementation 'com.github.bumptech.glide:glide:4.11.0'
-
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.atlassian.commonmark:commonmark:0.13.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
 }

--- a/stylar/build.gradle
+++ b/stylar/build.gradle
@@ -26,14 +26,10 @@ android {
     }
 }
 
-configurations.all {
-    exclude group: 'org.jetbrains', module: 'annotations-java5'
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.zeoflow:zson:1.2.1'
+    implementation 'com.zeoflow:zson:1.2.2'
     implementation 'com.zeoflow:material-elements:2.1.0'
 
     implementation 'io.coil-kt:coil:0.12.0'
@@ -47,7 +43,6 @@ dependencies {
     implementation 'com.atlassian.commonmark:commonmark-ext-gfm-strikethrough:0.13.0'
     implementation 'com.atlassian.commonmark:commonmark-ext-gfm-tables:0.13.0'
 
-
     implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.20'
     implementation 'ru.noties:jlatexmath-android:0.2.0'
     implementation 'junit:junit:4.13'
@@ -56,7 +51,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.github.akarnokd:ixjava:1.0.0'
     implementation 'commons-io:commons-io:2.6'
-    implementation 'org.jetbrains:annotations-java5:17.0.0'
     implementation 'com.google.googlejavaformat:google-java-format:1.6'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
 

--- a/stylar/build.gradle
+++ b/stylar/build.gradle
@@ -31,12 +31,13 @@ dependencies {
 
     implementation 'com.zeoflow:zson:1.2.2'
     implementation 'com.zeoflow:material-elements:2.1.0'
+    implementation 'com.zeoflow:flow-kit:1.0.1'
 
     implementation 'io.coil-kt:coil:0.12.0'
     implementation 'io.coil-kt:coil-base:0.12.0'
 
+    // soon -> replace with zeoflow's image library
     implementation 'com.squareup.picasso:picasso:2.71828'
-
     implementation 'com.github.bumptech.glide:glide:4.11.0'
 
     implementation 'com.atlassian.commonmark:commonmark:0.13.0'

--- a/stylar/gradle.properties
+++ b/stylar/gradle.properties
@@ -1,11 +1,9 @@
 POM_NAME=Stylar
 POM_ARTIFACT_ID=stylar
 POM_PACKAGING=aar
-
 VERSION_NAME=1.0.1
 VERSION_CODE=2
 GROUP=com.zeoflow
-
 POM_DESCRIPTION=An Android markdown library - it does not require WebView
 POM_URL=https://github.com/zeoflow/stylar
 POM_SCM_URL=https://github.com/zeoflow/stylar
@@ -16,9 +14,7 @@ POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=zeoflow
 POM_DEVELOPER_NAME=ZeoFlow
-
 org.gradle.daemon=true
-
 NEXUS_USERNAME=
 NEXUS_PASSWORD=
 signing.keyId=

--- a/stylar/gradle.properties
+++ b/stylar/gradle.properties
@@ -2,8 +2,8 @@ POM_NAME=Stylar
 POM_ARTIFACT_ID=stylar
 POM_PACKAGING=aar
 
-VERSION_NAME=1.0.0
-VERSION_CODE=1
+VERSION_NAME=1.0.1
+VERSION_CODE=2
 GROUP=com.zeoflow
 
 POM_DESCRIPTION=An Android markdown library - it does not require WebView

--- a/stylar/maven-push.gradle
+++ b/stylar/maven-push.gradle
@@ -18,88 +18,88 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 def isReleaseBuild() {
-  return VERSION_NAME.contains("SNAPSHOT") == false
+    return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
 def getReleaseRepositoryUrl() {
-  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-    : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 }
 
 def getSnapshotRepositoryUrl() {
-  return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-    : "https://oss.sonatype.org/content/repositories/snapshots/"
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
 def getRepositoryUsername() {
-  return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
 }
 
 def getRepositoryPassword() {
-  return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
 afterEvaluate { project ->
-  project.generateDebugBuildConfig.enabled = false
-  project.generateReleaseBuildConfig.enabled = false
-  uploadArchives {
-    repositories {
-      mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+    project.generateDebugBuildConfig.enabled = false
+    project.generateReleaseBuildConfig.enabled = false
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
+                pom.groupId = GROUP
+                pom.artifactId = POM_ARTIFACT_ID
+                pom.version = VERSION_NAME
 
-        repository(url: getReleaseRepositoryUrl()) {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
-        snapshotRepository(url: getSnapshotRepositoryUrl()) {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
+                repository(url: getReleaseRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
+                snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                }
 
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
+                pom.project {
+                    name POM_NAME
+                    packaging POM_PACKAGING
+                    description POM_DESCRIPTION
+                    url POM_URL
 
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
+                    scm {
+                        url POM_SCM_URL
+                        connection POM_SCM_CONNECTION
+                        developerConnection POM_SCM_DEV_CONNECTION
+                    }
 
-          licenses {
-            license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
+                    licenses {
+                        license {
+                            name POM_LICENCE_NAME
+                            url POM_LICENCE_URL
+                            distribution POM_LICENCE_DIST
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id POM_DEVELOPER_ID
+                            name POM_DEVELOPER_NAME
+                        }
+                    }
+                }
             }
-          }
-
-          developers {
-            developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
-            }
-          }
         }
-      }
     }
-  }
 
-  signing {
-    required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
-  }
+    signing {
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        sign configurations.archives
+    }
 
-  task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
-  }
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.sourceFiles
+    }
 
-  artifacts {
-    archives androidSourcesJar
-  }
+    artifacts {
+        archives androidSourcesJar
+    }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/AbstractStylarPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/AbstractStylarPlugin.java
@@ -5,10 +5,10 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import com.zeoflow.stylar.core.StylarTheme;
+
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
-
-import com.zeoflow.stylar.core.StylarTheme;
 
 /**
  * Class that extends {@link StylarPlugin} with all methods implemented (empty body)
@@ -21,58 +21,69 @@ public abstract class AbstractStylarPlugin implements StylarPlugin
 {
 
     @Override
-    public void configure(@NonNull Registry registry) {
+    public void configure(@NonNull Registry registry)
+    {
 
     }
 
     @Override
-    public void configureParser(@NonNull Parser.Builder builder) {
+    public void configureParser(@NonNull Parser.Builder builder)
+    {
 
     }
 
     @Override
-    public void configureTheme(@NonNull StylarTheme.Builder builder) {
+    public void configureTheme(@NonNull StylarTheme.Builder builder)
+    {
 
     }
 
     @Override
-    public void configureConfiguration(@NonNull StylarConfiguration.Builder builder) {
+    public void configureConfiguration(@NonNull StylarConfiguration.Builder builder)
+    {
 
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
 
     }
 
     @Override
-    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder) {
+    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder)
+    {
 
     }
 
     @NonNull
     @Override
-    public String processMarkdown(@NonNull String markdown) {
+    public String processMarkdown(@NonNull String markdown)
+    {
         return markdown;
     }
 
     @Override
-    public void beforeRender(@NonNull Node node) {
+    public void beforeRender(@NonNull Node node)
+    {
 
     }
 
     @Override
-    public void afterRender(@NonNull Node node, @NonNull StylarVisitor visitor) {
+    public void afterRender(@NonNull Node node, @NonNull StylarVisitor visitor)
+    {
 
     }
 
     @Override
-    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown) {
+    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown)
+    {
 
     }
 
     @Override
-    public void afterSetText(@NonNull TextView textView) {
+    public void afterSetText(@NonNull TextView textView)
+    {
 
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/BlockHandlerDef.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/BlockHandlerDef.java
@@ -7,15 +7,19 @@ import org.commonmark.node.Node;
 /**
  * @since 4.3.0
  */
-public class BlockHandlerDef implements StylarVisitor.BlockHandler {
+public class BlockHandlerDef implements StylarVisitor.BlockHandler
+{
     @Override
-    public void blockStart(@NonNull StylarVisitor visitor, @NonNull Node node) {
+    public void blockStart(@NonNull StylarVisitor visitor, @NonNull Node node)
+    {
         visitor.ensureNewLine();
     }
 
     @Override
-    public void blockEnd(@NonNull StylarVisitor visitor, @NonNull Node node) {
-        if (visitor.hasNext(node)) {
+    public void blockEnd(@NonNull StylarVisitor visitor, @NonNull Node node)
+    {
+        if (visitor.hasNext(node))
+        {
             visitor.ensureNewLine();
             visitor.forceNewLine();
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/LinkResolver.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/LinkResolver.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
  * @see StylarConfiguration.Builder#linkResolver(LinkResolver)
  * @since 4.0.0
  */
-public interface LinkResolver {
+public interface LinkResolver
+{
     void resolve(@NonNull View view, @NonNull String link);
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/LinkResolverDef.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/LinkResolverDef.java
@@ -11,35 +11,41 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 
-public class LinkResolverDef implements LinkResolver {
+public class LinkResolverDef implements LinkResolver
+{
 
     // @since 4.3.0
     private static final String DEFAULT_SCHEME = "https";
-
-    @Override
-    public void resolve(@NonNull View view, @NonNull String link) {
-        final Uri uri = parseLink(link);
-        final Context context = view.getContext();
-        final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-        intent.putExtra(Browser.EXTRA_APPLICATION_ID, context.getPackageName());
-        try {
-            context.startActivity(intent);
-        } catch (ActivityNotFoundException e) {
-            Log.w("LinkResolverDef", "Actvity was not found for the link: '" + link + "'");
-        }
-    }
 
     /**
      * @since 4.3.0
      */
     @NonNull
-    private static Uri parseLink(@NonNull String link) {
+    private static Uri parseLink(@NonNull String link)
+    {
         final Uri uri = Uri.parse(link);
-        if (TextUtils.isEmpty(uri.getScheme())) {
+        if (TextUtils.isEmpty(uri.getScheme()))
+        {
             return uri.buildUpon()
-                    .scheme(DEFAULT_SCHEME)
-                    .build();
+                .scheme(DEFAULT_SCHEME)
+                .build();
         }
         return uri;
+    }
+
+    @Override
+    public void resolve(@NonNull View view, @NonNull String link)
+    {
+        final Uri uri = parseLink(link);
+        final Context context = view.getContext();
+        final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        intent.putExtra(Browser.EXTRA_APPLICATION_ID, context.getPackageName());
+        try
+        {
+            context.startActivity(intent);
+        } catch (ActivityNotFoundException e)
+        {
+            Log.w("LinkResolverDef", "Actvity was not found for the link: '" + link + "'");
+        }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/PrecomputedFutureTextSetterCompat.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/PrecomputedFutureTextSetterCompat.java
@@ -18,48 +18,55 @@ import java.util.concurrent.Future;
  * @see Stylar.TextSetter
  * @since 4.3.1
  */
-public class PrecomputedFutureTextSetterCompat implements Stylar.TextSetter {
+public class PrecomputedFutureTextSetterCompat implements Stylar.TextSetter
+{
+
+    @Nullable
+    private final Executor executor;
+
+    @SuppressWarnings("WeakerAccess")
+    PrecomputedFutureTextSetterCompat(@Nullable Executor executor)
+    {
+        this.executor = executor;
+    }
 
     /**
      * @param executor for background execution of text pre-computation,
      *                 if not provided the standard, single threaded one will be used.
      */
     @NonNull
-    public static PrecomputedFutureTextSetterCompat create(@Nullable Executor executor) {
+    public static PrecomputedFutureTextSetterCompat create(@Nullable Executor executor)
+    {
         return new PrecomputedFutureTextSetterCompat(executor);
     }
 
     @NonNull
-    public static PrecomputedFutureTextSetterCompat create() {
+    public static PrecomputedFutureTextSetterCompat create()
+    {
         return new PrecomputedFutureTextSetterCompat(null);
-    }
-
-    @Nullable
-    private final Executor executor;
-
-    @SuppressWarnings("WeakerAccess")
-    PrecomputedFutureTextSetterCompat(@Nullable Executor executor) {
-        this.executor = executor;
     }
 
     @Override
     public void setText(
-            @NonNull TextView textView,
-            @NonNull Spanned markdown,
-            @NonNull TextView.BufferType bufferType,
-            @NonNull Runnable onComplete) {
-        if (textView instanceof AppCompatTextView) {
+        @NonNull TextView textView,
+        @NonNull Spanned markdown,
+        @NonNull TextView.BufferType bufferType,
+        @NonNull Runnable onComplete)
+    {
+        if (textView instanceof AppCompatTextView)
+        {
             final AppCompatTextView appCompatTextView = (AppCompatTextView) textView;
             final Future<PrecomputedTextCompat> future = PrecomputedTextCompat.getTextFuture(
-                    markdown,
-                    appCompatTextView.getTextMetricsParamsCompat(),
-                    executor);
+                markdown,
+                appCompatTextView.getTextMetricsParamsCompat(),
+                executor);
             appCompatTextView.setTextFuture(future);
             // `setTextFuture` is actually a synchronous call, so we should call onComplete now
             onComplete.run();
-        } else {
+        } else
+        {
             throw new IllegalStateException("TextView provided is not an instance of AppCompatTextView, " +
-                    "cannot call setTextFuture(), textView: " + textView);
+                "cannot call setTextFuture(), textView: " + textView);
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/Prop.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/Prop.java
@@ -11,59 +11,71 @@ import androidx.annotation.Nullable;
  * @see #of(Class, String)
  * @since 3.0.0
  */
-public class Prop<T> {
-
-    @SuppressWarnings("unused")
-    @NonNull
-    public static <T> Prop<T> of(@NonNull Class<T> type, @NonNull String name) {
-        return new Prop<>(name);
-    }
-
-    @NonNull
-    public static <T> Prop<T> of(@NonNull String name) {
-        return new Prop<>(name);
-    }
+public class Prop<T>
+{
 
     private final String name;
 
-    Prop(@NonNull String name) {
+    Prop(@NonNull String name)
+    {
         this.name = name;
     }
 
+    @SuppressWarnings("unused")
     @NonNull
-    public String name() {
+    public static <T> Prop<T> of(@NonNull Class<T> type, @NonNull String name)
+    {
+        return new Prop<>(name);
+    }
+
+    @NonNull
+    public static <T> Prop<T> of(@NonNull String name)
+    {
+        return new Prop<>(name);
+    }
+
+    @NonNull
+    public String name()
+    {
         return name;
     }
 
     @Nullable
-    public T get(@NonNull RenderProps props) {
+    public T get(@NonNull RenderProps props)
+    {
         return props.get(this);
     }
 
     @NonNull
-    public T get(@NonNull RenderProps props, @NonNull T defValue) {
+    public T get(@NonNull RenderProps props, @NonNull T defValue)
+    {
         return props.get(this, defValue);
     }
 
     @NonNull
-    public T require(@NonNull RenderProps props) {
+    public T require(@NonNull RenderProps props)
+    {
         final T t = get(props);
-        if (t == null) {
+        if (t == null)
+        {
             throw new NullPointerException(name);
         }
         return t;
     }
 
-    public void set(@NonNull RenderProps props, @Nullable T value) {
+    public void set(@NonNull RenderProps props, @Nullable T value)
+    {
         props.set(this, value);
     }
 
-    public void clear(@NonNull RenderProps props) {
+    public void clear(@NonNull RenderProps props)
+    {
         props.clear(this);
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(Object o)
+    {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -73,14 +85,16 @@ public class Prop<T> {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return name.hashCode();
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "Prop{" +
-                "name='" + name + '\'' +
-                '}';
+            "name='" + name + '\'' +
+            '}';
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/RenderProps.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/RenderProps.java
@@ -6,7 +6,8 @@ import androidx.annotation.Nullable;
 /**
  * @since 3.0.0
  */
-public interface RenderProps {
+public interface RenderProps
+{
 
     @Nullable
     <T> T get(@NonNull Prop<T> prop);

--- a/stylar/src/main/java/com/zeoflow/stylar/RenderPropsImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/RenderPropsImpl.java
@@ -9,22 +9,26 @@ import java.util.Map;
 /**
  * @since 3.0.0
  */
-class RenderPropsImpl implements RenderProps {
+class RenderPropsImpl implements RenderProps
+{
 
     private final Map<Prop, Object> values = new HashMap<>(3);
 
     @Nullable
     @Override
-    public <T> T get(@NonNull Prop<T> prop) {
+    public <T> T get(@NonNull Prop<T> prop)
+    {
         //noinspection unchecked
         return (T) values.get(prop);
     }
 
     @NonNull
     @Override
-    public <T> T get(@NonNull Prop<T> prop, @NonNull T defValue) {
+    public <T> T get(@NonNull Prop<T> prop, @NonNull T defValue)
+    {
         Object value = values.get(prop);
-        if (value != null) {
+        if (value != null)
+        {
             //noinspection unchecked
             return (T) value;
         }
@@ -32,21 +36,26 @@ class RenderPropsImpl implements RenderProps {
     }
 
     @Override
-    public <T> void set(@NonNull Prop<T> prop, @Nullable T value) {
-        if (value == null) {
+    public <T> void set(@NonNull Prop<T> prop, @Nullable T value)
+    {
+        if (value == null)
+        {
             values.remove(prop);
-        } else {
+        } else
+        {
             values.put(prop, value);
         }
     }
 
     @Override
-    public <T> void clear(@NonNull Prop<T> prop) {
+    public <T> void clear(@NonNull Prop<T> prop)
+    {
         values.remove(prop);
     }
 
     @Override
-    public void clearAll() {
+    public void clearAll()
+    {
         values.clear();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/SoftBreakAddsNewLinePlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/SoftBreakAddsNewLinePlugin.java
@@ -11,15 +11,19 @@ public class SoftBreakAddsNewLinePlugin extends AbstractStylarPlugin
 {
 
     @NonNull
-    public static SoftBreakAddsNewLinePlugin create() {
+    public static SoftBreakAddsNewLinePlugin create()
+    {
         return new SoftBreakAddsNewLinePlugin();
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
-        builder.on(SoftLineBreak.class, new StylarVisitor.NodeVisitor<SoftLineBreak>() {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(SoftLineBreak.class, new StylarVisitor.NodeVisitor<SoftLineBreak>()
+        {
             @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull SoftLineBreak softLineBreak) {
+            public void visit(@NonNull StylarVisitor visitor, @NonNull SoftLineBreak softLineBreak)
+            {
                 visitor.ensureNewLine();
             }
         });

--- a/stylar/src/main/java/com/zeoflow/stylar/SpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/SpanFactory.java
@@ -6,10 +6,11 @@ import androidx.annotation.Nullable;
 /**
  * @since 3.0.0
  */
-public interface SpanFactory {
+public interface SpanFactory
+{
 
     @Nullable
     Object getSpans(
-            @NonNull StylarConfiguration configuration,
-            @NonNull RenderProps props);
+        @NonNull StylarConfiguration configuration,
+        @NonNull RenderProps props);
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarBuilderImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarBuilderImpl.java
@@ -57,6 +57,12 @@ class StylarBuilderImpl implements Stylar.Builder
     }
 
     @NonNull
+    private static List<StylarPlugin> preparePlugins(@NonNull List<StylarPlugin> plugins)
+    {
+        return new RegistryImpl(plugins).process();
+    }
+
+    @NonNull
     @Override
     public Stylar.Builder bufferType(@NonNull TextView.BufferType bufferType)
     {
@@ -222,11 +228,5 @@ class StylarBuilderImpl implements Stylar.Builder
             codeStyle,
             clickEvent
         );
-    }
-
-    @NonNull
-    private static List<StylarPlugin> preparePlugins(@NonNull List<StylarPlugin> plugins)
-    {
-        return new RegistryImpl(plugins).process();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarConfiguration.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarConfiguration.java
@@ -16,11 +16,6 @@ import com.zeoflow.stylar.syntax.SyntaxHighlightNoOp;
 public class StylarConfiguration
 {
 
-    @NonNull
-    public static Builder builder() {
-        return new Builder();
-    }
-
     private final StylarTheme theme;
     private final AsyncDrawableLoader asyncDrawableLoader;
     private final SyntaxHighlight syntaxHighlight;
@@ -28,11 +23,11 @@ public class StylarConfiguration
     // @since 4.4.0
     private final ImageDestinationProcessor imageDestinationProcessor;
     private final ImageSizeResolver imageSizeResolver;
-
     // @since 3.0.0
     private final StylarSpansFactory spansFactory;
 
-    private StylarConfiguration(@NonNull Builder builder) {
+    private StylarConfiguration(@NonNull Builder builder)
+    {
         this.theme = builder.theme;
         this.asyncDrawableLoader = builder.asyncDrawableLoader;
         this.syntaxHighlight = builder.syntaxHighlight;
@@ -43,22 +38,32 @@ public class StylarConfiguration
     }
 
     @NonNull
-    public StylarTheme theme() {
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    @NonNull
+    public StylarTheme theme()
+    {
         return theme;
     }
 
     @NonNull
-    public AsyncDrawableLoader asyncDrawableLoader() {
+    public AsyncDrawableLoader asyncDrawableLoader()
+    {
         return asyncDrawableLoader;
     }
 
     @NonNull
-    public SyntaxHighlight syntaxHighlight() {
+    public SyntaxHighlight syntaxHighlight()
+    {
         return syntaxHighlight;
     }
 
     @NonNull
-    public LinkResolver linkResolver() {
+    public LinkResolver linkResolver()
+    {
         return linkResolver;
     }
 
@@ -66,12 +71,14 @@ public class StylarConfiguration
      * @since 4.4.0
      */
     @NonNull
-    public ImageDestinationProcessor imageDestinationProcessor() {
+    public ImageDestinationProcessor imageDestinationProcessor()
+    {
         return imageDestinationProcessor;
     }
 
     @NonNull
-    public ImageSizeResolver imageSizeResolver() {
+    public ImageSizeResolver imageSizeResolver()
+    {
         return imageSizeResolver;
     }
 
@@ -79,12 +86,14 @@ public class StylarConfiguration
      * @since 3.0.0
      */
     @NonNull
-    public StylarSpansFactory spansFactory() {
+    public StylarSpansFactory spansFactory()
+    {
         return spansFactory;
     }
 
     @SuppressWarnings({"unused", "UnusedReturnValue"})
-    public static class Builder {
+    public static class Builder
+    {
 
         private StylarTheme theme;
         private AsyncDrawableLoader asyncDrawableLoader;
@@ -95,26 +104,30 @@ public class StylarConfiguration
         private ImageSizeResolver imageSizeResolver;
         private StylarSpansFactory spansFactory;
 
-        public Builder() {
+        public Builder()
+        {
         }
 
         /**
          * @since 4.0.0
          */
         @NonNull
-        public Builder asyncDrawableLoader(@NonNull AsyncDrawableLoader asyncDrawableLoader) {
+        public Builder asyncDrawableLoader(@NonNull AsyncDrawableLoader asyncDrawableLoader)
+        {
             this.asyncDrawableLoader = asyncDrawableLoader;
             return this;
         }
 
         @NonNull
-        public Builder syntaxHighlight(@NonNull SyntaxHighlight syntaxHighlight) {
+        public Builder syntaxHighlight(@NonNull SyntaxHighlight syntaxHighlight)
+        {
             this.syntaxHighlight = syntaxHighlight;
             return this;
         }
 
         @NonNull
-        public Builder linkResolver(@NonNull LinkResolver linkResolver) {
+        public Builder linkResolver(@NonNull LinkResolver linkResolver)
+        {
             this.linkResolver = linkResolver;
             return this;
         }
@@ -123,7 +136,8 @@ public class StylarConfiguration
          * @since 4.4.0
          */
         @NonNull
-        public Builder imageDestinationProcessor(@NonNull ImageDestinationProcessor imageDestinationProcessor) {
+        public Builder imageDestinationProcessor(@NonNull ImageDestinationProcessor imageDestinationProcessor)
+        {
             this.imageDestinationProcessor = imageDestinationProcessor;
             return this;
         }
@@ -132,38 +146,45 @@ public class StylarConfiguration
          * @since 1.0.1
          */
         @NonNull
-        public Builder imageSizeResolver(@NonNull ImageSizeResolver imageSizeResolver) {
+        public Builder imageSizeResolver(@NonNull ImageSizeResolver imageSizeResolver)
+        {
             this.imageSizeResolver = imageSizeResolver;
             return this;
         }
 
         @NonNull
         public StylarConfiguration build(
-                @NonNull StylarTheme theme,
-                @NonNull StylarSpansFactory spansFactory) {
+            @NonNull StylarTheme theme,
+            @NonNull StylarSpansFactory spansFactory)
+        {
 
             this.theme = theme;
             this.spansFactory = spansFactory;
 
             // @since 4.0.0
-            if (asyncDrawableLoader == null) {
+            if (asyncDrawableLoader == null)
+            {
                 asyncDrawableLoader = AsyncDrawableLoader.noOp();
             }
 
-            if (syntaxHighlight == null) {
+            if (syntaxHighlight == null)
+            {
                 syntaxHighlight = new SyntaxHighlightNoOp();
             }
 
-            if (linkResolver == null) {
+            if (linkResolver == null)
+            {
                 linkResolver = new LinkResolverDef();
             }
 
             // @since 4.4.0
-            if (imageDestinationProcessor == null) {
+            if (imageDestinationProcessor == null)
+            {
                 imageDestinationProcessor = ImageDestinationProcessor.noOp();
             }
 
-            if (imageSizeResolver == null) {
+            if (imageSizeResolver == null)
+            {
                 imageSizeResolver = new ImageSizeResolverDef();
             }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarImpl.java
@@ -28,18 +28,16 @@ public class StylarImpl extends Stylar
     private final StylarVisitorFactory visitorFactory; // @since 4.1.1
     private final StylarConfiguration configuration;
     private final List<StylarPlugin> plugins;
+    // @since 4.1.0
+    @Nullable
+    private final TextSetter textSetter;
+    // @since 4.4.0
+    private final boolean fallbackToRawInputWhenEmpty;
     private StylarView stylarView;
     private boolean anchoredHeadings;
     private boolean imagePlugins;
     private boolean codeStyle;
     private ClickEvent clickEvent;
-
-    // @since 4.1.0
-    @Nullable
-    private final TextSetter textSetter;
-
-    // @since 4.4.0
-    private final boolean fallbackToRawInputWhenEmpty;
 
     public StylarImpl(
         @NonNull TextView.BufferType bufferType,

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarPlugin.java
@@ -5,13 +5,13 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
-import org.commonmark.node.Node;
-import org.commonmark.parser.Parser;
-
 import com.zeoflow.stylar.core.CorePlugin;
 import com.zeoflow.stylar.core.StylarTheme;
 import com.zeoflow.stylar.image.AsyncDrawableSpan;
 import com.zeoflow.stylar.movement.MovementMethodPlugin;
+
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
 
 /**
  * Class represents a plugin (extension) to Markwon to configure how parsing and rendering
@@ -24,28 +24,6 @@ import com.zeoflow.stylar.movement.MovementMethodPlugin;
  */
 public interface StylarPlugin
 {
-
-    /**
-     * @see Registry#require(Class, Action)
-     * @since 4.0.0
-     */
-    interface Action<P extends StylarPlugin> {
-        void apply(@NonNull P p);
-    }
-
-    /**
-     * @see #configure(Registry)
-     * @since 4.0.0
-     */
-    interface Registry {
-
-        @NonNull
-        <P extends StylarPlugin> P require(@NonNull Class<P> plugin);
-
-        <P extends StylarPlugin> void require(
-                @NonNull Class<P> plugin,
-                @NonNull Action<? super P> action);
-    }
 
     /**
      * This method will be called before any other during {@link Stylar} instance construction.
@@ -147,4 +125,28 @@ public interface StylarPlugin
      * @param textView TextView to which markdown was applied
      */
     void afterSetText(@NonNull TextView textView);
+
+    /**
+     * @see Registry#require(Class, Action)
+     * @since 4.0.0
+     */
+    interface Action<P extends StylarPlugin>
+    {
+        void apply(@NonNull P p);
+    }
+
+    /**
+     * @see #configure(Registry)
+     * @since 4.0.0
+     */
+    interface Registry
+    {
+
+        @NonNull
+        <P extends StylarPlugin> P require(@NonNull Class<P> plugin);
+
+        <P extends StylarPlugin> void require(
+            @NonNull Class<P> plugin,
+            @NonNull Action<? super P> action);
+    }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarReducer.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarReducer.java
@@ -20,7 +20,8 @@ public abstract class StylarReducer
      * will return all BlockNodes of a Document
      */
     @NonNull
-    public static StylarReducer directChildren() {
+    public static StylarReducer directChildren()
+    {
         return new DirectChildren();
     }
 
@@ -33,7 +34,8 @@ public abstract class StylarReducer
 
         @NonNull
         @Override
-        public List<Node> reduce(@NonNull Node root) {
+        public List<Node> reduce(@NonNull Node root)
+        {
 
             final List<Node> list;
 
@@ -42,18 +44,22 @@ public abstract class StylarReducer
 
             // please note, that if there are no children -> we will return a list with
             // single element (which was supplied)
-            if (node == null) {
+            if (node == null)
+            {
                 list = Collections.singletonList(root);
-            } else {
+            } else
+            {
 
                 list = new ArrayList<>();
 
                 Node temp;
 
-                while (node != null) {
+                while (node != null)
+                {
                     // @since 4.5.0 do not include LinkReferenceDefinition node (would result
                     //  in empty textView if rendered in recycler-view)
-                    if (!(node instanceof LinkReferenceDefinition)) {
+                    if (!(node instanceof LinkReferenceDefinition))
+                    {
                         list.add(node);
                     }
                     temp = node.getNext();

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarSpansFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarSpansFactory.java
@@ -30,7 +30,8 @@ public interface StylarSpansFactory
     <N extends Node> SpanFactory require(@NonNull Class<N> node);
 
 
-    interface Builder {
+    interface Builder
+    {
 
         @NonNull
         <N extends Node> Builder setFactory(@NonNull Class<N> node, @Nullable SpanFactory factory);

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarSpansFactoryImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarSpansFactoryImpl.java
@@ -19,37 +19,45 @@ public class StylarSpansFactoryImpl implements StylarSpansFactory
 
     private final Map<Class<? extends Node>, SpanFactory> factories;
 
-    StylarSpansFactoryImpl(@NonNull Map<Class<? extends Node>, SpanFactory> factories) {
+    StylarSpansFactoryImpl(@NonNull Map<Class<? extends Node>, SpanFactory> factories)
+    {
         this.factories = factories;
     }
 
     @Nullable
     @Override
-    public <N extends Node> SpanFactory get(@NonNull Class<N> node) {
+    public <N extends Node> SpanFactory get(@NonNull Class<N> node)
+    {
         return factories.get(node);
     }
 
     @NonNull
     @Override
-    public <N extends Node> SpanFactory require(@NonNull Class<N> node) {
+    public <N extends Node> SpanFactory require(@NonNull Class<N> node)
+    {
         final SpanFactory f = get(node);
-        if (f == null) {
+        if (f == null)
+        {
             throw new NullPointerException(node.getName());
         }
         return f;
     }
 
-    public static class BuilderImpl implements Builder {
+    public static class BuilderImpl implements Builder
+    {
 
         private final Map<Class<? extends Node>, SpanFactory> factories =
-                new HashMap<>(3);
+            new HashMap<>(3);
 
         @NonNull
         @Override
-        public <N extends Node> Builder setFactory(@NonNull Class<N> node, @Nullable SpanFactory factory) {
-            if (factory == null) {
+        public <N extends Node> Builder setFactory(@NonNull Class<N> node, @Nullable SpanFactory factory)
+        {
+            if (factory == null)
+            {
                 factories.remove(node);
-            } else {
+            } else
+            {
                 factories.put(node, factory);
             }
             return this;
@@ -58,22 +66,28 @@ public class StylarSpansFactoryImpl implements StylarSpansFactory
         @NonNull
         @Override
         @Deprecated
-        public <N extends Node> Builder addFactory(@NonNull Class<N> node, @NonNull SpanFactory factory) {
+        public <N extends Node> Builder addFactory(@NonNull Class<N> node, @NonNull SpanFactory factory)
+        {
             return prependFactory(node, factory);
         }
 
         @NonNull
         @Override
-        public <N extends Node> Builder appendFactory(@NonNull Class<N> node, @NonNull SpanFactory factory) {
+        public <N extends Node> Builder appendFactory(@NonNull Class<N> node, @NonNull SpanFactory factory)
+        {
             final SpanFactory existing = factories.get(node);
-            if (existing == null) {
+            if (existing == null)
+            {
                 factories.put(node, factory);
-            } else {
-                if (existing instanceof CompositeSpanFactory) {
+            } else
+            {
+                if (existing instanceof CompositeSpanFactory)
+                {
                     ((CompositeSpanFactory) existing).factories.add(0, factory);
-                } else {
+                } else
+                {
                     final CompositeSpanFactory compositeSpanFactory =
-                            new CompositeSpanFactory(factory, existing);
+                        new CompositeSpanFactory(factory, existing);
                     factories.put(node, compositeSpanFactory);
                 }
             }
@@ -82,19 +96,24 @@ public class StylarSpansFactoryImpl implements StylarSpansFactory
 
         @NonNull
         @Override
-        public <N extends Node> Builder prependFactory(@NonNull Class<N> node, @NonNull SpanFactory factory) {
+        public <N extends Node> Builder prependFactory(@NonNull Class<N> node, @NonNull SpanFactory factory)
+        {
             // if there is no factory registered for this node -> just add it
             final SpanFactory existing = factories.get(node);
-            if (existing == null) {
+            if (existing == null)
+            {
                 factories.put(node, factory);
-            } else {
+            } else
+            {
                 // existing span factory can be of CompositeSpanFactory at this point -> append to it
-                if (existing instanceof CompositeSpanFactory) {
+                if (existing instanceof CompositeSpanFactory)
+                {
                     ((CompositeSpanFactory) existing).factories.add(factory);
-                } else {
+                } else
+                {
                     // if it's not composite at this point -> make it
                     final CompositeSpanFactory compositeSpanFactory =
-                            new CompositeSpanFactory(existing, factory);
+                        new CompositeSpanFactory(existing, factory);
                     factories.put(node, compositeSpanFactory);
                 }
             }
@@ -103,15 +122,18 @@ public class StylarSpansFactoryImpl implements StylarSpansFactory
 
         @Nullable
         @Override
-        public <N extends Node> SpanFactory getFactory(@NonNull Class<N> node) {
+        public <N extends Node> SpanFactory getFactory(@NonNull Class<N> node)
+        {
             return factories.get(node);
         }
 
         @NonNull
         @Override
-        public <N extends Node> SpanFactory requireFactory(@NonNull Class<N> node) {
+        public <N extends Node> SpanFactory requireFactory(@NonNull Class<N> node)
+        {
             final SpanFactory factory = getFactory(node);
-            if (factory == null) {
+            if (factory == null)
+            {
                 throw new NullPointerException(node.getName());
             }
             return factory;
@@ -119,16 +141,19 @@ public class StylarSpansFactoryImpl implements StylarSpansFactory
 
         @NonNull
         @Override
-        public StylarSpansFactory build() {
+        public StylarSpansFactory build()
+        {
             return new StylarSpansFactoryImpl(Collections.unmodifiableMap(factories));
         }
     }
 
-    static class CompositeSpanFactory implements SpanFactory {
+    static class CompositeSpanFactory implements SpanFactory
+    {
 
         final List<SpanFactory> factories;
 
-        CompositeSpanFactory(@NonNull SpanFactory first, @NonNull SpanFactory second) {
+        CompositeSpanFactory(@NonNull SpanFactory first, @NonNull SpanFactory second)
+        {
             this.factories = new ArrayList<>(3);
             this.factories.add(first);
             this.factories.add(second);
@@ -136,12 +161,14 @@ public class StylarSpansFactoryImpl implements StylarSpansFactory
 
         @Nullable
         @Override
-        public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+        public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+        {
             // please note that we do not check it factory itself returns an array of spans,
             // as this behaviour is supported now (previously we supported only a single-level array)
             final int length = factories.size();
             final Object[] out = new Object[length];
-            for (int i = 0; i < length; i++) {
+            for (int i = 0; i < length; i++)
+            {
                 out[i] = factories.get(i).getSpans(configuration, props);
             }
             return out;

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarVisitor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarVisitor.java
@@ -14,51 +14,8 @@ import org.commonmark.node.Visitor;
  * @see StylarPlugin#configureVisitor(Builder)
  * @since 3.0.0
  */
-public interface StylarVisitor extends Visitor {
-
-    /**
-     * @see Builder#on(Class, NodeVisitor)
-     */
-    interface NodeVisitor<N extends Node> {
-        void visit(@NonNull StylarVisitor visitor, @NonNull N n);
-    }
-
-    /**
-     * Primary purpose is to control the spacing applied before/after certain blocks, which
-     * visitors are created elsewhere
-     *
-     * @since 4.3.0
-     */
-    interface BlockHandler {
-
-        void blockStart(@NonNull StylarVisitor visitor, @NonNull Node node);
-
-        void blockEnd(@NonNull StylarVisitor visitor, @NonNull Node node);
-    }
-
-    interface Builder {
-
-        /**
-         * @param node        to register
-         * @param nodeVisitor {@link NodeVisitor} to be used or null to ignore previously registered
-         *                    visitor for this node
-         */
-        @NonNull
-        <N extends Node> Builder on(@NonNull Class<N> node, @Nullable NodeVisitor<? super N> nodeVisitor);
-
-        /**
-         * @param blockHandler to handle block start/end
-         * @see BlockHandler
-         * @see BlockHandlerDef
-         * @since 4.3.0
-         */
-        @SuppressWarnings("UnusedReturnValue")
-        @NonNull
-        Builder blockHandler(@NonNull BlockHandler blockHandler);
-
-        @NonNull
-        StylarVisitor build(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps);
-    }
+public interface StylarVisitor extends Visitor
+{
 
     @NonNull
     StylarConfiguration configuration();
@@ -135,8 +92,6 @@ public interface StylarVisitor extends Visitor {
      */
     <N extends Node> void setSpansForNode(@NonNull Class<N> node, int start);
 
-    // does not throw if there is no SpanFactory registered for this node
-
     /**
      * Helper method to apply spans from a {@link SpanFactory} <b>if</b> it\'s registered in
      * {@link StylarSpansFactory} instance. Otherwise ignores this call (no spans will be applied).
@@ -162,8 +117,57 @@ public interface StylarVisitor extends Visitor {
      */
     void blockStart(@NonNull Node node);
 
+    // does not throw if there is no SpanFactory registered for this node
+
     /**
      * @since 4.3.0
      */
     void blockEnd(@NonNull Node node);
+
+    /**
+     * @see Builder#on(Class, NodeVisitor)
+     */
+    interface NodeVisitor<N extends Node>
+    {
+        void visit(@NonNull StylarVisitor visitor, @NonNull N n);
+    }
+
+    /**
+     * Primary purpose is to control the spacing applied before/after certain blocks, which
+     * visitors are created elsewhere
+     *
+     * @since 4.3.0
+     */
+    interface BlockHandler
+    {
+
+        void blockStart(@NonNull StylarVisitor visitor, @NonNull Node node);
+
+        void blockEnd(@NonNull StylarVisitor visitor, @NonNull Node node);
+    }
+
+    interface Builder
+    {
+
+        /**
+         * @param node        to register
+         * @param nodeVisitor {@link NodeVisitor} to be used or null to ignore previously registered
+         *                    visitor for this node
+         */
+        @NonNull
+        <N extends Node> Builder on(@NonNull Class<N> node, @Nullable NodeVisitor<? super N> nodeVisitor);
+
+        /**
+         * @param blockHandler to handle block start/end
+         * @see BlockHandler
+         * @see BlockHandlerDef
+         * @since 4.3.0
+         */
+        @SuppressWarnings("UnusedReturnValue")
+        @NonNull
+        Builder blockHandler(@NonNull BlockHandler blockHandler);
+
+        @NonNull
+        StylarVisitor build(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps);
+    }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarVisitorFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarVisitorFactory.java
@@ -9,18 +9,21 @@ public abstract class StylarVisitorFactory
 {
 
     @NonNull
-    abstract StylarVisitor create();
-
-    @NonNull
     public static StylarVisitorFactory create(
         @NonNull final StylarVisitorImpl.Builder builder,
-        @NonNull final StylarConfiguration configuration) {
-        return new StylarVisitorFactory() {
+        @NonNull final StylarConfiguration configuration)
+    {
+        return new StylarVisitorFactory()
+        {
             @NonNull
             @Override
-            StylarVisitor create() {
+            StylarVisitor create()
+            {
                 return builder.build(configuration, new RenderPropsImpl());
             }
         };
     }
+
+    @NonNull
+    abstract StylarVisitor create();
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/StylarVisitorImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/StylarVisitorImpl.java
@@ -50,11 +50,12 @@ public class StylarVisitorImpl implements StylarVisitor
     private final BlockHandler blockHandler;
 
     StylarVisitorImpl(
-            @NonNull StylarConfiguration configuration,
-            @NonNull RenderProps renderProps,
-            @NonNull SpannableBuilder builder,
-            @NonNull Map<Class<? extends Node>, NodeVisitor<? extends Node>> nodes,
-            @NonNull BlockHandler blockHandler) {
+        @NonNull StylarConfiguration configuration,
+        @NonNull RenderProps renderProps,
+        @NonNull SpannableBuilder builder,
+        @NonNull Map<Class<? extends Node>, NodeVisitor<? extends Node>> nodes,
+        @NonNull BlockHandler blockHandler)
+    {
         this.configuration = configuration;
         this.renderProps = renderProps;
         this.builder = builder;
@@ -63,152 +64,183 @@ public class StylarVisitorImpl implements StylarVisitor
     }
 
     @Override
-    public void visit(BlockQuote blockQuote) {
+    public void visit(BlockQuote blockQuote)
+    {
         visit((Node) blockQuote);
     }
 
     @Override
-    public void visit(BulletList bulletList) {
+    public void visit(BulletList bulletList)
+    {
         visit((Node) bulletList);
     }
 
     @Override
-    public void visit(Code code) {
+    public void visit(Code code)
+    {
         visit((Node) code);
     }
 
     @Override
-    public void visit(Document document) {
+    public void visit(Document document)
+    {
         visit((Node) document);
     }
 
     @Override
-    public void visit(Emphasis emphasis) {
+    public void visit(Emphasis emphasis)
+    {
         visit((Node) emphasis);
     }
 
     @Override
-    public void visit(FencedCodeBlock fencedCodeBlock) {
+    public void visit(FencedCodeBlock fencedCodeBlock)
+    {
         visit((Node) fencedCodeBlock);
     }
 
     @Override
-    public void visit(HardLineBreak hardLineBreak) {
+    public void visit(HardLineBreak hardLineBreak)
+    {
         visit((Node) hardLineBreak);
     }
 
     @Override
-    public void visit(Heading heading) {
+    public void visit(Heading heading)
+    {
         visit((Node) heading);
     }
 
     @Override
-    public void visit(ThematicBreak thematicBreak) {
+    public void visit(ThematicBreak thematicBreak)
+    {
         visit((Node) thematicBreak);
     }
 
     @Override
-    public void visit(HtmlInline htmlInline) {
+    public void visit(HtmlInline htmlInline)
+    {
         visit((Node) htmlInline);
     }
 
     @Override
-    public void visit(HtmlBlock htmlBlock) {
+    public void visit(HtmlBlock htmlBlock)
+    {
         visit((Node) htmlBlock);
     }
 
     @Override
-    public void visit(Image image) {
+    public void visit(Image image)
+    {
         visit((Node) image);
     }
 
     @Override
-    public void visit(IndentedCodeBlock indentedCodeBlock) {
+    public void visit(IndentedCodeBlock indentedCodeBlock)
+    {
         visit((Node) indentedCodeBlock);
     }
 
     @Override
-    public void visit(Link link) {
+    public void visit(Link link)
+    {
         visit((Node) link);
     }
 
     @Override
-    public void visit(ListItem listItem) {
+    public void visit(ListItem listItem)
+    {
         visit((Node) listItem);
     }
 
     @Override
-    public void visit(OrderedList orderedList) {
+    public void visit(OrderedList orderedList)
+    {
         visit((Node) orderedList);
     }
 
     @Override
-    public void visit(Paragraph paragraph) {
+    public void visit(Paragraph paragraph)
+    {
         visit((Node) paragraph);
     }
 
     @Override
-    public void visit(SoftLineBreak softLineBreak) {
+    public void visit(SoftLineBreak softLineBreak)
+    {
         visit((Node) softLineBreak);
     }
 
     @Override
-    public void visit(StrongEmphasis strongEmphasis) {
+    public void visit(StrongEmphasis strongEmphasis)
+    {
         visit((Node) strongEmphasis);
     }
 
     @Override
-    public void visit(Text text) {
+    public void visit(Text text)
+    {
         visit((Node) text);
     }
 
     @Override
-    public void visit(LinkReferenceDefinition linkReferenceDefinition) {
+    public void visit(LinkReferenceDefinition linkReferenceDefinition)
+    {
         visit((Node) linkReferenceDefinition);
     }
 
     @Override
-    public void visit(CustomBlock customBlock) {
+    public void visit(CustomBlock customBlock)
+    {
         visit((Node) customBlock);
     }
 
     @Override
-    public void visit(CustomNode customNode) {
+    public void visit(CustomNode customNode)
+    {
         visit((Node) customNode);
     }
 
-    private void visit(@NonNull Node node) {
+    private void visit(@NonNull Node node)
+    {
         //noinspection unchecked
         final NodeVisitor<Node> nodeVisitor = (NodeVisitor<Node>) nodes.get(node.getClass());
-        if (nodeVisitor != null) {
+        if (nodeVisitor != null)
+        {
             nodeVisitor.visit(this, node);
-        } else {
+        } else
+        {
             visitChildren(node);
         }
     }
 
     @NonNull
     @Override
-    public StylarConfiguration configuration() {
+    public StylarConfiguration configuration()
+    {
         return configuration;
     }
 
     @NonNull
     @Override
-    public RenderProps renderProps() {
+    public RenderProps renderProps()
+    {
         return renderProps;
     }
 
     @NonNull
     @Override
-    public SpannableBuilder builder() {
+    public SpannableBuilder builder()
+    {
         return builder;
     }
 
     @Override
-    public void visitChildren(@NonNull Node parent) {
+    public void visitChildren(@NonNull Node parent)
+    {
         Node node = parent.getFirstChild();
-        while (node != null) {
+        while (node != null)
+        {
             // A subclass of this visitor might modify the node, resulting in getNext returning a different node or no
             // node after visiting it. So get the next node before visiting.
             Node next = node.getNext();
@@ -218,80 +250,96 @@ public class StylarVisitorImpl implements StylarVisitor
     }
 
     @Override
-    public boolean hasNext(@NonNull Node node) {
+    public boolean hasNext(@NonNull Node node)
+    {
         return node.getNext() != null;
     }
 
     @Override
-    public void ensureNewLine() {
+    public void ensureNewLine()
+    {
         if (builder.length() > 0
-                && '\n' != builder.lastChar()) {
+            && '\n' != builder.lastChar())
+        {
             builder.append('\n');
         }
     }
 
     @Override
-    public void forceNewLine() {
+    public void forceNewLine()
+    {
         builder.append('\n');
     }
 
     @Override
-    public int length() {
+    public int length()
+    {
         return builder.length();
     }
 
     @Override
-    public void setSpans(int start, @Nullable Object spans) {
+    public void setSpans(int start, @Nullable Object spans)
+    {
         SpannableBuilder.setSpans(builder, spans, start, builder.length());
     }
 
     @Override
-    public void clear() {
+    public void clear()
+    {
         renderProps.clearAll();
         builder.clear();
     }
 
     @Override
-    public <N extends Node> void setSpansForNode(@NonNull N node, int start) {
+    public <N extends Node> void setSpansForNode(@NonNull N node, int start)
+    {
         setSpansForNode(node.getClass(), start);
     }
 
     @Override
-    public <N extends Node> void setSpansForNode(@NonNull Class<N> node, int start) {
+    public <N extends Node> void setSpansForNode(@NonNull Class<N> node, int start)
+    {
         setSpans(start, configuration.spansFactory().require(node).getSpans(configuration, renderProps));
     }
 
     @Override
-    public <N extends Node> void setSpansForNodeOptional(@NonNull N node, int start) {
+    public <N extends Node> void setSpansForNodeOptional(@NonNull N node, int start)
+    {
         setSpansForNodeOptional(node.getClass(), start);
     }
 
     @Override
-    public <N extends Node> void setSpansForNodeOptional(@NonNull Class<N> node, int start) {
+    public <N extends Node> void setSpansForNodeOptional(@NonNull Class<N> node, int start)
+    {
         final SpanFactory factory = configuration.spansFactory().get(node);
-        if (factory != null) {
+        if (factory != null)
+        {
             setSpans(start, factory.getSpans(configuration, renderProps));
         }
     }
 
     @Override
-    public void blockStart(@NonNull Node node) {
+    public void blockStart(@NonNull Node node)
+    {
         blockHandler.blockStart(this, node);
     }
 
     @Override
-    public void blockEnd(@NonNull Node node) {
+    public void blockEnd(@NonNull Node node)
+    {
         blockHandler.blockEnd(this, node);
     }
 
-    public static class BuilderImpl implements Builder {
+    public static class BuilderImpl implements Builder
+    {
 
         private final Map<Class<? extends Node>, NodeVisitor<? extends Node>> nodes = new HashMap<>();
         private BlockHandler blockHandler;
 
         @NonNull
         @Override
-        public <N extends Node> Builder on(@NonNull Class<N> node, @Nullable NodeVisitor<? super N> nodeVisitor) {
+        public <N extends Node> Builder on(@NonNull Class<N> node, @Nullable NodeVisitor<? super N> nodeVisitor)
+        {
 
             // @since 4.1.1 we might actually introduce a local flag to check if it's been built
             //  and throw an exception here if some modification is requested
@@ -299,9 +347,11 @@ public class StylarVisitorImpl implements StylarVisitor
 
             // we should allow `null` to exclude node from being visited (for example to disable
             // some functionality)
-            if (nodeVisitor == null) {
+            if (nodeVisitor == null)
+            {
                 nodes.remove(node);
-            } else {
+            } else
+            {
                 nodes.put(node, nodeVisitor);
             }
             return this;
@@ -309,26 +359,29 @@ public class StylarVisitorImpl implements StylarVisitor
 
         @NonNull
         @Override
-        public Builder blockHandler(@NonNull BlockHandler blockHandler) {
+        public Builder blockHandler(@NonNull BlockHandler blockHandler)
+        {
             this.blockHandler = blockHandler;
             return this;
         }
 
         @NonNull
         @Override
-        public StylarVisitor build(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps) {
+        public StylarVisitor build(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps)
+        {
             // @since 4.3.0
             BlockHandler blockHandler = this.blockHandler;
-            if (blockHandler == null) {
+            if (blockHandler == null)
+            {
                 blockHandler = new BlockHandlerDef();
             }
 
             return new StylarVisitorImpl(
-                    configuration,
-                    renderProps,
-                    new SpannableBuilder(),
-                    Collections.unmodifiableMap(nodes),
-                    blockHandler);
+                configuration,
+                renderProps,
+                new SpannableBuilder(),
+                Collections.unmodifiableMap(nodes),
+                blockHandler);
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/AbsVisitor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/AbsVisitor.java
@@ -8,11 +8,15 @@ public abstract class AbsVisitor implements CodeStyle.Visitor
 {
 
     @Override
-    public void visit(@NotNull List<? extends CodeStyle.Node> nodes) {
-        for (CodeStyle.Node node : nodes) {
-            if (node.isSyntax()) {
+    public void visit(@NotNull List<? extends CodeStyle.Node> nodes)
+    {
+        for (CodeStyle.Node node : nodes)
+        {
+            if (node.isSyntax())
+            {
                 visitSyntax((CodeStyle.Syntax) node);
-            } else {
+            } else
+            {
                 visitText((CodeStyle.Text) node);
             }
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/ArrayUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/ArrayUtils.java
@@ -6,21 +6,25 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-abstract class ArrayUtils {
+abstract class ArrayUtils
+{
+
+    private ArrayUtils()
+    {
+    }
 
     @SafeVarargs
     @NotNull
-    static <T> List<T> toList(T... args) {
+    static <T> List<T> toList(T... args)
+    {
         final int length = args != null
-                ? args.length
-                : 0;
+            ? args.length
+            : 0;
         final List<T> list = new ArrayList<>(length);
-        if (length > 0) {
+        if (length > 0)
+        {
             Collections.addAll(list, args);
         }
         return list;
-    }
-
-    private ArrayUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/Cloner.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/Cloner.java
@@ -8,7 +8,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-abstract class Cloner {
+abstract class Cloner
+{
+
+    @NotNull
+    static Cloner create()
+    {
+        return new Impl();
+    }
 
     @NotNull
     abstract CodeStyle.Grammar clone(@NotNull CodeStyle.Grammar grammar);
@@ -19,14 +26,105 @@ abstract class Cloner {
     @NotNull
     abstract CodeStyle.Pattern clone(@NotNull CodeStyle.Pattern pattern);
 
-    @NotNull
-    static Cloner create() {
-        return new Impl();
-    }
+    static class Impl extends Cloner
+    {
 
-    static class Impl extends Cloner {
+        @NotNull
+        @Override
+        CodeStyle.Grammar clone(@NotNull CodeStyle.Grammar grammar)
+        {
+            return clone(new ContextImpl(), grammar);
+        }
 
-        interface Context {
+        @NotNull
+        @Override
+        CodeStyle.Token clone(@NotNull CodeStyle.Token token)
+        {
+            return clone(new ContextImpl(), token);
+        }
+
+        @NotNull
+        @Override
+        CodeStyle.Pattern clone(@NotNull CodeStyle.Pattern pattern)
+        {
+            return clone(new ContextImpl(), pattern);
+        }
+
+        @NotNull
+        private CodeStyle.Grammar clone(@NotNull Context context, @NotNull CodeStyle.Grammar grammar)
+        {
+
+            CodeStyle.Grammar clone = context.grammar(grammar);
+            if (clone != null)
+            {
+                return clone;
+            }
+
+            final List<CodeStyle.Token> tokens = grammar.tokens();
+            final List<CodeStyle.Token> out = new ArrayList<>(tokens.size());
+
+            clone = new GrammarImpl(grammar.name(), out);
+            context.save(grammar, clone);
+
+            for (CodeStyle.Token token : tokens)
+            {
+                out.add(clone(context, token));
+            }
+
+            return clone;
+        }
+
+        @NotNull
+        private CodeStyle.Token clone(@NotNull Context context, @NotNull CodeStyle.Token token)
+        {
+
+            CodeStyle.Token clone = context.token(token);
+            if (clone != null)
+            {
+                return clone;
+            }
+
+            final List<CodeStyle.Pattern> patterns = token.patterns();
+            final List<CodeStyle.Pattern> out = new ArrayList<>(patterns.size());
+
+            clone = new TokenImpl(token.name(), out);
+            context.save(token, clone);
+
+            for (CodeStyle.Pattern pattern : patterns)
+            {
+                out.add(clone(context, pattern));
+            }
+
+            return clone;
+        }
+
+        @NotNull
+        private CodeStyle.Pattern clone(@NotNull Context context, @NotNull CodeStyle.Pattern pattern)
+        {
+
+            CodeStyle.Pattern clone = context.pattern(pattern);
+            if (clone != null)
+            {
+                return clone;
+            }
+
+            final CodeStyle.Grammar inside = pattern.inside();
+
+            clone = new PatternImpl(
+                pattern.regex(),
+                pattern.lookbehind(),
+                pattern.greedy(),
+                pattern.alias(),
+                inside != null ? clone(context, inside) : null
+            );
+
+            context.save(pattern, clone);
+
+            return clone;
+        }
+
+        interface Context
+        {
 
             @Nullable
             CodeStyle.Grammar grammar(@NotNull CodeStyle.Grammar origin);
@@ -45,128 +143,53 @@ abstract class Cloner {
             void save(@NotNull CodeStyle.Pattern origin, @NotNull CodeStyle.Pattern clone);
         }
 
-        @NotNull
-        @Override
-        CodeStyle.Grammar clone(@NotNull CodeStyle.Grammar grammar) {
-            return clone(new ContextImpl(), grammar);
-        }
-
-        @NotNull
-        @Override
-        CodeStyle.Token clone(@NotNull CodeStyle.Token token) {
-            return clone(new ContextImpl(), token);
-        }
-
-        @NotNull
-        @Override
-        CodeStyle.Pattern clone(@NotNull CodeStyle.Pattern pattern) {
-            return clone(new ContextImpl(), pattern);
-        }
-
-        @NotNull
-        private CodeStyle.Grammar clone(@NotNull Context context, @NotNull CodeStyle.Grammar grammar) {
-
-            CodeStyle.Grammar clone = context.grammar(grammar);
-            if (clone != null) {
-                return clone;
-            }
-
-            final List<CodeStyle.Token> tokens = grammar.tokens();
-            final List<CodeStyle.Token> out = new ArrayList<>(tokens.size());
-
-            clone = new GrammarImpl(grammar.name(), out);
-            context.save(grammar, clone);
-
-            for (CodeStyle.Token token : tokens) {
-                out.add(clone(context, token));
-            }
-
-            return clone;
-        }
-
-        @NotNull
-        private CodeStyle.Token clone(@NotNull Context context, @NotNull CodeStyle.Token token) {
-
-            CodeStyle.Token clone = context.token(token);
-            if (clone != null) {
-                return clone;
-            }
-
-            final List<CodeStyle.Pattern> patterns = token.patterns();
-            final List<CodeStyle.Pattern> out = new ArrayList<>(patterns.size());
-
-            clone = new TokenImpl(token.name(), out);
-            context.save(token, clone);
-
-            for (CodeStyle.Pattern pattern : patterns) {
-                out.add(clone(context, pattern));
-            }
-
-            return clone;
-        }
-
-        @NotNull
-        private CodeStyle.Pattern clone(@NotNull Context context, @NotNull CodeStyle.Pattern pattern) {
-
-            CodeStyle.Pattern clone = context.pattern(pattern);
-            if (clone != null) {
-                return clone;
-            }
-
-            final CodeStyle.Grammar inside = pattern.inside();
-
-            clone = new PatternImpl(
-                    pattern.regex(),
-                    pattern.lookbehind(),
-                    pattern.greedy(),
-                    pattern.alias(),
-                    inside != null ? clone(context, inside) : null
-            );
-
-            context.save(pattern, clone);
-
-            return clone;
-        }
-
-        private static class ContextImpl implements Context {
+        private static class ContextImpl implements Context
+        {
 
             private final Map<Integer, Object> cache = new HashMap<>(3);
 
+            private static int key(@NotNull Object o)
+            {
+                return System.identityHashCode(o);
+            }
+
             @Nullable
             @Override
-            public CodeStyle.Grammar grammar(@NotNull CodeStyle.Grammar origin) {
+            public CodeStyle.Grammar grammar(@NotNull CodeStyle.Grammar origin)
+            {
                 return (CodeStyle.Grammar) cache.get(key(origin));
             }
 
             @Nullable
             @Override
-            public CodeStyle.Token token(@NotNull CodeStyle.Token origin) {
+            public CodeStyle.Token token(@NotNull CodeStyle.Token origin)
+            {
                 return (CodeStyle.Token) cache.get(key(origin));
             }
 
             @Nullable
             @Override
-            public CodeStyle.Pattern pattern(@NotNull CodeStyle.Pattern origin) {
+            public CodeStyle.Pattern pattern(@NotNull CodeStyle.Pattern origin)
+            {
                 return (CodeStyle.Pattern) cache.get(key(origin));
             }
 
             @Override
-            public void save(@NotNull CodeStyle.Grammar origin, @NotNull CodeStyle.Grammar clone) {
+            public void save(@NotNull CodeStyle.Grammar origin, @NotNull CodeStyle.Grammar clone)
+            {
                 cache.put(key(origin), clone);
             }
 
             @Override
-            public void save(@NotNull CodeStyle.Token origin, @NotNull CodeStyle.Token clone) {
+            public void save(@NotNull CodeStyle.Token origin, @NotNull CodeStyle.Token clone)
+            {
                 cache.put(key(origin), clone);
             }
 
             @Override
-            public void save(@NotNull CodeStyle.Pattern origin, @NotNull CodeStyle.Pattern clone) {
+            public void save(@NotNull CodeStyle.Pattern origin, @NotNull CodeStyle.Pattern clone)
+            {
                 cache.put(key(origin), clone);
-            }
-
-            private static int key(@NotNull Object o) {
-                return System.identityHashCode(o);
             }
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/CodeStyle.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/CodeStyle.java
@@ -1,7 +1,5 @@
 package com.zeoflow.stylar.codestyle;
 
-import android.util.Log;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +11,302 @@ import java.util.regex.Matcher;
 public class CodeStyle
 {
 
-    public interface Grammar {
+    private final GrammarLocator grammarLocator;
+
+    public CodeStyle(@NotNull GrammarLocator grammarLocator)
+    {
+        this.grammarLocator = grammarLocator;
+    }
+
+    /**
+     * Factory method to create a {@link Grammar}
+     *
+     * @param name   of the defined grammar
+     * @param tokens a list of {@link Token}s
+     * @return an instance of {@link Grammar}
+     */
+    @NotNull
+    public static Grammar grammar(@NotNull String name, @NotNull List<Token> tokens)
+    {
+        return new GrammarImpl(name, tokens);
+    }
+
+    @NotNull
+    public static Grammar grammar(@NotNull String name, Token... tokens)
+    {
+        return new GrammarImpl(name, ArrayUtils.toList(tokens));
+    }
+
+    @NotNull
+    public static Token token(@NotNull String name, @NotNull List<Pattern> patterns)
+    {
+        return new TokenImpl(name, patterns);
+    }
+
+    @NotNull
+    public static Token token(@NotNull String name, Pattern... patterns)
+    {
+        return new TokenImpl(name, ArrayUtils.toList(patterns));
+    }
+
+    @NotNull
+    public static Pattern pattern(@NotNull java.util.regex.Pattern regex)
+    {
+        return new PatternImpl(regex, false, false, null, null);
+    }
+
+    @NotNull
+    public static Pattern pattern(@NotNull java.util.regex.Pattern regex, boolean lookbehind)
+    {
+        return new PatternImpl(regex, lookbehind, false, null, null);
+    }
+
+    @NotNull
+    public static Pattern pattern(
+        @NotNull java.util.regex.Pattern regex,
+        boolean lookbehind,
+        boolean greedy)
+    {
+        return new PatternImpl(regex, lookbehind, greedy, null, null);
+    }
+
+    @NotNull
+    public static Pattern pattern(
+        @NotNull java.util.regex.Pattern regex,
+        boolean lookbehind,
+        boolean greedy,
+        @Nullable String alias)
+    {
+        return new PatternImpl(regex, lookbehind, greedy, alias, null);
+    }
+
+    @NotNull
+    public static Pattern pattern(
+        @NotNull java.util.regex.Pattern regex,
+        boolean lookbehind,
+        boolean greedy,
+        @Nullable String alias,
+        @Nullable Grammar inside)
+    {
+        return new PatternImpl(regex, lookbehind, greedy, alias, inside);
+    }
+
+    private static boolean isSyntaxNode(@NotNull Node node)
+    {
+        return node.isSyntax();
+    }
+
+    private static boolean isGreedyNode(@NotNull Node node)
+    {
+        return node.isSyntax() && ((Syntax) node).greedy();
+    }
+
+    @NotNull
+    public List<Node> tokenize(@NotNull String text, @NotNull Grammar grammar)
+    {
+        final List<Node> entries = new ArrayList<>(3);
+        entries.add(new TextImpl(text));
+        matchGrammar(text, entries, grammar, 0, 0, false, null);
+        return entries;
+    }
+
+    @Nullable
+    public Grammar grammar(@NotNull String name)
+    {
+        return grammarLocator.grammar(this, name);
+    }
+
+    private void matchGrammar(
+        @NotNull String text,
+        @NotNull List<Node> entries,
+        @NotNull Grammar grammar,
+        int index,
+        int startPosition,
+        boolean oneShot,
+        @Nullable Token target
+    )
+    {
+
+        final int textLength = text.length();
+
+        for (Token token : grammar.tokens())
+        {
+
+            if (token == target)
+            {
+                return;
+            }
+
+            for (Pattern pattern : token.patterns())
+            {
+
+                final boolean lookbehind = pattern.lookbehind();
+                final boolean greedy = pattern.greedy();
+                int lookbehindLength = 0;
+
+                final java.util.regex.Pattern regex = pattern.regex();
+
+                // Don't cache textLength as it changes during the loop
+                for (int i = index, position = startPosition; i < entries.size(); position += entries.get(i).textLength(), ++i)
+                {
+
+                    if (entries.size() > textLength)
+                    {
+                        throw new RuntimeException("CodeStyle internal error. Number of entry nodes " +
+                            "is greater that the text length.\n" +
+                            "Nodes: " + entries + "\n" +
+                            "Text: " + text);
+                    }
+
+                    final Node node = entries.get(i);
+                    if (isSyntaxNode(node))
+                    {
+                        continue;
+                    }
+
+                    String str = ((Text) node).literal();
+
+                    final Matcher matcher;
+                    final int deleteCount;
+                    final boolean greedyMatch;
+                    int greedyAdd = 0;
+
+                    if (greedy && i != entries.size() - 1)
+                    {
+
+                        matcher = regex.matcher(text);
+                        // limit search to the position (?)
+                        matcher.region(position, textLength);
+
+                        if (!matcher.find())
+                        {
+                            break;
+                        }
+
+                        int from = matcher.start();
+
+                        if (lookbehind)
+                        {
+                            from += matcher.group(1).length();
+                        }
+                        final int to = matcher.start() + matcher.group(0).length();
+
+                        int k = i;
+                        int p = position;
+
+                        for (int len = entries.size(); k < len && (p < to || (!isSyntaxNode(entries.get(k)) && !isGreedyNode(entries.get(k - 1)))); ++k)
+                        {
+                            p += entries.get(k).textLength();
+                            // Move the index i to the element in strarr that is closest to from
+                            if (from >= p)
+                            {
+                                i += 1;
+                                position = p;
+                            }
+                        }
+
+                        if (isSyntaxNode(entries.get(i)))
+                        {
+                            continue;
+                        }
+
+                        deleteCount = k - i;
+                        str = text.substring(position, p);
+                        greedyMatch = true;
+                        greedyAdd = -position;
+
+                    } else
+                    {
+                        matcher = regex.matcher(str);
+                        deleteCount = 1;
+                        greedyMatch = false;
+                    }
+
+                    if (!greedyMatch && !matcher.find())
+                    {
+                        if (oneShot)
+                        {
+                            break;
+                        }
+                        continue;
+                    }
+
+                    if (lookbehind)
+                    {
+                        final String group = matcher.group(1);
+                        lookbehindLength = group != null ? group.length() : 0;
+                    }
+
+                    final int from = matcher.start() + greedyAdd + lookbehindLength;
+                    final String match;
+                    if (lookbehindLength > 0)
+                    {
+                        match = matcher.group().substring(lookbehindLength);
+                    } else
+                    {
+                        match = matcher.group();
+                    }
+                    final int to = from + match.length();
+
+                    for (int d = 0; d < deleteCount; d++)
+                    {
+                        entries.remove(i);
+                    }
+
+                    int i2 = i;
+
+                    if (from != 0)
+                    {
+                        final String before = str.substring(0, from);
+                        i += 1;
+                        position += before.length();
+                        entries.add(i2++, new TextImpl(before));
+                    }
+
+                    final List<? extends Node> tokenEntries;
+                    final Grammar inside = pattern.inside();
+                    final boolean hasInside = inside != null;
+                    if (hasInside)
+                    {
+                        tokenEntries = tokenize(match, inside);
+                    } else
+                    {
+                        tokenEntries = Collections.singletonList(new TextImpl(match));
+                    }
+
+                    entries.add(i2++, new SyntaxImpl(
+                        token.name(),
+                        tokenEntries,
+                        pattern.alias(),
+                        match,
+                        greedy,
+                        hasInside
+                    ));
+
+                    // important thing here (famous off-by one error) to check against full length (not `length - 1`)
+                    if (to < str.length())
+                    {
+                        final String after = str.substring(to);
+                        entries.add(i2, new TextImpl(after));
+                    }
+
+                    if (deleteCount != 1)
+                    {
+                        matchGrammar(text, entries, grammar, i, position, true, token);
+                    }
+
+                    if (oneShot)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+
+    public interface Grammar
+    {
 
         @NotNull
         String name();
@@ -23,7 +316,8 @@ public class CodeStyle
         List<Token> tokens();
     }
 
-    public interface Token {
+    public interface Token
+    {
 
         @NotNull
         String name();
@@ -32,7 +326,8 @@ public class CodeStyle
         List<Pattern> patterns();
     }
 
-    public interface Pattern {
+    public interface Pattern
+    {
 
         @NotNull
         java.util.regex.Pattern regex();
@@ -54,7 +349,8 @@ public class CodeStyle
      * @see Text
      * @see Syntax
      */
-    public interface Node {
+    public interface Node
+    {
 
         /**
          * @return raw text length. For {@link Text} node it\'s {@link Text#literal()} length
@@ -70,13 +366,15 @@ public class CodeStyle
         boolean isSyntax();
     }
 
-    public interface Text extends Node {
+    public interface Text extends Node
+    {
 
         @NotNull
         String literal();
     }
 
-    public interface Syntax extends Node {
+    public interface Syntax extends Node
+    {
 
         @NotNull
         String type();
@@ -106,261 +404,8 @@ public class CodeStyle
     /**
      * @see AbsVisitor
      */
-    public interface Visitor {
+    public interface Visitor
+    {
         void visit(@NotNull List<? extends Node> nodes);
-    }
-
-    /**
-     * Factory method to create a {@link Grammar}
-     *
-     * @param name   of the defined grammar
-     * @param tokens a list of {@link Token}s
-     * @return an instance of {@link Grammar}
-     */
-    @NotNull
-    public static Grammar grammar(@NotNull String name, @NotNull List<Token> tokens) {
-        return new GrammarImpl(name, tokens);
-    }
-
-    @NotNull
-    public static Grammar grammar(@NotNull String name, Token... tokens) {
-        return new GrammarImpl(name, ArrayUtils.toList(tokens));
-    }
-
-    @NotNull
-    public static Token token(@NotNull String name, @NotNull List<Pattern> patterns) {
-        return new TokenImpl(name, patterns);
-    }
-
-    @NotNull
-    public static Token token(@NotNull String name, Pattern... patterns) {
-        return new TokenImpl(name, ArrayUtils.toList(patterns));
-    }
-
-    @NotNull
-    public static Pattern pattern(@NotNull java.util.regex.Pattern regex) {
-        return new PatternImpl(regex, false, false, null, null);
-    }
-
-    @NotNull
-    public static Pattern pattern(@NotNull java.util.regex.Pattern regex, boolean lookbehind) {
-        return new PatternImpl(regex, lookbehind, false, null, null);
-    }
-
-    @NotNull
-    public static Pattern pattern(
-            @NotNull java.util.regex.Pattern regex,
-            boolean lookbehind,
-            boolean greedy) {
-        return new PatternImpl(regex, lookbehind, greedy, null, null);
-    }
-
-    @NotNull
-    public static Pattern pattern(
-            @NotNull java.util.regex.Pattern regex,
-            boolean lookbehind,
-            boolean greedy,
-            @Nullable String alias) {
-        return new PatternImpl(regex, lookbehind, greedy, alias, null);
-    }
-
-    @NotNull
-    public static Pattern pattern(
-            @NotNull java.util.regex.Pattern regex,
-            boolean lookbehind,
-            boolean greedy,
-            @Nullable String alias,
-            @Nullable Grammar inside) {
-        return new PatternImpl(regex, lookbehind, greedy, alias, inside);
-    }
-
-
-    private final GrammarLocator grammarLocator;
-
-    public CodeStyle(@NotNull GrammarLocator grammarLocator) {
-        this.grammarLocator = grammarLocator;
-    }
-
-    @NotNull
-    public List<Node> tokenize(@NotNull String text, @NotNull Grammar grammar) {
-        final List<Node> entries = new ArrayList<>(3);
-        entries.add(new TextImpl(text));
-        matchGrammar(text, entries, grammar, 0, 0, false, null);
-        return entries;
-    }
-
-    @Nullable
-    public Grammar grammar(@NotNull String name) {
-        return grammarLocator.grammar(this, name);
-    }
-
-    private void matchGrammar(
-            @NotNull String text,
-            @NotNull List<Node> entries,
-            @NotNull Grammar grammar,
-            int index,
-            int startPosition,
-            boolean oneShot,
-            @Nullable Token target
-    ) {
-
-        final int textLength = text.length();
-
-        for (Token token : grammar.tokens()) {
-
-            if (token == target) {
-                return;
-            }
-
-            for (Pattern pattern : token.patterns()) {
-
-                final boolean lookbehind = pattern.lookbehind();
-                final boolean greedy = pattern.greedy();
-                int lookbehindLength = 0;
-
-                final java.util.regex.Pattern regex = pattern.regex();
-
-                // Don't cache textLength as it changes during the loop
-                for (int i = index, position = startPosition; i < entries.size(); position += entries.get(i).textLength(), ++i) {
-
-                    if (entries.size() > textLength) {
-                        throw new RuntimeException("CodeStyle internal error. Number of entry nodes " +
-                                "is greater that the text length.\n" +
-                                "Nodes: " + entries + "\n" +
-                                "Text: " + text);
-                    }
-
-                    final Node node = entries.get(i);
-                    if (isSyntaxNode(node)) {
-                        continue;
-                    }
-
-                    String str = ((Text) node).literal();
-
-                    final Matcher matcher;
-                    final int deleteCount;
-                    final boolean greedyMatch;
-                    int greedyAdd = 0;
-
-                    if (greedy && i != entries.size() - 1) {
-
-                        matcher = regex.matcher(text);
-                        // limit search to the position (?)
-                        matcher.region(position, textLength);
-
-                        if (!matcher.find()) {
-                            break;
-                        }
-
-                        int from = matcher.start();
-
-                        if (lookbehind) {
-                            from += matcher.group(1).length();
-                        }
-                        final int to = matcher.start() + matcher.group(0).length();
-
-                        int k = i;
-                        int p = position;
-
-                        for (int len = entries.size(); k < len && (p < to || (!isSyntaxNode(entries.get(k)) && !isGreedyNode(entries.get(k - 1)))); ++k) {
-                            p += entries.get(k).textLength();
-                            // Move the index i to the element in strarr that is closest to from
-                            if (from >= p) {
-                                i += 1;
-                                position = p;
-                            }
-                        }
-
-                        if (isSyntaxNode(entries.get(i))) {
-                            continue;
-                        }
-
-                        deleteCount = k - i;
-                        str = text.substring(position, p);
-                        greedyMatch = true;
-                        greedyAdd = -position;
-
-                    } else {
-                        matcher = regex.matcher(str);
-                        deleteCount = 1;
-                        greedyMatch = false;
-                    }
-
-                    if (!greedyMatch && !matcher.find()) {
-                        if (oneShot) {
-                            break;
-                        }
-                        continue;
-                    }
-
-                    if (lookbehind) {
-                        final String group = matcher.group(1);
-                        lookbehindLength = group != null ? group.length() : 0;
-                    }
-
-                    final int from = matcher.start() + greedyAdd + lookbehindLength;
-                    final String match;
-                    if (lookbehindLength > 0) {
-                        match = matcher.group().substring(lookbehindLength);
-                    } else {
-                        match = matcher.group();
-                    }
-                    final int to = from + match.length();
-
-                    for (int d = 0; d < deleteCount; d++) {
-                        entries.remove(i);
-                    }
-
-                    int i2 = i;
-
-                    if (from != 0) {
-                        final String before = str.substring(0, from);
-                        i += 1;
-                        position += before.length();
-                        entries.add(i2++, new TextImpl(before));
-                    }
-
-                    final List<? extends Node> tokenEntries;
-                    final Grammar inside = pattern.inside();
-                    final boolean hasInside = inside != null;
-                    if (hasInside) {
-                        tokenEntries = tokenize(match, inside);
-                    } else {
-                        tokenEntries = Collections.singletonList(new TextImpl(match));
-                    }
-
-                    entries.add(i2++, new SyntaxImpl(
-                            token.name(),
-                            tokenEntries,
-                            pattern.alias(),
-                            match,
-                            greedy,
-                            hasInside
-                    ));
-
-                    // important thing here (famous off-by one error) to check against full length (not `length - 1`)
-                    if (to < str.length()) {
-                        final String after = str.substring(to);
-                        entries.add(i2, new TextImpl(after));
-                    }
-
-                    if (deleteCount != 1) {
-                        matchGrammar(text, entries, grammar, i, position, true, token);
-                    }
-
-                    if (oneShot) {
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    private static boolean isSyntaxNode(@NotNull Node node) {
-        return node.isSyntax();
-    }
-
-    private static boolean isGreedyNode(@NotNull Node node) {
-        return node.isSyntax() && ((Syntax) node).greedy();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/GrammarImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/GrammarImpl.java
@@ -10,25 +10,29 @@ public class GrammarImpl implements CodeStyle.Grammar
     private final String name;
     private final List<CodeStyle.Token> tokens;
 
-    public GrammarImpl(@NotNull String name, @NotNull List<CodeStyle.Token> tokens) {
+    public GrammarImpl(@NotNull String name, @NotNull List<CodeStyle.Token> tokens)
+    {
         this.name = name;
         this.tokens = tokens;
     }
 
     @NotNull
     @Override
-    public String name() {
+    public String name()
+    {
         return name;
     }
 
     @NotNull
     @Override
-    public List<CodeStyle.Token> tokens() {
+    public List<CodeStyle.Token> tokens()
+    {
         return tokens;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return ToString.toString(this);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/GrammarLocator.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/GrammarLocator.java
@@ -10,7 +10,8 @@ import java.util.Set;
  *
  * @see CodeStyle#CodeStyle(GrammarLocator)
  */
-public interface GrammarLocator {
+public interface GrammarLocator
+{
 
     @Nullable
     CodeStyle.Grammar grammar(@NotNull CodeStyle codeStyle, @NotNull String language);

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/GrammarUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/GrammarUtils.java
@@ -1,7 +1,5 @@
 package com.zeoflow.stylar.codestyle;
 
-import android.util.Log;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,20 +9,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class GrammarUtils {
+public abstract class GrammarUtils
+{
 
-    /**
-     * Used when extending an existing grammar to filter out tokens that should not be cloned.
-     *
-     * @see #extend(CodeStyle.Grammar, String, TokenFilter, CodeStyle.Token...)
-     */
-    public interface TokenFilter {
+    private static final Cloner CLONER = Cloner.create();
 
-        /**
-         * @param token {@link CodeStyle.Token} to validate
-         * @return a boolean indicating if supplied token should be included (passes the test)
-         */
-        boolean test(@NotNull CodeStyle.Token token);
+    private GrammarUtils()
+    {
     }
 
     /**
@@ -43,26 +34,34 @@ public abstract class GrammarUtils {
      * @return a found {@link CodeStyle.Token} or null
      */
     @Nullable
-    public static CodeStyle.Token findToken(@NotNull CodeStyle.Grammar grammar, @NotNull String path) {
+    public static CodeStyle.Token findToken(@NotNull CodeStyle.Grammar grammar, @NotNull String path)
+    {
         final String[] parts = path.split("/");
         return findToken(grammar, parts, 0);
     }
 
     @Nullable
-    private static CodeStyle.Token findToken(@NotNull CodeStyle.Grammar grammar, @NotNull String[] parts, int index) {
+    private static CodeStyle.Token findToken(@NotNull CodeStyle.Grammar grammar, @NotNull String[] parts, int index)
+    {
 
         final String part = parts[index];
         final boolean last = index == parts.length - 1;
 
-        for (CodeStyle.Token token : grammar.tokens()) {
-            if (part.equals(token.name())) {
-                if (last) {
+        for (CodeStyle.Token token : grammar.tokens())
+        {
+            if (part.equals(token.name()))
+            {
+                if (last)
+                {
                     return token;
-                } else {
+                } else
+                {
                     final CodeStyle.Grammar inside = findFirstInsideGrammar(token);
-                    if (inside != null) {
+                    if (inside != null)
+                    {
                         return findToken(inside, parts, index + 1);
-                    } else {
+                    } else
+                    {
                         break;
                     }
                 }
@@ -74,13 +73,15 @@ public abstract class GrammarUtils {
 
     // won't work if there are multiple patterns provided for a token (each with inside grammar)
     public static void insertBeforeToken(
-            @NotNull CodeStyle.Grammar grammar,
-            @NotNull String path,
-            CodeStyle.Token... tokens
-    ) {
+        @NotNull CodeStyle.Grammar grammar,
+        @NotNull String path,
+        CodeStyle.Token... tokens
+    )
+    {
 
         if (tokens == null
-                || tokens.length == 0) {
+            || tokens.length == 0)
+        {
             return;
         }
 
@@ -90,10 +91,11 @@ public abstract class GrammarUtils {
     }
 
     private static void insertBeforeToken(
-            @NotNull CodeStyle.Grammar grammar,
-            @NotNull String[] parts,
-            int index,
-            @NotNull CodeStyle.Token[] tokens) {
+        @NotNull CodeStyle.Grammar grammar,
+        @NotNull String[] parts,
+        int index,
+        @NotNull CodeStyle.Token[] tokens)
+    {
 
         final String part = parts[index];
         final boolean last = index == parts.length - 1;
@@ -102,25 +104,30 @@ public abstract class GrammarUtils {
 
         CodeStyle.Token token;
 
-        for (int i = 0, size = grammarTokens.size(); i < size; i++) {
+        for (int i = 0, size = grammarTokens.size(); i < size; i++)
+        {
 
             token = grammarTokens.get(i);
 
-            if (part.equals(token.name())) {
+            if (part.equals(token.name()))
+            {
 
                 // here we must decide what to do next:
                 //  - it can be out found one
                 //  - or we need to go deeper (c)
-                if (last) {
+                if (last)
+                {
                     // here we go, it's our token
                     insertTokensAt(i, grammarTokens, tokens);
-                } else {
+                } else
+                {
                     // now we must find a grammar that is inside
                     // token can have multiple patterns
                     // but as they are not identified somehow (no name or anything)
                     // we will try to find first pattern with inside grammar
                     final CodeStyle.Grammar inside = findFirstInsideGrammar(token);
-                    if (inside != null) {
+                    if (inside != null)
+                    {
                         insertBeforeToken(inside, parts, index + 1, tokens);
                     }
                 }
@@ -132,10 +139,13 @@ public abstract class GrammarUtils {
     }
 
     @Nullable
-    public static CodeStyle.Grammar findFirstInsideGrammar(@NotNull CodeStyle.Token token) {
+    public static CodeStyle.Grammar findFirstInsideGrammar(@NotNull CodeStyle.Token token)
+    {
         CodeStyle.Grammar grammar = null;
-        for (CodeStyle.Pattern pattern : token.patterns()) {
-            if (pattern.inside() != null) {
+        for (CodeStyle.Pattern pattern : token.patterns())
+        {
+            if (pattern.inside() != null)
+            {
                 grammar = pattern.inside();
                 break;
             }
@@ -144,48 +154,56 @@ public abstract class GrammarUtils {
     }
 
     private static void insertTokensAt(
-            int start,
-            @NotNull List<CodeStyle.Token> grammarTokens,
-            @NotNull CodeStyle.Token[] tokens
-    ) {
-        for (int i = 0, length = tokens.length; i < length; i++) {
+        int start,
+        @NotNull List<CodeStyle.Token> grammarTokens,
+        @NotNull CodeStyle.Token[] tokens
+    )
+    {
+        for (int i = 0, length = tokens.length; i < length; i++)
+        {
             grammarTokens.add(start + i, tokens[i]);
         }
     }
 
     @NotNull
-    public static CodeStyle.Grammar clone(@NotNull CodeStyle.Grammar grammar) {
+    public static CodeStyle.Grammar clone(@NotNull CodeStyle.Grammar grammar)
+    {
         return CLONER.clone(grammar);
     }
 
     @NotNull
-    public static CodeStyle.Token clone(@NotNull CodeStyle.Token token) {
+    public static CodeStyle.Token clone(@NotNull CodeStyle.Token token)
+    {
         return CLONER.clone(token);
     }
 
     @NotNull
-    public static CodeStyle.Pattern clone(@NotNull CodeStyle.Pattern pattern) {
+    public static CodeStyle.Pattern clone(@NotNull CodeStyle.Pattern pattern)
+    {
         return CLONER.clone(pattern);
     }
 
     @NotNull
     public static CodeStyle.Grammar extend(
-            @NotNull CodeStyle.Grammar grammar,
-            @NotNull String name,
-            CodeStyle.Token... tokens) {
+        @NotNull CodeStyle.Grammar grammar,
+        @NotNull String name,
+        CodeStyle.Token... tokens)
+    {
 
         // we clone the whole grammar, but override top-most tokens that are passed here
 
         final int size = tokens != null
-                ? tokens.length
-                : 0;
+            ? tokens.length
+            : 0;
 
-        if (size == 0) {
+        if (size == 0)
+        {
             return new GrammarImpl(name, clone(grammar).tokens());
         }
 
         final Map<String, CodeStyle.Token> overrides = new HashMap<>(size);
-        for (CodeStyle.Token token : tokens) {
+        for (CodeStyle.Token token : tokens)
+        {
             overrides.put(token.name(), token);
         }
 
@@ -194,11 +212,14 @@ public abstract class GrammarUtils {
 
         CodeStyle.Token override;
 
-        for (CodeStyle.Token origin : origins) {
+        for (CodeStyle.Token origin : origins)
+        {
             override = overrides.get(origin.name());
-            if (override != null) {
+            if (override != null)
+            {
                 out.add(override);
-            } else {
+            } else
+            {
                 out.add(clone(origin));
             }
         }
@@ -208,21 +229,25 @@ public abstract class GrammarUtils {
 
     @NotNull
     public static CodeStyle.Grammar extend(
-            @NotNull CodeStyle.Grammar grammar,
-            @NotNull String name,
-            @NotNull TokenFilter filter,
-            CodeStyle.Token... tokens) {
+        @NotNull CodeStyle.Grammar grammar,
+        @NotNull String name,
+        @NotNull TokenFilter filter,
+        CodeStyle.Token... tokens)
+    {
 
         final int size = tokens != null
-                ? tokens.length
-                : 0;
+            ? tokens.length
+            : 0;
 
         final Map<String, CodeStyle.Token> overrides;
-        if (size == 0) {
+        if (size == 0)
+        {
             overrides = Collections.emptyMap();
-        } else {
+        } else
+        {
             overrides = new HashMap<>(size);
-            for (CodeStyle.Token token : tokens) {
+            for (CodeStyle.Token token : tokens)
+            {
                 overrides.put(token.name(), token);
             }
         }
@@ -232,17 +257,21 @@ public abstract class GrammarUtils {
 
         CodeStyle.Token override;
 
-        for (CodeStyle.Token origin : origins) {
+        for (CodeStyle.Token origin : origins)
+        {
 
             // filter out undesired tokens
-            if (!filter.test(origin)) {
+            if (!filter.test(origin))
+            {
                 continue;
             }
 
             override = overrides.get(origin.name());
-            if (override != null) {
+            if (override != null)
+            {
                 out.add(override);
-            } else {
+            } else
+            {
                 out.add(clone(origin));
             }
         }
@@ -251,16 +280,28 @@ public abstract class GrammarUtils {
     }
 
     @NotNull
-    public static CodeStyle.Grammar require(@NotNull CodeStyle codeStyle, @NotNull String name) {
+    public static CodeStyle.Grammar require(@NotNull CodeStyle codeStyle, @NotNull String name)
+    {
         final CodeStyle.Grammar grammar = codeStyle.grammar(name);
-        if (grammar == null) {
+        if (grammar == null)
+        {
             throw new IllegalStateException("Unexpected state, requested language is not found: " + name);
         }
         return grammar;
     }
 
-    private GrammarUtils() {
-    }
+    /**
+     * Used when extending an existing grammar to filter out tokens that should not be cloned.
+     *
+     * @see #extend(CodeStyle.Grammar, String, TokenFilter, CodeStyle.Token...)
+     */
+    public interface TokenFilter
+    {
 
-    private static final Cloner CLONER = Cloner.create();
+        /**
+         * @param token {@link CodeStyle.Token} to validate
+         * @return a boolean indicating if supplied token should be included (passes the test)
+         */
+        boolean test(@NotNull CodeStyle.Token token);
+    }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/PatternImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/PatternImpl.java
@@ -3,7 +3,8 @@ package com.zeoflow.stylar.codestyle;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class PatternImpl implements CodeStyle.Pattern {
+public class PatternImpl implements CodeStyle.Pattern
+{
 
     private final java.util.regex.Pattern regex;
     private final boolean lookbehind;
@@ -12,11 +13,12 @@ public class PatternImpl implements CodeStyle.Pattern {
     private final CodeStyle.Grammar inside;
 
     public PatternImpl(
-            @NotNull java.util.regex.Pattern regex,
-            boolean lookbehind,
-            boolean greedy,
-            @Nullable String alias,
-            @Nullable CodeStyle.Grammar inside) {
+        @NotNull java.util.regex.Pattern regex,
+        boolean lookbehind,
+        boolean greedy,
+        @Nullable String alias,
+        @Nullable CodeStyle.Grammar inside)
+    {
         this.regex = regex;
         this.lookbehind = lookbehind;
         this.greedy = greedy;
@@ -26,34 +28,40 @@ public class PatternImpl implements CodeStyle.Pattern {
 
     @NotNull
     @Override
-    public java.util.regex.Pattern regex() {
+    public java.util.regex.Pattern regex()
+    {
         return regex;
     }
 
     @Override
-    public boolean lookbehind() {
+    public boolean lookbehind()
+    {
         return lookbehind;
     }
 
     @Override
-    public boolean greedy() {
+    public boolean greedy()
+    {
         return greedy;
     }
 
     @Nullable
     @Override
-    public String alias() {
+    public String alias()
+    {
         return alias;
     }
 
     @Nullable
     @Override
-    public CodeStyle.Grammar inside() {
+    public CodeStyle.Grammar inside()
+    {
         return inside;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return ToString.toString(this);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/SyntaxImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/SyntaxImpl.java
@@ -5,7 +5,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class SyntaxImpl implements CodeStyle.Syntax {
+public class SyntaxImpl implements CodeStyle.Syntax
+{
 
     private final String type;
     private final List<? extends CodeStyle.Node> children;
@@ -15,12 +16,13 @@ public class SyntaxImpl implements CodeStyle.Syntax {
     private final boolean tokenized;
 
     public SyntaxImpl(
-            @NotNull String type,
-            @NotNull List<? extends CodeStyle.Node> children,
-            @Nullable String alias,
-            @NotNull String matchedString,
-            boolean greedy,
-            boolean tokenized) {
+        @NotNull String type,
+        @NotNull List<? extends CodeStyle.Node> children,
+        @Nullable String alias,
+        @NotNull String matchedString,
+        boolean greedy,
+        boolean tokenized)
+    {
         this.type = type;
         this.children = children;
         this.alias = alias;
@@ -30,58 +32,67 @@ public class SyntaxImpl implements CodeStyle.Syntax {
     }
 
     @Override
-    public int textLength() {
+    public int textLength()
+    {
         return matchedString.length();
     }
 
     @Override
-    public final boolean isSyntax() {
+    public final boolean isSyntax()
+    {
         return true;
     }
 
     @NotNull
     @Override
-    public String type() {
+    public String type()
+    {
         return type;
     }
 
     @NotNull
     @Override
-    public List<? extends CodeStyle.Node> children() {
+    public List<? extends CodeStyle.Node> children()
+    {
         return children;
     }
 
     @Nullable
     @Override
-    public String alias() {
+    public String alias()
+    {
         return alias;
     }
 
     @NotNull
     @Override
-    public String matchedString() {
+    public String matchedString()
+    {
         return matchedString;
     }
 
     @Override
-    public boolean greedy() {
+    public boolean greedy()
+    {
         return greedy;
     }
 
     @Override
-    public boolean tokenized() {
+    public boolean tokenized()
+    {
         return tokenized;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "SyntaxImpl{" +
-                "type='" + type + '\'' +
-                ", children=" + children +
-                ", alias='" + alias + '\'' +
-                ", matchedString='" + matchedString + '\'' +
-                ", greedy=" + greedy +
-                ", tokenized=" + tokenized +
-                '}';
+            "type='" + type + '\'' +
+            ", children=" + children +
+            ", alias='" + alias + '\'' +
+            ", matchedString='" + matchedString + '\'' +
+            ", greedy=" + greedy +
+            ", tokenized=" + tokenized +
+            '}';
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/TextImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/TextImpl.java
@@ -7,30 +7,35 @@ public class TextImpl implements CodeStyle.Text
 
     private final String literal;
 
-    public TextImpl(@NotNull String literal) {
+    public TextImpl(@NotNull String literal)
+    {
         this.literal = literal;
     }
 
     @Override
-    public int textLength() {
+    public int textLength()
+    {
         return literal.length();
     }
 
     @Override
-    public final boolean isSyntax() {
+    public final boolean isSyntax()
+    {
         return false;
     }
 
     @NotNull
     @Override
-    public String literal() {
+    public String literal()
+    {
         return literal;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "TextImpl{" +
-                "literal='" + literal + '\'' +
-                '}';
+            "literal='" + literal + '\'' +
+            '}';
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/ToString.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/ToString.java
@@ -6,58 +6,62 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashSet;
 import java.util.Set;
 
-abstract class ToString {
+abstract class ToString
+{
+
+    private ToString()
+    {
+    }
 
     @NotNull
-    static String toString(@NotNull CodeStyle.Grammar grammar) {
+    static String toString(@NotNull CodeStyle.Grammar grammar)
+    {
         final StringBuilder builder = new StringBuilder();
         toString(builder, new CacheImpl(), grammar);
         return builder.toString();
     }
 
     @NotNull
-    static String toString(@NotNull CodeStyle.Token token) {
+    static String toString(@NotNull CodeStyle.Token token)
+    {
         final StringBuilder builder = new StringBuilder();
         toString(builder, new CacheImpl(), token);
         return builder.toString();
     }
 
     @NotNull
-    static String toString(@NotNull CodeStyle.Pattern pattern) {
+    static String toString(@NotNull CodeStyle.Pattern pattern)
+    {
         final StringBuilder builder = new StringBuilder();
         toString(builder, new CacheImpl(), pattern);
         return builder.toString();
     }
 
-    private ToString() {
-    }
-
-    private interface Cache {
-
-        boolean visited(@NotNull Object o);
-
-        void markVisited(@NotNull Object o);
-    }
-
-    private static void toString(@NotNull StringBuilder builder, @NotNull Cache cache, @NotNull CodeStyle.Grammar grammar) {
+    private static void toString(@NotNull StringBuilder builder, @NotNull Cache cache, @NotNull CodeStyle.Grammar grammar)
+    {
 
         builder
-                .append("Grammar{id=0x")
-                .append(Integer.toHexString(System.identityHashCode(grammar)))
-                .append(",name=\"")
-                .append(grammar.name())
-                .append('\"');
+            .append("Grammar{id=0x")
+            .append(Integer.toHexString(System.identityHashCode(grammar)))
+            .append(",name=\"")
+            .append(grammar.name())
+            .append('\"');
 
-        if (cache.visited(grammar)) {
+        if (cache.visited(grammar))
+        {
             builder.append(",[...]");
-        } else {
+        } else
+        {
             cache.markVisited(grammar);
             builder.append(",tokens=[");
             boolean first = true;
-            for (CodeStyle.Token token : grammar.tokens()) {
-                if (first) {
+            for (CodeStyle.Token token : grammar.tokens())
+            {
+                if (first)
+                {
                     first = false;
-                } else {
+                } else
+                {
                     builder.append(',');
                 }
                 toString(builder, cache, token);
@@ -68,25 +72,31 @@ abstract class ToString {
         builder.append('}');
     }
 
-    private static void toString(@NotNull StringBuilder builder, @NotNull Cache cache, @NotNull CodeStyle.Token token) {
+    private static void toString(@NotNull StringBuilder builder, @NotNull Cache cache, @NotNull CodeStyle.Token token)
+    {
 
         builder
-                .append("Token{id=0x")
-                .append(Integer.toHexString(System.identityHashCode(token)))
-                .append(",name=\"")
-                .append(token.name())
-                .append('\"');
+            .append("Token{id=0x")
+            .append(Integer.toHexString(System.identityHashCode(token)))
+            .append(",name=\"")
+            .append(token.name())
+            .append('\"');
 
-        if (cache.visited(token)) {
+        if (cache.visited(token))
+        {
             builder.append(",[...]");
-        } else {
+        } else
+        {
             cache.markVisited(token);
             builder.append(",patterns=[");
             boolean first = true;
-            for (CodeStyle.Pattern pattern : token.patterns()) {
-                if (first) {
+            for (CodeStyle.Pattern pattern : token.patterns())
+            {
+                if (first)
+                {
                     first = false;
-                } else {
+                } else
+                {
                     builder.append(',');
                 }
                 toString(builder, cache, pattern);
@@ -96,34 +106,41 @@ abstract class ToString {
         builder.append('}');
     }
 
-    private static void toString(@NotNull StringBuilder builder, @NotNull Cache cache, @NotNull CodeStyle.Pattern pattern) {
+    private static void toString(@NotNull StringBuilder builder, @NotNull Cache cache, @NotNull CodeStyle.Pattern pattern)
+    {
 
         builder
-                .append("Pattern{id=0x")
-                .append(Integer.toHexString(System.identityHashCode(pattern)));
+            .append("Pattern{id=0x")
+            .append(Integer.toHexString(System.identityHashCode(pattern)));
 
-        if (cache.visited(pattern)) {
+        if (cache.visited(pattern))
+        {
             builder.append(",[...]");
-        } else {
+        } else
+        {
 
             cache.markVisited(pattern);
 
             builder.append(",regex=\"").append(pattern.regex()).append('\"');
 
-            if (pattern.lookbehind()) {
+            if (pattern.lookbehind())
+            {
                 builder.append(",lookbehind=true");
             }
 
-            if (pattern.greedy()) {
+            if (pattern.greedy())
+            {
                 builder.append(",greedy=true");
             }
 
-            if (pattern.alias() != null) {
+            if (pattern.alias() != null)
+            {
                 builder.append(",alias=\"").append(pattern.alias()).append('\"');
             }
 
             final CodeStyle.Grammar inside = pattern.inside();
-            if (inside != null) {
+            if (inside != null)
+            {
                 builder.append(",inside=");
                 toString(builder, cache, inside);
             }
@@ -132,23 +149,35 @@ abstract class ToString {
         builder.append('}');
     }
 
-    private static class CacheImpl implements Cache {
+    private interface Cache
+    {
+
+        boolean visited(@NotNull Object o);
+
+        void markVisited(@NotNull Object o);
+    }
+
+    private static class CacheImpl implements Cache
+    {
 
         private final Set<Integer> cache = new HashSet<>(3);
 
+        @NotNull
+        private static Integer key(@NotNull Object o)
+        {
+            return System.identityHashCode(o);
+        }
+
         @Override
-        public boolean visited(@NotNull Object o) {
+        public boolean visited(@NotNull Object o)
+        {
             return cache.contains(key(o));
         }
 
         @Override
-        public void markVisited(@NotNull Object o) {
+        public void markVisited(@NotNull Object o)
+        {
             cache.add(key(o));
-        }
-
-        @NotNull
-        private static Integer key(@NotNull Object o) {
-            return System.identityHashCode(o);
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/TokenImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/TokenImpl.java
@@ -10,25 +10,29 @@ public class TokenImpl implements CodeStyle.Token
     private final String name;
     private final List<CodeStyle.Pattern> patterns;
 
-    public TokenImpl(@NotNull String name, @NotNull List<CodeStyle.Pattern> patterns) {
+    public TokenImpl(@NotNull String name, @NotNull List<CodeStyle.Pattern> patterns)
+    {
         this.name = name;
         this.patterns = patterns;
     }
 
     @NotNull
     @Override
-    public String name() {
+    public String name()
+    {
         return name;
     }
 
     @NotNull
     @Override
-    public List<CodeStyle.Pattern> patterns() {
+    public List<CodeStyle.Pattern> patterns()
+    {
         return patterns;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return ToString.toString(this);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/annotations/Aliases.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/annotations/Aliases.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
-public @interface Aliases {
+public @interface Aliases
+{
     String[] value();
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/annotations/Extend.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/annotations/Extend.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
-public @interface Extend {
+public @interface Extend
+{
     String value();
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/annotations/Modify.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/annotations/Modify.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
-public @interface Modify {
+public @interface Modify
+{
     String[] value();
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/AnnotationsInformation.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/AnnotationsInformation.java
@@ -1,14 +1,19 @@
 package com.zeoflow.stylar.codestyle.bundler;
 
-import android.util.Log;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class AnnotationsInformation {
+public abstract class AnnotationsInformation
+{
+
+    @NotNull
+    public static AnnotationsInformation create()
+    {
+        return new Impl();
+    }
 
     @Nullable
     public abstract String findExtendInformation(@NotNull String source);
@@ -19,81 +24,22 @@ public abstract class AnnotationsInformation {
     @Nullable
     public abstract List<String> findModifyInformation(@NotNull String source);
 
-
-    @NotNull
-    public static AnnotationsInformation create() {
-        return new Impl();
-    }
-
-    static class Impl extends AnnotationsInformation {
+    static class Impl extends AnnotationsInformation
+    {
 
         @Nullable
-        @Override
-        public String findExtendInformation(@NotNull String source) {
-
-            final String annotation = "@Extend";
-            final int index = source.indexOf(annotation);
-            if (index < 0) {
-                return null;
-            }
-
-            char c;
-
-            final StringBuilder builder = new StringBuilder();
-
-            boolean insideString = false;
-
-            for (int i = index + annotation.length(); i < source.length(); i++) {
-
-                c = source.charAt(i);
-
-                if (Character.isWhitespace(c)) {
-                    continue;
-                }
-
-                if ('\"' == c) {
-                    insideString = !insideString;
-                    if (!insideString) {
-                        break;
-                    } else {
-                        continue;
-                    }
-                }
-
-                if (insideString) {
-                    builder.append(c);
-                }
-            }
-
-            if (builder.length() == 0) {
-                return null;
-            } else {
-                return builder.toString();
-            }
-        }
-
-        @Nullable
-        @Override
-        public List<String> findAliasesInformation(@NotNull String source) {
-            return findAnnotationArrayInformation("@Aliases", source);
-        }
-
-        @Nullable
-        @Override
-        public List<String> findModifyInformation(@NotNull String source) {
-            return findAnnotationArrayInformation("@Modify", source);
-        }
-
-        @Nullable
-        private static List<String> findAnnotationArrayInformation(@NotNull String annotation, @NotNull String source) {
+        private static List<String> findAnnotationArrayInformation(@NotNull String annotation, @NotNull String source)
+        {
 
             final int start = source.indexOf(annotation);
-            if (start < 0) {
+            if (start < 0)
+            {
                 return null;
             }
 
             final int end = source.indexOf(')', start);
-            if (end < 0) {
+            if (end < 0)
+            {
                 return null;
             }
 
@@ -105,33 +51,109 @@ public abstract class AnnotationsInformation {
 
             boolean insideString = false;
 
-            for (int i = start; i < end; i++) {
+            for (int i = start; i < end; i++)
+            {
 
                 c = source.charAt(i);
 
-                if (Character.isWhitespace(c)) {
+                if (Character.isWhitespace(c))
+                {
                     continue;
                 }
 
-                if ('\"' == c) {
+                if ('\"' == c)
+                {
                     insideString = !insideString;
-                    if (!insideString) {
+                    if (!insideString)
+                    {
                         aliases.add(builder.toString());
                         builder.setLength(0);
                     }
                     continue;
                 }
 
-                if (insideString) {
+                if (insideString)
+                {
                     builder.append(c);
                 }
             }
 
-            if (aliases.size() == 0) {
+            if (aliases.size() == 0)
+            {
                 return null;
-            } else {
+            } else
+            {
                 return aliases;
             }
+        }
+
+        @Nullable
+        @Override
+        public String findExtendInformation(@NotNull String source)
+        {
+
+            final String annotation = "@Extend";
+            final int index = source.indexOf(annotation);
+            if (index < 0)
+            {
+                return null;
+            }
+
+            char c;
+
+            final StringBuilder builder = new StringBuilder();
+
+            boolean insideString = false;
+
+            for (int i = index + annotation.length(); i < source.length(); i++)
+            {
+
+                c = source.charAt(i);
+
+                if (Character.isWhitespace(c))
+                {
+                    continue;
+                }
+
+                if ('\"' == c)
+                {
+                    insideString = !insideString;
+                    if (!insideString)
+                    {
+                        break;
+                    } else
+                    {
+                        continue;
+                    }
+                }
+
+                if (insideString)
+                {
+                    builder.append(c);
+                }
+            }
+
+            if (builder.length() == 0)
+            {
+                return null;
+            } else
+            {
+                return builder.toString();
+            }
+        }
+
+        @Nullable
+        @Override
+        public List<String> findAliasesInformation(@NotNull String source)
+        {
+            return findAnnotationArrayInformation("@Aliases", source);
+        }
+
+        @Nullable
+        @Override
+        public List<String> findModifyInformation(@NotNull String source)
+        {
+            return findAnnotationArrayInformation("@Modify", source);
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/ClassInfo.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/ClassInfo.java
@@ -2,12 +2,14 @@ package com.zeoflow.stylar.codestyle.bundler;
 
 import org.jetbrains.annotations.NotNull;
 
-public class ClassInfo {
+public class ClassInfo
+{
 
     public final String packageName;
     public final String className;
 
-    public ClassInfo(@NotNull String packageName, @NotNull String className) {
+    public ClassInfo(@NotNull String packageName, @NotNull String className)
+    {
         this.packageName = packageName;
         this.className = className;
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/CodeStyleBundler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/CodeStyleBundler.java
@@ -39,7 +39,6 @@ import ix.Ix;
 import static org.openjdk.javax.tools.Diagnostic.Kind.ERROR;
 import static org.openjdk.javax.tools.Diagnostic.Kind.NOTE;
 
-
 public class CodeStyleBundler extends AbstractProcessor
 {
 

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/CodeStyleBundler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/CodeStyleBundler.java
@@ -63,6 +63,212 @@ public class CodeStyleBundler extends AbstractProcessor
     private Elements elements;
     private Filer filer;
 
+    @NotNull
+    private static String languageSourceFileName(@NotNull String name)
+    {
+        return String.format(Locale.US, LANGUAGE_SOURCE_PATTERN, javaValidName(name));
+    }
+
+    @NotNull
+    private static String grammarLocatorTemplate()
+    {
+        try
+        {
+            return IOUtils.resourceToString("/GrammarLocator.template.java", StandardCharsets.UTF_8);
+        } catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    private static String grammarLocatorSource(
+        @NotNull String template,
+        @NotNull ClassInfo classInfo,
+        @NotNull Map<String, LanguageInfo> languages)
+    {
+        final StringBuilder builder = new StringBuilder(template);
+        replaceTemplate(builder, TEMPLATE_PACKAGE_NAME, classInfo.packageName);
+        replaceTemplate(builder, TEMPLATE_IMPORTS, createImports(languages));
+        replaceTemplate(builder, TEMPLATE_CLASS_NAME, classInfo.className);
+        replaceTemplate(builder, TEMPLATE_REAL_LANGUAGE_NAME, createRealLanguageName(languages));
+        replaceTemplate(builder, TEMPLATE_OBTAIN_GRAMMAR, createObtainGrammar(languages));
+        replaceTemplate(builder, TEMPLATE_TRIGGER_MODIFY, createTriggerModify(languages));
+        replaceTemplate(builder, TEMPLATE_LANGUAGES, createLanguages(languages));
+        final Formatter formatter = new Formatter(JavaFormatterOptions.defaultOptions());
+        try
+        {
+            return formatter.formatSource(builder.toString());
+        } catch (FormatterException e)
+        {
+            System.out.printf("source: %n%s%n", builder.toString());
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void replaceTemplate(@NotNull StringBuilder template, @NotNull String name, @NotNull String content)
+    {
+        final int index = template.indexOf(name);
+        template.replace(index, index + name.length(), content);
+    }
+
+    @NotNull
+    private static String createImports(@NotNull Map<String, LanguageInfo> languages)
+    {
+        final StringBuilder builder = new StringBuilder();
+        Ix.from(languages.values())
+            .map(languageInfo -> languageInfo.name)
+            .orderBy(String::compareTo)
+            .foreach(s -> builder
+                .append("import ")
+                .append(LANGUAGES_PACKAGE)
+                .append(".CodeStyle_")
+                .append(javaValidName(s))
+                .append(';')
+                .append('\n'));
+        return builder.toString();
+    }
+
+    // we must return a set of languageInfos here (so we do not copy language more than once
+    // thus allowing multiple grammarLocators)
+
+    @NotNull
+    private static String createRealLanguageName(@NotNull Map<String, LanguageInfo> languages)
+    {
+        final StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, LanguageInfo> entry : languages.entrySet())
+        {
+            final List<String> aliases = entry.getValue().aliases;
+            if (aliases != null
+                && aliases.size() > 0)
+            {
+                for (String alias : aliases)
+                {
+                    builder.append("case \"")
+                        .append(alias)
+                        .append('\"')
+                        .append(':')
+                        .append('\n');
+                }
+                builder.append("out = \"")
+                    .append(entry.getKey())
+                    .append('\"')
+                    .append(';')
+                    .append('\n')
+                    .append("break;\n");
+            }
+        }
+
+        if (builder.length() > 0)
+        {
+            builder.append("default:\n")
+                .append("out = name;\n")
+                .append("}\nreturn out;");
+            builder.insert(0, "final String out;\nswitch (name) {");
+            return builder.toString();
+        } else
+        {
+            return "return name;";
+        }
+    }
+
+    @NotNull
+    private static String createObtainGrammar(@NotNull Map<String, LanguageInfo> languages)
+    {
+        final StringBuilder builder = new StringBuilder();
+        builder
+            .append("final CodeStyle.Grammar grammar;\n")
+            .append("switch(name) {\n");
+        Ix.from(languages.keySet())
+            .orderBy(String::compareTo)
+            .foreach(s -> builder.append("case \"")
+                .append(s)
+                .append("\":\n")
+                .append("grammar = CodeStyle_")
+                .append(javaValidName(s))
+                .append(".create(prism4j);\nbreak;\n"));
+        builder.append("default:\ngrammar = null;\n}")
+            .append("return grammar;");
+        return builder.toString();
+    }
+
+    @NotNull
+    private static String createTriggerModify(@NotNull Map<String, LanguageInfo> languages)
+    {
+
+        // so, create a map collection where each entry in `modify` is the key and languageInfo.name is value
+        final Map<String, List<String>> map = new HashMap<>(3);
+
+        List<String> modify;
+
+        for (LanguageInfo info : languages.values())
+        {
+
+            modify = info.modify;
+
+            if (modify != null
+                && modify.size() > 0)
+            {
+
+                for (String name : modify)
+                {
+                    map.computeIfAbsent(name, k -> new ArrayList<>(3)).add(info.name);
+                }
+            }
+        }
+
+        if (map.size() == 0)
+        {
+            return "";
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        builder.append("switch(name){\n");
+        for (Map.Entry<String, List<String>> entry : map.entrySet())
+        {
+            builder.append("case \"")
+                .append(entry.getKey())
+                .append("\":\n");
+            for (String lang : entry.getValue())
+            {
+                builder.append("prism4j.grammar(\"")
+                    .append(lang)
+                    .append("\");\n");
+            }
+            builder.append("break;\n");
+        }
+        builder.append("}");
+        return builder.toString();
+    }
+
+    @NotNull
+    private static String javaValidName(@NotNull String name)
+    {
+        return name.replaceAll("-", "_");
+    }
+
+    @NotNull
+    private static String createLanguages(@NotNull Map<String, LanguageInfo> languages)
+    {
+
+        final StringBuilder builder = new StringBuilder();
+        final List<String> list = new ArrayList<>(languages.keySet());
+        list.sort(String::compareTo);
+
+        builder.append("final Set<String> set = new HashSet<String>(")
+            .append(list.size())
+            .append(");\n");
+
+        for (String language : list)
+        {
+            builder.append("set.add(\"").append(language).append("\");\n");
+        }
+
+        builder.append("return set;");
+
+        return builder.toString();
+    }
+
     // this override might've killed me... without it processor cannot find ANY resources...
     @Override
     public Set<String> getSupportedOptions()
@@ -127,9 +333,6 @@ public class CodeStyleBundler extends AbstractProcessor
 
         return false;
     }
-
-    // we must return a set of languageInfos here (so we do not copy language more than once
-    // thus allowing multiple grammarLocators)
 
     @NotNull
     private Set<LanguageInfo> process(@NotNull Element element)
@@ -312,24 +515,6 @@ public class CodeStyleBundler extends AbstractProcessor
     }
 
     @NotNull
-    private static String languageSourceFileName(@NotNull String name)
-    {
-        return String.format(Locale.US, LANGUAGE_SOURCE_PATTERN, javaValidName(name));
-    }
-
-    @NotNull
-    private static String grammarLocatorTemplate()
-    {
-        try
-        {
-            return IOUtils.resourceToString("/GrammarLocator.template.java", StandardCharsets.UTF_8);
-        } catch (IOException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @NotNull
     private ClassInfo classInfo(@NotNull Element element, @NotNull String name)
     {
 
@@ -358,190 +543,5 @@ public class CodeStyleBundler extends AbstractProcessor
         }
 
         return new ClassInfo(packageName, className);
-    }
-
-    @NotNull
-    private static String grammarLocatorSource(
-        @NotNull String template,
-        @NotNull ClassInfo classInfo,
-        @NotNull Map<String, LanguageInfo> languages)
-    {
-        final StringBuilder builder = new StringBuilder(template);
-        replaceTemplate(builder, TEMPLATE_PACKAGE_NAME, classInfo.packageName);
-        replaceTemplate(builder, TEMPLATE_IMPORTS, createImports(languages));
-        replaceTemplate(builder, TEMPLATE_CLASS_NAME, classInfo.className);
-        replaceTemplate(builder, TEMPLATE_REAL_LANGUAGE_NAME, createRealLanguageName(languages));
-        replaceTemplate(builder, TEMPLATE_OBTAIN_GRAMMAR, createObtainGrammar(languages));
-        replaceTemplate(builder, TEMPLATE_TRIGGER_MODIFY, createTriggerModify(languages));
-        replaceTemplate(builder, TEMPLATE_LANGUAGES, createLanguages(languages));
-        final Formatter formatter = new Formatter(JavaFormatterOptions.defaultOptions());
-        try
-        {
-            return formatter.formatSource(builder.toString());
-        } catch (FormatterException e)
-        {
-            System.out.printf("source: %n%s%n", builder.toString());
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static void replaceTemplate(@NotNull StringBuilder template, @NotNull String name, @NotNull String content)
-    {
-        final int index = template.indexOf(name);
-        template.replace(index, index + name.length(), content);
-    }
-
-    @NotNull
-    private static String createImports(@NotNull Map<String, LanguageInfo> languages)
-    {
-        final StringBuilder builder = new StringBuilder();
-        Ix.from(languages.values())
-            .map(languageInfo -> languageInfo.name)
-            .orderBy(String::compareTo)
-            .foreach(s -> builder
-                .append("import ")
-                .append(LANGUAGES_PACKAGE)
-                .append(".CodeStyle_")
-                .append(javaValidName(s))
-                .append(';')
-                .append('\n'));
-        return builder.toString();
-    }
-
-    @NotNull
-    private static String createRealLanguageName(@NotNull Map<String, LanguageInfo> languages)
-    {
-        final StringBuilder builder = new StringBuilder();
-        for (Map.Entry<String, LanguageInfo> entry : languages.entrySet())
-        {
-            final List<String> aliases = entry.getValue().aliases;
-            if (aliases != null
-                && aliases.size() > 0)
-            {
-                for (String alias : aliases)
-                {
-                    builder.append("case \"")
-                        .append(alias)
-                        .append('\"')
-                        .append(':')
-                        .append('\n');
-                }
-                builder.append("out = \"")
-                    .append(entry.getKey())
-                    .append('\"')
-                    .append(';')
-                    .append('\n')
-                    .append("break;\n");
-            }
-        }
-
-        if (builder.length() > 0)
-        {
-            builder.append("default:\n")
-                .append("out = name;\n")
-                .append("}\nreturn out;");
-            builder.insert(0, "final String out;\nswitch (name) {");
-            return builder.toString();
-        } else
-        {
-            return "return name;";
-        }
-    }
-
-    @NotNull
-    private static String createObtainGrammar(@NotNull Map<String, LanguageInfo> languages)
-    {
-        final StringBuilder builder = new StringBuilder();
-        builder
-            .append("final CodeStyle.Grammar grammar;\n")
-            .append("switch(name) {\n");
-        Ix.from(languages.keySet())
-            .orderBy(String::compareTo)
-            .foreach(s -> builder.append("case \"")
-                .append(s)
-                .append("\":\n")
-                .append("grammar = CodeStyle_")
-                .append(javaValidName(s))
-                .append(".create(prism4j);\nbreak;\n"));
-        builder.append("default:\ngrammar = null;\n}")
-            .append("return grammar;");
-        return builder.toString();
-    }
-
-    @NotNull
-    private static String createTriggerModify(@NotNull Map<String, LanguageInfo> languages)
-    {
-
-        // so, create a map collection where each entry in `modify` is the key and languageInfo.name is value
-        final Map<String, List<String>> map = new HashMap<>(3);
-
-        List<String> modify;
-
-        for (LanguageInfo info : languages.values())
-        {
-
-            modify = info.modify;
-
-            if (modify != null
-                && modify.size() > 0)
-            {
-
-                for (String name : modify)
-                {
-                    map.computeIfAbsent(name, k -> new ArrayList<>(3)).add(info.name);
-                }
-            }
-        }
-
-        if (map.size() == 0)
-        {
-            return "";
-        }
-
-        final StringBuilder builder = new StringBuilder();
-        builder.append("switch(name){\n");
-        for (Map.Entry<String, List<String>> entry : map.entrySet())
-        {
-            builder.append("case \"")
-                .append(entry.getKey())
-                .append("\":\n");
-            for (String lang : entry.getValue())
-            {
-                builder.append("prism4j.grammar(\"")
-                    .append(lang)
-                    .append("\");\n");
-            }
-            builder.append("break;\n");
-        }
-        builder.append("}");
-        return builder.toString();
-    }
-
-    @NotNull
-    private static String javaValidName(@NotNull String name)
-    {
-        return name.replaceAll("-", "_");
-    }
-
-    @NotNull
-    private static String createLanguages(@NotNull Map<String, LanguageInfo> languages)
-    {
-
-        final StringBuilder builder = new StringBuilder();
-        final List<String> list = new ArrayList<>(languages.keySet());
-        list.sort(String::compareTo);
-
-        builder.append("final Set<String> set = new HashSet<String>(")
-            .append(list.size())
-            .append(");\n");
-
-        for (String language : list)
-        {
-            builder.append("set.add(\"").append(language).append("\");\n");
-        }
-
-        builder.append("return set;");
-
-        return builder.toString();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/LanguageInfo.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/LanguageInfo.java
@@ -6,7 +6,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class LanguageInfo {
+public class LanguageInfo
+{
 
     public final String name;
     public final List<String> aliases;
@@ -15,12 +16,13 @@ public class LanguageInfo {
     public final String source;
 
     public LanguageInfo(
-            @NotNull String name,
-            @Nullable List<String> aliases,
-            @Nullable String extend,
-            @Nullable List<String> modify,
-            @NotNull String source
-    ) {
+        @NotNull String name,
+        @Nullable List<String> aliases,
+        @Nullable String extend,
+        @Nullable List<String> modify,
+        @NotNull String source
+    )
+    {
         this.name = name;
         this.aliases = aliases;
         this.extend = extend;
@@ -29,7 +31,8 @@ public class LanguageInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(Object o)
+    {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -39,15 +42,17 @@ public class LanguageInfo {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return name.hashCode();
     }
 
     @NotNull
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "LanguageInfo{" +
-                "name='" + name + '\'' +
-                '}';
+            "name='" + name + '\'' +
+            '}';
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/ListResources.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/bundler/ListResources.java
@@ -14,78 +14,95 @@ import java.util.Objects;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-abstract class ListResources {
+abstract class ListResources
+{
+
+    @NotNull
+    static ListResources create()
+    {
+        return new Impl();
+    }
 
     @NotNull
     abstract List<String> listResourceFiles(@NotNull Class<?> type, @NotNull String folder);
 
-    @NotNull
-    static ListResources create() {
-        return new Impl();
-    }
-
-    static class Impl extends ListResources {
+    static class Impl extends ListResources
+    {
 
         // thanks to http://www.uofr.net/~greg/java/get-resource-listing.html
         @NotNull
         @Override
-        List<String> listResourceFiles(@NotNull Class<?> type, @NotNull String folder) {
+        List<String> listResourceFiles(@NotNull Class<?> type, @NotNull String folder)
+        {
 
             URL url = Objects.requireNonNull(type.getClassLoader()).getResource(folder);
 
             if (url != null
-                    && "file".equals(url.getProtocol())) {
-                try {
+                && "file".equals(url.getProtocol()))
+            {
+                try
+                {
                     final File file = new File(url.toURI());
                     final String[] files = file.list();
                     if (files != null
-                            && files.length > 0) {
+                        && files.length > 0)
+                    {
                         final List<String> list = new ArrayList<>(files.length);
                         Collections.addAll(list, files);
                         return list;
-                    } else {
+                    } else
+                    {
                         throw new RuntimeException("Unexpected state, no files found for resource folder: " + folder);
                     }
-                } catch (URISyntaxException e) {
+                } catch (URISyntaxException e)
+                {
                     throw new RuntimeException(e);
                 }
             }
 
-            if (url == null) {
+            if (url == null)
+            {
                 final String me = type.getName().replace('.', '/') + ".class";
                 url = type.getClassLoader().getResource(me);
-                if (url == null) {
+                if (url == null)
+                {
                     throw new RuntimeException("Unexpected state, cannot obtain a resource");
                 }
             }
 
-            if (!"jar".equals(url.getProtocol())) {
+            if (!"jar".equals(url.getProtocol()))
+            {
                 throw new RuntimeException("Cannot obtain resource for url (expecting `jar` " +
-                        "protocol): " + url);
+                    "protocol): " + url);
             }
 
             final String path = url.getPath();
             final String jarPath = path.substring(5, path.indexOf('!'));
-            try {
+            try
+            {
                 final JarFile jarFile = new JarFile(URLDecoder.decode(jarPath, "UTF-8"));
                 final Enumeration<JarEntry> jarEntries = jarFile.entries();
                 final List<String> strings = new ArrayList<>();
                 final int start = folder.length();
                 String name;
                 int index;
-                while (jarEntries.hasMoreElements()) {
+                while (jarEntries.hasMoreElements())
+                {
                     name = jarEntries.nextElement().getName();
-                    if (name.startsWith(folder)) {
+                    if (name.startsWith(folder))
+                    {
                         name = name.substring(start);
                         index = name.indexOf('/');
-                        if (index > -1) {
+                        if (index > -1)
+                        {
                             name = name.substring(0, index);
                         }
                         strings.add(name);
                     }
                 }
                 return strings;
-            } catch (Throwable t) {
+            } catch (Throwable t)
+            {
                 throw new RuntimeException(t);
             }
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_clike.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_clike.java
@@ -14,8 +14,13 @@ import static java.util.regex.Pattern.compile;
 public abstract class CodeStyle_clike
 {
 
+  private CodeStyle_clike()
+  {
+  }
+
   @NotNull
-  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle) {
+  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle)
+  {
     return grammar(
       "clike",
       token(
@@ -50,8 +55,5 @@ public abstract class CodeStyle_clike
       token("operator", pattern(compile("--?|\\+\\+?|!=?=?|<=?|>=?|==?=?|&&?|\\|\\|?|\\?|\\*|\\/|~|\\^|%"))),
       token("punctuation", pattern(compile("[{}\\[\\];(),.:]")))
     );
-  }
-
-  private CodeStyle_clike() {
   }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_csharp.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_csharp.java
@@ -20,7 +20,8 @@ public class CodeStyle_csharp
 {
 
   @NotNull
-  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle) {
+  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle)
+  {
 
     final CodeStyle.Grammar classNameInsidePunctuation = grammar("inside",
       token("punctuation", pattern(compile("\\.")))

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_css.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_css.java
@@ -20,6 +20,10 @@ public abstract class CodeStyle_css
   // before a language is requested (fro example css)
   // it won't be initialized (so we won't modify markup to highlight css) before it was requested...
 
+  private CodeStyle_css()
+  {
+  }
+
   @NotNull
   public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle)
   {
@@ -147,9 +151,5 @@ public abstract class CodeStyle_css
     }
 
     return grammar;
-  }
-
-  private CodeStyle_css()
-  {
   }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_css_extras.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_css_extras.java
@@ -19,14 +19,17 @@ public class CodeStyle_css_extras
 {
 
   @Nullable
-  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle) {
+  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle)
+  {
 
     final CodeStyle.Grammar css = codeStyle.grammar("css");
 
-    if (css != null) {
+    if (css != null)
+    {
 
       final CodeStyle.Token selector = GrammarUtils.findToken(css, "selector");
-      if (selector != null) {
+      if (selector != null)
+      {
         final CodeStyle.Pattern pattern = pattern(
           compile("[^{}\\s][^{}]*(?=\\s*\\{)"),
           false,

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_go.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_go.java
@@ -1,7 +1,7 @@
 package com.zeoflow.stylar.codestyle.languages;
 
-import com.zeoflow.stylar.codestyle.GrammarUtils;
 import com.zeoflow.stylar.codestyle.CodeStyle;
+import com.zeoflow.stylar.codestyle.GrammarUtils;
 import com.zeoflow.stylar.codestyle.annotations.Extend;
 
 import org.jetbrains.annotations.NotNull;

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_java.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_java.java
@@ -1,9 +1,7 @@
 package com.zeoflow.stylar.codestyle.languages;
 
-import android.util.Log;
-
-import com.zeoflow.stylar.codestyle.GrammarUtils;
 import com.zeoflow.stylar.codestyle.CodeStyle;
+import com.zeoflow.stylar.codestyle.GrammarUtils;
 import com.zeoflow.stylar.codestyle.annotations.Extend;
 
 import org.jetbrains.annotations.NotNull;

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_javascript.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_javascript.java
@@ -24,7 +24,8 @@ public class CodeStyle_javascript
 {
 
   @NotNull
-  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle) {
+  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle)
+  {
 
     final CodeStyle.Grammar js = GrammarUtils.extend(GrammarUtils.require(codeStyle, "clike"), "javascript",
       token("keyword", pattern(compile("\\b(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\\b"))),
@@ -90,7 +91,8 @@ public class CodeStyle_javascript
     ));
 
     final CodeStyle.Grammar markup = codeStyle.grammar("markup");
-    if (markup != null) {
+    if (markup != null)
+    {
       GrammarUtils.insertBeforeToken(markup, "tag",
         token(
           "script", pattern(

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_markup.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_markup.java
@@ -16,8 +16,13 @@ import static java.util.regex.Pattern.compile;
 public abstract class CodeStyle_markup
 {
 
+  private CodeStyle_markup()
+  {
+  }
+
   @NotNull
-  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle) {
+  public static CodeStyle.Grammar create(@NotNull CodeStyle codeStyle)
+  {
     final CodeStyle.Token entity = token("entity", pattern(compile("&#?[\\da-z]{1,8};", Pattern.CASE_INSENSITIVE)));
     return grammar(
       "markup",
@@ -85,8 +90,5 @@ public abstract class CodeStyle_markup
       ),
       entity
     );
-  }
-
-  private CodeStyle_markup() {
   }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_swift.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/codestyle/languages/CodeStyle_swift.java
@@ -1,7 +1,7 @@
 package com.zeoflow.stylar.codestyle.languages;
 
-import com.zeoflow.stylar.codestyle.GrammarUtils;
 import com.zeoflow.stylar.codestyle.CodeStyle;
+import com.zeoflow.stylar.codestyle.GrammarUtils;
 import com.zeoflow.stylar.codestyle.annotations.Extend;
 
 import org.jetbrains.annotations.NotNull;

--- a/stylar/src/main/java/com/zeoflow/stylar/core/CorePlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/CorePlugin.java
@@ -10,11 +10,12 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.zeoflow.stylar.AbstractStylarPlugin;
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.SpannableBuilder;
 import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.StylarSpansFactory;
 import com.zeoflow.stylar.StylarVisitor;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpannableBuilder;
 import com.zeoflow.stylar.core.factory.BlockQuoteSpanFactory;
 import com.zeoflow.stylar.core.factory.CodeBlockSpanFactory;
 import com.zeoflow.stylar.core.factory.CodeSpanFactory;
@@ -56,8 +57,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.zeoflow.stylar.SpanFactory;
-
 /**
  * @see CoreProps
  * @since 3.0.0
@@ -65,35 +64,18 @@ import com.zeoflow.stylar.SpanFactory;
 public class CorePlugin extends AbstractStylarPlugin
 {
 
-    /**
-     * @see #addOnTextAddedListener(OnTextAddedListener)
-     * @since 4.0.0
-     */
-    public interface OnTextAddedListener {
+    // @since 4.0.0
+    private final List<OnTextAddedListener> onTextAddedListeners = new ArrayList<>(0);
+    // @since 4.5.0
+    private boolean hasExplicitMovementMethod;
 
-        /**
-         * Will be called when new text is added to resulting {@link SpannableBuilder}.
-         * Please note that only text represented by {@link Text} node will trigger this callback
-         * (text inside code and code-blocks won\'t trigger it).
-         * <p>
-         * Please note that if you wish to add spans you must use {@code start} parameter
-         * in order to place spans correctly ({@code start} represents the index at which {@code text}
-         * was added). So, to set a span for the whole length of the text added one should use:
-         * <p>
-         * {@code
-         * visitor.builder().setSpan(new MySpan(), start, start + text.length(), 0);
-         * }
-         *
-         * @param visitor {@link StylarVisitor}
-         * @param text    literal that had been added
-         * @param start   index in {@code visitor} as which text had been added
-         * @see #addOnTextAddedListener(OnTextAddedListener)
-         */
-        void onTextAdded(@NonNull StylarVisitor visitor, @NonNull String text, int start);
+    protected CorePlugin()
+    {
     }
 
     @NonNull
-    public static CorePlugin create() {
+    public static CorePlugin create()
+    {
         return new CorePlugin();
     }
 
@@ -102,25 +84,394 @@ public class CorePlugin extends AbstractStylarPlugin
      * @since 4.4.0
      */
     @NonNull
-    public static Set<Class<? extends Block>> enabledBlockTypes() {
+    public static Set<Class<? extends Block>> enabledBlockTypes()
+    {
         return new HashSet<>(Arrays.asList(
-                BlockQuote.class,
-                Heading.class,
-                FencedCodeBlock.class,
-                HtmlBlock.class,
-                ThematicBreak.class,
-                ListBlock.class,
-                IndentedCodeBlock.class
+            BlockQuote.class,
+            Heading.class,
+            FencedCodeBlock.class,
+            HtmlBlock.class,
+            ThematicBreak.class,
+            ListBlock.class,
+            IndentedCodeBlock.class
         ));
     }
 
+    private static void strongEmphasis(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(StrongEmphasis.class, new StylarVisitor.NodeVisitor<StrongEmphasis>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull StrongEmphasis strongEmphasis)
+            {
+                final int length = visitor.length();
+                visitor.visitChildren(strongEmphasis);
+                visitor.setSpansForNodeOptional(strongEmphasis, length);
+            }
+        });
+    }
+
+    private static void emphasis(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(Emphasis.class, new StylarVisitor.NodeVisitor<Emphasis>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Emphasis emphasis)
+            {
+                final int length = visitor.length();
+                visitor.visitChildren(emphasis);
+                visitor.setSpansForNodeOptional(emphasis, length);
+            }
+        });
+    }
+
+    private static void blockQuote(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(BlockQuote.class, new StylarVisitor.NodeVisitor<BlockQuote>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull BlockQuote blockQuote)
+            {
+
+                visitor.blockStart(blockQuote);
+
+                final int length = visitor.length();
+
+                visitor.visitChildren(blockQuote);
+                visitor.setSpansForNodeOptional(blockQuote, length);
+
+                visitor.blockEnd(blockQuote);
+            }
+        });
+    }
+
+    private static void code(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(Code.class, new StylarVisitor.NodeVisitor<Code>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Code code)
+            {
+
+                final int length = visitor.length();
+
+                // NB, in order to provide a _padding_ feeling code is wrapped inside two unbreakable spaces
+                // unfortunately we cannot use this for multiline code as we cannot control where a new line break will be inserted
+                visitor.builder()
+                    .append('\u00a0')
+                    .append(code.getLiteral())
+                    .append('\u00a0');
+
+                visitor.setSpansForNodeOptional(code, length);
+            }
+        });
+    }
+
+    private static void fencedCodeBlock(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(FencedCodeBlock.class, new StylarVisitor.NodeVisitor<FencedCodeBlock>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull FencedCodeBlock fencedCodeBlock)
+            {
+                visitCodeBlock(visitor, fencedCodeBlock.getInfo(), fencedCodeBlock.getLiteral(), fencedCodeBlock);
+            }
+        });
+    }
+
+    private static void indentedCodeBlock(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(IndentedCodeBlock.class, new StylarVisitor.NodeVisitor<IndentedCodeBlock>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull IndentedCodeBlock indentedCodeBlock)
+            {
+                visitCodeBlock(visitor, null, indentedCodeBlock.getLiteral(), indentedCodeBlock);
+            }
+        });
+    }
+
     // @since 4.0.0
-    private final List<OnTextAddedListener> onTextAddedListeners = new ArrayList<>(0);
+    // his method is moved from ImagesPlugin. Alternative implementations must set SpanFactory
+    // for Image node in order for this visitor to function
+    private static void image(StylarVisitor.Builder builder)
+    {
+        builder.on(Image.class, new StylarVisitor.NodeVisitor<Image>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Image image)
+            {
 
-    // @since 4.5.0
-    private boolean hasExplicitMovementMethod;
+                // if there is no image spanFactory, ignore
+                final SpanFactory spanFactory = visitor.configuration().spansFactory().get(Image.class);
+                if (spanFactory == null)
+                {
+                    visitor.visitChildren(image);
+                    return;
+                }
 
-    protected CorePlugin() {
+                final int length = visitor.length();
+
+                visitor.visitChildren(image);
+
+                // we must check if anything _was_ added, as we need at least one char to render
+                if (length == visitor.length())
+                {
+                    visitor.builder().append('\uFFFC');
+                }
+
+                final StylarConfiguration configuration = visitor.configuration();
+
+                final Node parent = image.getParent();
+                final boolean link = parent instanceof Link;
+
+                final String destination = configuration
+                    .imageDestinationProcessor()
+                    .process(image.getDestination());
+
+                final RenderProps props = visitor.renderProps();
+
+                // apply image properties
+                // Please note that we explicitly set IMAGE_SIZE to null as we do not clear
+                // properties after we applied span (we could though)
+                ImageProps.DESTINATION.set(props, destination);
+                ImageProps.REPLACEMENT_TEXT_IS_LINK.set(props, link);
+                ImageProps.IMAGE_SIZE.set(props, null);
+
+                visitor.setSpans(length, spanFactory.getSpans(configuration, props));
+            }
+        });
+    }
+
+    @VisibleForTesting
+    static void visitCodeBlock(
+        @NonNull StylarVisitor visitor,
+        @Nullable String info,
+        @NonNull String code,
+        @NonNull Node node)
+    {
+
+        visitor.blockStart(node);
+
+        final int length = visitor.length();
+
+        visitor.builder()
+            .append('\u00a0').append('\n')
+            .append(visitor.configuration().syntaxHighlight().highlight(info, code));
+
+        visitor.ensureNewLine();
+
+        visitor.builder().append('\u00a0');
+
+        // @since 4.1.1
+        CoreProps.CODE_BLOCK_INFO.set(visitor.renderProps(), info);
+
+        visitor.setSpansForNodeOptional(node, length);
+
+        visitor.blockEnd(node);
+    }
+
+    private static void bulletList(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(BulletList.class, new SimpleBlockNodeVisitor());
+    }
+
+    private static void orderedList(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(OrderedList.class, new SimpleBlockNodeVisitor());
+    }
+
+    private static void listItem(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(ListItem.class, new StylarVisitor.NodeVisitor<ListItem>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull ListItem listItem)
+            {
+
+                final int length = visitor.length();
+
+                // it's important to visit children before applying render props (
+                // we can have nested children, who are list items also, thus they will
+                // override out props (if we set them before visiting children)
+                visitor.visitChildren(listItem);
+
+                final Node parent = listItem.getParent();
+                if (parent instanceof OrderedList)
+                {
+
+                    final int start = ((OrderedList) parent).getStartNumber();
+
+                    CoreProps.LIST_ITEM_TYPE.set(visitor.renderProps(), CoreProps.ListItemType.ORDERED);
+                    CoreProps.ORDERED_LIST_ITEM_NUMBER.set(visitor.renderProps(), start);
+
+                    // after we have visited the children increment start number
+                    final OrderedList orderedList = (OrderedList) parent;
+                    orderedList.setStartNumber(orderedList.getStartNumber() + 1);
+
+                } else
+                {
+                    CoreProps.LIST_ITEM_TYPE.set(visitor.renderProps(), CoreProps.ListItemType.BULLET);
+                    CoreProps.BULLET_LIST_ITEM_LEVEL.set(visitor.renderProps(), listLevel(listItem));
+                }
+
+                visitor.setSpansForNodeOptional(listItem, length);
+
+                if (visitor.hasNext(listItem))
+                {
+                    visitor.ensureNewLine();
+                }
+            }
+        });
+    }
+
+    private static int listLevel(@NonNull Node node)
+    {
+        int level = 0;
+        Node parent = node.getParent();
+        while (parent != null)
+        {
+            if (parent instanceof ListItem)
+            {
+                level += 1;
+            }
+            parent = parent.getParent();
+        }
+        return level;
+    }
+
+    private static void thematicBreak(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(ThematicBreak.class, new StylarVisitor.NodeVisitor<ThematicBreak>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull ThematicBreak thematicBreak)
+            {
+
+                visitor.blockStart(thematicBreak);
+
+                final int length = visitor.length();
+
+                // without space it won't render
+                visitor.builder().append('\u00a0');
+
+                visitor.setSpansForNodeOptional(thematicBreak, length);
+
+                visitor.blockEnd(thematicBreak);
+            }
+        });
+    }
+
+    private static void heading(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(Heading.class, new StylarVisitor.NodeVisitor<Heading>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Heading heading)
+            {
+
+                visitor.blockStart(heading);
+
+                final int length = visitor.length();
+                visitor.visitChildren(heading);
+
+                CoreProps.HEADING_LEVEL.set(visitor.renderProps(), heading.getLevel());
+
+                visitor.setSpansForNodeOptional(heading, length);
+
+                visitor.blockEnd(heading);
+            }
+        });
+    }
+
+    private static void softLineBreak(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(SoftLineBreak.class, new StylarVisitor.NodeVisitor<SoftLineBreak>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull SoftLineBreak softLineBreak)
+            {
+                visitor.builder().append(' ');
+            }
+        });
+    }
+
+    private static void hardLineBreak(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(HardLineBreak.class, new StylarVisitor.NodeVisitor<HardLineBreak>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull HardLineBreak hardLineBreak)
+            {
+                visitor.ensureNewLine();
+            }
+        });
+    }
+
+    private static void paragraph(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(Paragraph.class, new StylarVisitor.NodeVisitor<Paragraph>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Paragraph paragraph)
+            {
+
+                final boolean inTightList = isInTightList(paragraph);
+
+                if (!inTightList)
+                {
+                    visitor.blockStart(paragraph);
+                }
+
+                final int length = visitor.length();
+                visitor.visitChildren(paragraph);
+
+                CoreProps.PARAGRAPH_IS_IN_TIGHT_LIST.set(visitor.renderProps(), inTightList);
+
+                // @since 1.1.1 apply paragraph span
+                visitor.setSpansForNodeOptional(paragraph, length);
+
+                if (!inTightList)
+                {
+                    visitor.blockEnd(paragraph);
+                }
+            }
+        });
+    }
+
+    private static boolean isInTightList(@NonNull Paragraph paragraph)
+    {
+        final Node parent = paragraph.getParent();
+        if (parent != null)
+        {
+            final Node gramps = parent.getParent();
+            if (gramps instanceof ListBlock)
+            {
+                ListBlock list = (ListBlock) gramps;
+                return list.isTight();
+            }
+        }
+        return false;
+    }
+
+    private static void link(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(Link.class, new StylarVisitor.NodeVisitor<Link>()
+        {
+            @Override
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Link link)
+            {
+
+                final int length = visitor.length();
+                visitor.visitChildren(link);
+
+                final String destination = link.getDestination();
+
+                CoreProps.LINK_DESTINATION.set(visitor.renderProps(), destination);
+
+                visitor.setSpansForNodeOptional(link, length);
+            }
+        });
     }
 
     /**
@@ -128,7 +479,8 @@ public class CorePlugin extends AbstractStylarPlugin
      */
     @SuppressWarnings("UnusedReturnValue")
     @NonNull
-    public CorePlugin hasExplicitMovementMethod(boolean hasExplicitMovementMethod) {
+    public CorePlugin hasExplicitMovementMethod(boolean hasExplicitMovementMethod)
+    {
         this.hasExplicitMovementMethod = hasExplicitMovementMethod;
         return this;
     }
@@ -141,13 +493,15 @@ public class CorePlugin extends AbstractStylarPlugin
      */
     @SuppressWarnings("UnusedReturnValue")
     @NonNull
-    public CorePlugin addOnTextAddedListener(@NonNull OnTextAddedListener onTextAddedListener) {
+    public CorePlugin addOnTextAddedListener(@NonNull OnTextAddedListener onTextAddedListener)
+    {
         onTextAddedListeners.add(onTextAddedListener);
         return this;
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
         text(builder);
         strongEmphasis(builder);
         emphasis(builder);
@@ -168,61 +522,71 @@ public class CorePlugin extends AbstractStylarPlugin
     }
 
     @Override
-    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder) {
+    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder)
+    {
 
         // reuse this one for both code-blocks (indent & fenced)
         final CodeBlockSpanFactory codeBlockSpanFactory = new CodeBlockSpanFactory();
 
         builder
-                .setFactory(StrongEmphasis.class, new StrongEmphasisSpanFactory())
-                .setFactory(Emphasis.class, new EmphasisSpanFactory())
-                .setFactory(BlockQuote.class, new BlockQuoteSpanFactory())
-                .setFactory(Code.class, new CodeSpanFactory())
-                .setFactory(FencedCodeBlock.class, codeBlockSpanFactory)
-                .setFactory(IndentedCodeBlock.class, codeBlockSpanFactory)
-                .setFactory(ListItem.class, new ListItemSpanFactory())
-                .setFactory(Heading.class, new HeadingSpanFactory())
-                .setFactory(Link.class, new LinkSpanFactory())
-                .setFactory(ThematicBreak.class, new ThematicBreakSpanFactory());
+            .setFactory(StrongEmphasis.class, new StrongEmphasisSpanFactory())
+            .setFactory(Emphasis.class, new EmphasisSpanFactory())
+            .setFactory(BlockQuote.class, new BlockQuoteSpanFactory())
+            .setFactory(Code.class, new CodeSpanFactory())
+            .setFactory(FencedCodeBlock.class, codeBlockSpanFactory)
+            .setFactory(IndentedCodeBlock.class, codeBlockSpanFactory)
+            .setFactory(ListItem.class, new ListItemSpanFactory())
+            .setFactory(Heading.class, new HeadingSpanFactory())
+            .setFactory(Link.class, new LinkSpanFactory())
+            .setFactory(ThematicBreak.class, new ThematicBreakSpanFactory());
     }
 
     @Override
-    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown) {
+    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown)
+    {
         OrderedListItemSpan.measure(textView, markdown);
 
         // @since 4.4.0
         // we do not break API compatibility, instead we introduce the `instance of` check
-        if (markdown instanceof Spannable) {
+        if (markdown instanceof Spannable)
+        {
             final Spannable spannable = (Spannable) markdown;
             TextViewSpan.applyTo(spannable, textView);
         }
     }
 
     @Override
-    public void afterSetText(@NonNull TextView textView) {
+    public void afterSetText(@NonNull TextView textView)
+    {
         // let's ensure that there is a movement method applied
         // we do it `afterSetText` so any user-defined movement method won't be
         // replaced (it should be done in `beforeSetText` or manually on a TextView)
         // @since 4.5.0 we additionally check if we should apply _implicit_ movement method
-        if (!hasExplicitMovementMethod && textView.getMovementMethod() == null) {
+        if (!hasExplicitMovementMethod && textView.getMovementMethod() == null)
+        {
             textView.setMovementMethod(LinkMovementMethod.getInstance());
         }
     }
 
-    private void text(@NonNull StylarVisitor.Builder builder) {
-        builder.on(Text.class, new StylarVisitor.NodeVisitor<Text>() {
+    private void text(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(Text.class, new StylarVisitor.NodeVisitor<Text>()
+        {
             @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Text text) {
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Text text)
+            {
 
                 final String literal = text.getLiteral();
 
                 visitor.builder().append(literal);
 
                 // @since 4.0.0
-                if (!onTextAddedListeners.isEmpty()) {
+                if (!onTextAddedListeners.isEmpty())
+                {
                     // calculate the start position
                     final int length = visitor.length() - literal.length();
-                    for (OnTextAddedListener onTextAddedListener : onTextAddedListeners) {
+                    for (OnTextAddedListener onTextAddedListener : onTextAddedListeners)
+                    {
                         onTextAddedListener.onTextAdded(visitor, literal, length);
                     }
                 }
@@ -230,322 +594,31 @@ public class CorePlugin extends AbstractStylarPlugin
         });
     }
 
-    private static void strongEmphasis(@NonNull StylarVisitor.Builder builder) {
-        builder.on(StrongEmphasis.class, new StylarVisitor.NodeVisitor<StrongEmphasis>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull StrongEmphasis strongEmphasis) {
-                final int length = visitor.length();
-                visitor.visitChildren(strongEmphasis);
-                visitor.setSpansForNodeOptional(strongEmphasis, length);
-            }
-        });
-    }
-
-    private static void emphasis(@NonNull StylarVisitor.Builder builder) {
-        builder.on(Emphasis.class, new StylarVisitor.NodeVisitor<Emphasis>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Emphasis emphasis) {
-                final int length = visitor.length();
-                visitor.visitChildren(emphasis);
-                visitor.setSpansForNodeOptional(emphasis, length);
-            }
-        });
-    }
-
-    private static void blockQuote(@NonNull StylarVisitor.Builder builder) {
-        builder.on(BlockQuote.class, new StylarVisitor.NodeVisitor<BlockQuote>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull BlockQuote blockQuote) {
-
-                visitor.blockStart(blockQuote);
-
-                final int length = visitor.length();
-
-                visitor.visitChildren(blockQuote);
-                visitor.setSpansForNodeOptional(blockQuote, length);
-
-                visitor.blockEnd(blockQuote);
-            }
-        });
-    }
-
-    private static void code(@NonNull StylarVisitor.Builder builder) {
-        builder.on(Code.class, new StylarVisitor.NodeVisitor<Code>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Code code) {
-
-                final int length = visitor.length();
-
-                // NB, in order to provide a _padding_ feeling code is wrapped inside two unbreakable spaces
-                // unfortunately we cannot use this for multiline code as we cannot control where a new line break will be inserted
-                visitor.builder()
-                        .append('\u00a0')
-                        .append(code.getLiteral())
-                        .append('\u00a0');
-
-                visitor.setSpansForNodeOptional(code, length);
-            }
-        });
-    }
-
-    private static void fencedCodeBlock(@NonNull StylarVisitor.Builder builder) {
-        builder.on(FencedCodeBlock.class, new StylarVisitor.NodeVisitor<FencedCodeBlock>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull FencedCodeBlock fencedCodeBlock) {
-                visitCodeBlock(visitor, fencedCodeBlock.getInfo(), fencedCodeBlock.getLiteral(), fencedCodeBlock);
-            }
-        });
-    }
-
-    private static void indentedCodeBlock(@NonNull StylarVisitor.Builder builder) {
-        builder.on(IndentedCodeBlock.class, new StylarVisitor.NodeVisitor<IndentedCodeBlock>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull IndentedCodeBlock indentedCodeBlock) {
-                visitCodeBlock(visitor, null, indentedCodeBlock.getLiteral(), indentedCodeBlock);
-            }
-        });
-    }
-
-    // @since 4.0.0
-    // his method is moved from ImagesPlugin. Alternative implementations must set SpanFactory
-    // for Image node in order for this visitor to function
-    private static void image(StylarVisitor.Builder builder) {
-        builder.on(Image.class, new StylarVisitor.NodeVisitor<Image>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Image image) {
-
-                // if there is no image spanFactory, ignore
-                final SpanFactory spanFactory = visitor.configuration().spansFactory().get(Image.class);
-                if (spanFactory == null) {
-                    visitor.visitChildren(image);
-                    return;
-                }
-
-                final int length = visitor.length();
-
-                visitor.visitChildren(image);
-
-                // we must check if anything _was_ added, as we need at least one char to render
-                if (length == visitor.length()) {
-                    visitor.builder().append('\uFFFC');
-                }
-
-                final StylarConfiguration configuration = visitor.configuration();
-
-                final Node parent = image.getParent();
-                final boolean link = parent instanceof Link;
-
-                final String destination = configuration
-                        .imageDestinationProcessor()
-                        .process(image.getDestination());
-
-                final RenderProps props = visitor.renderProps();
-
-                // apply image properties
-                // Please note that we explicitly set IMAGE_SIZE to null as we do not clear
-                // properties after we applied span (we could though)
-                ImageProps.DESTINATION.set(props, destination);
-                ImageProps.REPLACEMENT_TEXT_IS_LINK.set(props, link);
-                ImageProps.IMAGE_SIZE.set(props, null);
-
-                visitor.setSpans(length, spanFactory.getSpans(configuration, props));
-            }
-        });
-    }
-
-    @VisibleForTesting
-    static void visitCodeBlock(
-            @NonNull StylarVisitor visitor,
-            @Nullable String info,
-            @NonNull String code,
-            @NonNull Node node) {
-
-        visitor.blockStart(node);
-
-        final int length = visitor.length();
-
-        visitor.builder()
-                .append('\u00a0').append('\n')
-                .append(visitor.configuration().syntaxHighlight().highlight(info, code));
-
-        visitor.ensureNewLine();
-
-        visitor.builder().append('\u00a0');
-
-        // @since 4.1.1
-        CoreProps.CODE_BLOCK_INFO.set(visitor.renderProps(), info);
-
-        visitor.setSpansForNodeOptional(node, length);
-
-        visitor.blockEnd(node);
-    }
-
-    private static void bulletList(@NonNull StylarVisitor.Builder builder) {
-        builder.on(BulletList.class, new SimpleBlockNodeVisitor());
-    }
-
-    private static void orderedList(@NonNull StylarVisitor.Builder builder) {
-        builder.on(OrderedList.class, new SimpleBlockNodeVisitor());
-    }
-
-    private static void listItem(@NonNull StylarVisitor.Builder builder) {
-        builder.on(ListItem.class, new StylarVisitor.NodeVisitor<ListItem>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull ListItem listItem) {
-
-                final int length = visitor.length();
-
-                // it's important to visit children before applying render props (
-                // we can have nested children, who are list items also, thus they will
-                // override out props (if we set them before visiting children)
-                visitor.visitChildren(listItem);
-
-                final Node parent = listItem.getParent();
-                if (parent instanceof OrderedList) {
-
-                    final int start = ((OrderedList) parent).getStartNumber();
-
-                    CoreProps.LIST_ITEM_TYPE.set(visitor.renderProps(), CoreProps.ListItemType.ORDERED);
-                    CoreProps.ORDERED_LIST_ITEM_NUMBER.set(visitor.renderProps(), start);
-
-                    // after we have visited the children increment start number
-                    final OrderedList orderedList = (OrderedList) parent;
-                    orderedList.setStartNumber(orderedList.getStartNumber() + 1);
-
-                } else {
-                    CoreProps.LIST_ITEM_TYPE.set(visitor.renderProps(), CoreProps.ListItemType.BULLET);
-                    CoreProps.BULLET_LIST_ITEM_LEVEL.set(visitor.renderProps(), listLevel(listItem));
-                }
-
-                visitor.setSpansForNodeOptional(listItem, length);
-
-                if (visitor.hasNext(listItem)) {
-                    visitor.ensureNewLine();
-                }
-            }
-        });
-    }
-
-    private static int listLevel(@NonNull Node node) {
-        int level = 0;
-        Node parent = node.getParent();
-        while (parent != null) {
-            if (parent instanceof ListItem) {
-                level += 1;
-            }
-            parent = parent.getParent();
-        }
-        return level;
-    }
-
-    private static void thematicBreak(@NonNull StylarVisitor.Builder builder) {
-        builder.on(ThematicBreak.class, new StylarVisitor.NodeVisitor<ThematicBreak>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull ThematicBreak thematicBreak) {
-
-                visitor.blockStart(thematicBreak);
-
-                final int length = visitor.length();
-
-                // without space it won't render
-                visitor.builder().append('\u00a0');
-
-                visitor.setSpansForNodeOptional(thematicBreak, length);
-
-                visitor.blockEnd(thematicBreak);
-            }
-        });
-    }
-
-    private static void heading(@NonNull StylarVisitor.Builder builder) {
-        builder.on(Heading.class, new StylarVisitor.NodeVisitor<Heading>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Heading heading) {
-
-                visitor.blockStart(heading);
-
-                final int length = visitor.length();
-                visitor.visitChildren(heading);
-
-                CoreProps.HEADING_LEVEL.set(visitor.renderProps(), heading.getLevel());
-
-                visitor.setSpansForNodeOptional(heading, length);
-
-                visitor.blockEnd(heading);
-            }
-        });
-    }
-
-    private static void softLineBreak(@NonNull StylarVisitor.Builder builder) {
-        builder.on(SoftLineBreak.class, new StylarVisitor.NodeVisitor<SoftLineBreak>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull SoftLineBreak softLineBreak) {
-                visitor.builder().append(' ');
-            }
-        });
-    }
-
-    private static void hardLineBreak(@NonNull StylarVisitor.Builder builder) {
-        builder.on(HardLineBreak.class, new StylarVisitor.NodeVisitor<HardLineBreak>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull HardLineBreak hardLineBreak) {
-                visitor.ensureNewLine();
-            }
-        });
-    }
-
-    private static void paragraph(@NonNull StylarVisitor.Builder builder) {
-        builder.on(Paragraph.class, new StylarVisitor.NodeVisitor<Paragraph>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Paragraph paragraph) {
-
-                final boolean inTightList = isInTightList(paragraph);
-
-                if (!inTightList) {
-                    visitor.blockStart(paragraph);
-                }
-
-                final int length = visitor.length();
-                visitor.visitChildren(paragraph);
-
-                CoreProps.PARAGRAPH_IS_IN_TIGHT_LIST.set(visitor.renderProps(), inTightList);
-
-                // @since 1.1.1 apply paragraph span
-                visitor.setSpansForNodeOptional(paragraph, length);
-
-                if (!inTightList) {
-                    visitor.blockEnd(paragraph);
-                }
-            }
-        });
-    }
-
-    private static boolean isInTightList(@NonNull Paragraph paragraph) {
-        final Node parent = paragraph.getParent();
-        if (parent != null) {
-            final Node gramps = parent.getParent();
-            if (gramps instanceof ListBlock) {
-                ListBlock list = (ListBlock) gramps;
-                return list.isTight();
-            }
-        }
-        return false;
-    }
-
-    private static void link(@NonNull StylarVisitor.Builder builder) {
-        builder.on(Link.class, new StylarVisitor.NodeVisitor<Link>() {
-            @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Link link) {
-
-                final int length = visitor.length();
-                visitor.visitChildren(link);
-
-                final String destination = link.getDestination();
-
-                CoreProps.LINK_DESTINATION.set(visitor.renderProps(), destination);
-
-                visitor.setSpansForNodeOptional(link, length);
-            }
-        });
+    /**
+     * @see #addOnTextAddedListener(OnTextAddedListener)
+     * @since 4.0.0
+     */
+    public interface OnTextAddedListener
+    {
+
+        /**
+         * Will be called when new text is added to resulting {@link SpannableBuilder}.
+         * Please note that only text represented by {@link Text} node will trigger this callback
+         * (text inside code and code-blocks won\'t trigger it).
+         * <p>
+         * Please note that if you wish to add spans you must use {@code start} parameter
+         * in order to place spans correctly ({@code start} represents the index at which {@code text}
+         * was added). So, to set a span for the whole length of the text added one should use:
+         * <p>
+         * {@code
+         * visitor.builder().setSpan(new MySpan(), start, start + text.length(), 0);
+         * }
+         *
+         * @param visitor {@link StylarVisitor}
+         * @param text    literal that had been added
+         * @param start   index in {@code visitor} as which text had been added
+         * @see #addOnTextAddedListener(OnTextAddedListener)
+         */
+        void onTextAdded(@NonNull StylarVisitor visitor, @NonNull String text, int start);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/CoreProps.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/CoreProps.java
@@ -5,7 +5,8 @@ import com.zeoflow.stylar.Prop;
 /**
  * @since 3.0.0
  */
-public abstract class CoreProps {
+public abstract class CoreProps
+{
 
     public static final Prop<ListItemType> LIST_ITEM_TYPE = Prop.of("list-item-type");
 
@@ -24,11 +25,13 @@ public abstract class CoreProps {
      */
     public static final Prop<String> CODE_BLOCK_INFO = Prop.of("code-block-info");
 
-    public enum ListItemType {
-        BULLET,
-        ORDERED
+    private CoreProps()
+    {
     }
 
-    private CoreProps() {
+    public enum ListItemType
+    {
+        BULLET,
+        ORDERED
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/SimpleBlockNodeVisitor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/SimpleBlockNodeVisitor.java
@@ -13,9 +13,11 @@ import org.commonmark.node.Node;
  *
  * @since 3.0.0
  */
-public class SimpleBlockNodeVisitor implements StylarVisitor.NodeVisitor<Node> {
+public class SimpleBlockNodeVisitor implements StylarVisitor.NodeVisitor<Node>
+{
     @Override
-    public void visit(@NonNull StylarVisitor visitor, @NonNull Node node) {
+    public void visit(@NonNull StylarVisitor visitor, @NonNull Node node)
+    {
 
         visitor.blockStart(node);
 

--- a/stylar/src/main/java/com/zeoflow/stylar/core/StylarTheme.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/StylarTheme.java
@@ -38,157 +38,68 @@ import java.util.Locale;
 public class StylarTheme
 {
 
-    /**
-     * Factory method to obtain an instance of {@link StylarTheme} with all values as defaults
-     *
-     * @param context Context in order to resolve defaults
-     * @return {@link StylarTheme} instance
-     * @see #builderWithDefaults(Context)
-     * @since 1.0.0
-     */
-    @NonNull
-    public static StylarTheme create(@NonNull Context context) {
-        return builderWithDefaults(context).build();
-    }
-
-    /**
-     * Create an <strong>empty</strong> instance of {@link Builder} with no default values applied
-     * <p>
-     * Since version 3.0.0 manual construction of {@link StylarTheme} is not required, instead a
-     * {@link StylarPlugin#configureTheme(Builder)} should be used in order
-     * to change certain theme properties
-     *
-     * @since 3.0.0
-     */
-    @SuppressWarnings("unused")
-    @NonNull
-    public static Builder emptyBuilder() {
-        return new Builder();
-    }
-
-    /**
-     * Factory method to create a {@link Builder} instance and initialize it with values
-     * from supplied {@link StylarTheme}
-     *
-     * @param copyFrom {@link StylarTheme} to copy values from
-     * @return {@link Builder} instance
-     * @see #builderWithDefaults(Context)
-     * @since 1.0.0
-     */
-    @NonNull
-    public static Builder builder(@NonNull StylarTheme copyFrom) {
-        return new Builder(copyFrom);
-    }
-
-    /**
-     * Factory method to obtain a {@link Builder} instance initialized with default values taken
-     * from current application theme.
-     *
-     * @param context Context to obtain default styling values (colors, etc)
-     * @return {@link Builder} instance
-     * @since 1.0.0
-     */
-    @NonNull
-    public static Builder builderWithDefaults(@NonNull Context context) {
-
-        final Dip dip = Dip.create(context);
-        return new Builder()
-                .codeBlockMargin(dip.toPx(8))
-                .blockMargin(dip.toPx(24))
-                .blockQuoteWidth(dip.toPx(4))
-                .bulletListItemStrokeWidth(dip.toPx(1))
-                .headingBreakHeight(dip.toPx(1))
-                .thematicBreakHeight(dip.toPx(4));
-    }
-
     protected static final int BLOCK_QUOTE_DEF_COLOR_ALPHA = 25;
-
     protected static final int CODE_DEF_BACKGROUND_COLOR_ALPHA = 25;
     protected static final float CODE_DEF_TEXT_SIZE_RATIO = .87F;
-
     protected static final int HEADING_DEF_BREAK_COLOR_ALPHA = 75;
-
+    protected static final int THEMATIC_BREAK_DEF_ALPHA = 25;
     // taken from html spec (most browsers render headings like that)
     // is not exposed via protected modifier in order to disallow modification
     private static final float[] HEADING_SIZES = {
-            2.F, 1.5F, 1.17F, 1.F, .83F, .67F,
+        2.F, 1.5F, 1.17F, 1.F, .83F, .67F,
     };
-
-    protected static final int THEMATIC_BREAK_DEF_ALPHA = 25;
-
     protected final int linkColor;
-
     // specifies whether we underline links, by default is true
     // @since 4.5.0
     protected final boolean isLinkedUnderlined;
-
     // used in quote, lists
     protected final int blockMargin;
-
     // by default it's 1/4th of `blockMargin`
     protected final int blockQuoteWidth;
-
     // by default it's text color with `BLOCK_QUOTE_DEF_COLOR_ALPHA` applied alpha
     protected final int blockQuoteColor;
-
     // by default uses text color (applied for un-ordered lists & ordered (bullets & numbers)
     protected final int listItemColor;
-
     // by default the stroke color of a paint object
     protected final int bulletListItemStrokeWidth;
-
     // width of bullet, by default min(blockMargin, height) / 2
     protected final int bulletWidth;
-
     // by default - main text color
     protected final int codeTextColor;
-
     // by default - codeTextColor
     protected final int codeBlockTextColor;
-
     // by default 0.1 alpha of textColor/codeTextColor
     protected final int codeBackgroundColor;
-
     // by default codeBackgroundColor
     protected final int codeBlockBackgroundColor;
-
     // by default `width` of a space char... it's fun and games, but span doesn't have access to paint in `getLeadingMargin`
     // so, we need to set this value explicitly (think of an utility method, that takes TextView/TextPaint and measures space char)
     protected final int codeBlockMargin;
-
     // by default Typeface.MONOSPACE
     protected final Typeface codeTypeface;
-
     protected final Typeface codeBlockTypeface;
-
     // by default a bit (how much?!) smaller than normal text
     // applied ONLY if default typeface was used, otherwise, not applied
     protected final int codeTextSize;
-
     protected final int codeBlockTextSize;
-
     // by default paint.getStrokeWidth
     protected final int headingBreakHeight;
-
     // by default, text color with `HEADING_DEF_BREAK_COLOR_ALPHA` applied alpha
     protected final int headingBreakColor;
-
     // by default, whatever typeface is set on the TextView
     // @since 1.1.0
     protected final Typeface headingTypeface;
-
     // by default, we use standard multipliers from the HTML spec (see HEADING_SIZES for values).
     // this library supports 6 heading sizes, so make sure the array you pass here has 6 elements.
     // @since 1.1.0
     protected final float[] headingTextSizeMultipliers;
-
     // by default textColor with `THEMATIC_BREAK_DEF_ALPHA` applied alpha
     protected final int thematicBreakColor;
-
     // by default paint.strokeWidth
     protected final int thematicBreakHeight;
 
-    protected StylarTheme(@NonNull Builder builder) {
+    protected StylarTheme(@NonNull Builder builder)
+    {
         this.linkColor = builder.linkColor;
         this.isLinkedUnderlined = builder.isLinkUnderlined;
         this.blockMargin = builder.blockMargin;
@@ -215,81 +126,169 @@ public class StylarTheme
     }
 
     /**
+     * Factory method to obtain an instance of {@link StylarTheme} with all values as defaults
+     *
+     * @param context Context in order to resolve defaults
+     * @return {@link StylarTheme} instance
+     * @see #builderWithDefaults(Context)
+     * @since 1.0.0
+     */
+    @NonNull
+    public static StylarTheme create(@NonNull Context context)
+    {
+        return builderWithDefaults(context).build();
+    }
+
+    /**
+     * Create an <strong>empty</strong> instance of {@link Builder} with no default values applied
+     * <p>
+     * Since version 3.0.0 manual construction of {@link StylarTheme} is not required, instead a
+     * {@link StylarPlugin#configureTheme(Builder)} should be used in order
+     * to change certain theme properties
+     *
+     * @since 3.0.0
+     */
+    @SuppressWarnings("unused")
+    @NonNull
+    public static Builder emptyBuilder()
+    {
+        return new Builder();
+    }
+
+    /**
+     * Factory method to create a {@link Builder} instance and initialize it with values
+     * from supplied {@link StylarTheme}
+     *
+     * @param copyFrom {@link StylarTheme} to copy values from
+     * @return {@link Builder} instance
+     * @see #builderWithDefaults(Context)
+     * @since 1.0.0
+     */
+    @NonNull
+    public static Builder builder(@NonNull StylarTheme copyFrom)
+    {
+        return new Builder(copyFrom);
+    }
+
+    /**
+     * Factory method to obtain a {@link Builder} instance initialized with default values taken
+     * from current application theme.
+     *
+     * @param context Context to obtain default styling values (colors, etc)
+     * @return {@link Builder} instance
+     * @since 1.0.0
+     */
+    @NonNull
+    public static Builder builderWithDefaults(@NonNull Context context)
+    {
+
+        final Dip dip = Dip.create(context);
+        return new Builder()
+            .codeBlockMargin(dip.toPx(8))
+            .blockMargin(dip.toPx(24))
+            .blockQuoteWidth(dip.toPx(4))
+            .bulletListItemStrokeWidth(dip.toPx(1))
+            .headingBreakHeight(dip.toPx(1))
+            .thematicBreakHeight(dip.toPx(4));
+    }
+
+    /**
      * @since 1.0.5
      */
-    public void applyLinkStyle(@NonNull TextPaint paint) {
+    public void applyLinkStyle(@NonNull TextPaint paint)
+    {
         paint.setUnderlineText(isLinkedUnderlined);
-        if (linkColor != 0) {
+        if (linkColor != 0)
+        {
             paint.setColor(linkColor);
-        } else {
+        } else
+        {
             // if linkColor is not specified during configuration -> use default one
             paint.setColor(paint.linkColor);
         }
     }
 
-    public void applyLinkStyle(@NonNull Paint paint) {
+    public void applyLinkStyle(@NonNull Paint paint)
+    {
         paint.setUnderlineText(isLinkedUnderlined);
-        if (linkColor != 0) {
+        if (linkColor != 0)
+        {
             // by default we will be using text color
             paint.setColor(linkColor);
-        } else {
+        } else
+        {
             // @since 1.0.5, if link color is specified during configuration, _try_ to use the
             // default one (if provided paint is an instance of TextPaint)
-            if (paint instanceof TextPaint) {
+            if (paint instanceof TextPaint)
+            {
                 paint.setColor(((TextPaint) paint).linkColor);
             }
         }
     }
 
-    public void applyBlockQuoteStyle(@NonNull Paint paint) {
+    public void applyBlockQuoteStyle(@NonNull Paint paint)
+    {
         final int color;
-        if (blockQuoteColor == 0) {
+        if (blockQuoteColor == 0)
+        {
             color = ColorUtils.applyAlpha(paint.getColor(), BLOCK_QUOTE_DEF_COLOR_ALPHA);
-        } else {
+        } else
+        {
             color = blockQuoteColor;
         }
         paint.setStyle(Paint.Style.FILL);
         paint.setColor(color);
     }
 
-    public int getBlockMargin() {
+    public int getBlockMargin()
+    {
         return blockMargin;
     }
 
-    public int getBlockQuoteWidth() {
+    public int getBlockQuoteWidth()
+    {
         final int out;
-        if (blockQuoteWidth == 0) {
+        if (blockQuoteWidth == 0)
+        {
             out = (int) (blockMargin * .25F + .5F);
-        } else {
+        } else
+        {
             out = blockQuoteWidth;
         }
         return out;
     }
 
-    public void applyListItemStyle(@NonNull Paint paint) {
+    public void applyListItemStyle(@NonNull Paint paint)
+    {
 
         final int color;
-        if (listItemColor != 0) {
+        if (listItemColor != 0)
+        {
             color = listItemColor;
-        } else {
+        } else
+        {
             color = paint.getColor();
         }
         paint.setColor(color);
 
-        if (bulletListItemStrokeWidth != 0) {
+        if (bulletListItemStrokeWidth != 0)
+        {
             paint.setStrokeWidth(bulletListItemStrokeWidth);
         }
     }
 
-    public int getBulletWidth(int height) {
+    public int getBulletWidth(int height)
+    {
 
         final int min = Math.min(blockMargin, height) / 2;
 
         final int width;
         if (bulletWidth == 0
-                || bulletWidth > min) {
+            || bulletWidth > min)
+        {
             width = min;
-        } else {
+        } else
+        {
             width = bulletWidth;
         }
 
@@ -299,27 +298,34 @@ public class StylarTheme
     /**
      * @since 3.0.0
      */
-    public void applyCodeTextStyle(@NonNull Paint paint) {
+    public void applyCodeTextStyle(@NonNull Paint paint)
+    {
 
-        if (codeTextColor != 0) {
+        if (codeTextColor != 0)
+        {
             paint.setColor(codeTextColor);
         }
 
-        if (codeTypeface != null) {
+        if (codeTypeface != null)
+        {
 
             paint.setTypeface(codeTypeface);
 
-            if (codeTextSize > 0) {
+            if (codeTextSize > 0)
+            {
                 paint.setTextSize(codeTextSize);
             }
 
-        } else {
+        } else
+        {
 
             paint.setTypeface(Typeface.MONOSPACE);
 
-            if (codeTextSize > 0) {
+            if (codeTextSize > 0)
+            {
                 paint.setTextSize(codeTextSize);
-            } else {
+            } else
+            {
                 paint.setTextSize(paint.getTextSize() * CODE_DEF_TEXT_SIZE_RATIO);
             }
         }
@@ -328,23 +334,26 @@ public class StylarTheme
     /**
      * @since 3.0.0
      */
-    public void applyCodeBlockTextStyle(@NonNull Paint paint) {
+    public void applyCodeBlockTextStyle(@NonNull Paint paint)
+    {
 
         // apply text color, first check for block specific value,
         // then check for code (inline), else do nothing (keep original color of text)
         final int textColor = codeBlockTextColor != 0
-                ? codeBlockTextColor
-                : codeTextColor;
+            ? codeBlockTextColor
+            : codeTextColor;
 
-        if (textColor != 0) {
+        if (textColor != 0)
+        {
             paint.setColor(textColor);
         }
 
         final Typeface typeface = codeBlockTypeface != null
-                ? codeBlockTypeface
-                : codeTypeface;
+            ? codeBlockTypeface
+            : codeTypeface;
 
-        if (typeface != null) {
+        if (typeface != null)
+        {
 
             paint.setTypeface(typeface);
 
@@ -352,24 +361,28 @@ public class StylarTheme
             // (like we do when no Typeface is provided), if it's some specific typeface
             // we would confuse users about textSize
             final int textSize = codeBlockTextSize > 0
-                    ? codeBlockTextSize
-                    : codeTextSize;
+                ? codeBlockTextSize
+                : codeTextSize;
 
-            if (textSize > 0) {
+            if (textSize > 0)
+            {
                 paint.setTextSize(textSize);
             }
-        } else {
+        } else
+        {
 
             // by default use monospace
             paint.setTypeface(Typeface.MONOSPACE);
 
             final int textSize = codeBlockTextSize > 0
-                    ? codeBlockTextSize
-                    : codeTextSize;
+                ? codeBlockTextSize
+                : codeTextSize;
 
-            if (textSize > 0) {
+            if (textSize > 0)
+            {
                 paint.setTextSize(textSize);
-            } else {
+            } else
+            {
                 // calculate default value
                 paint.setTextSize(paint.getTextSize() * CODE_DEF_TEXT_SIZE_RATIO);
             }
@@ -377,18 +390,22 @@ public class StylarTheme
     }
 
 
-    public int getCodeBlockMargin() {
+    public int getCodeBlockMargin()
+    {
         return codeBlockMargin;
     }
 
     /**
      * @since 3.0.0
      */
-    public int getCodeBackgroundColor(@NonNull Paint paint) {
+    public int getCodeBackgroundColor(@NonNull Paint paint)
+    {
         final int color;
-        if (codeBackgroundColor != 0) {
+        if (codeBackgroundColor != 0)
+        {
             color = codeBackgroundColor;
-        } else {
+        } else
+        {
             color = ColorUtils.applyAlpha(paint.getColor(), CODE_DEF_BACKGROUND_COLOR_ALPHA);
         }
         return color;
@@ -397,70 +414,85 @@ public class StylarTheme
     /**
      * @since 3.0.0
      */
-    public int getCodeBlockBackgroundColor(@NonNull Paint paint) {
+    public int getCodeBlockBackgroundColor(@NonNull Paint paint)
+    {
 
         final int color = codeBlockBackgroundColor != 0
-                ? codeBlockBackgroundColor
-                : codeBackgroundColor;
+            ? codeBlockBackgroundColor
+            : codeBackgroundColor;
 
         return color != 0
-                ? color
-                : ColorUtils.applyAlpha(paint.getColor(), CODE_DEF_BACKGROUND_COLOR_ALPHA);
+            ? color
+            : ColorUtils.applyAlpha(paint.getColor(), CODE_DEF_BACKGROUND_COLOR_ALPHA);
     }
 
-    public void applyHeadingTextStyle(@NonNull Paint paint, @IntRange(from = 1, to = 6) int level) {
-        if (headingTypeface == null) {
+    public void applyHeadingTextStyle(@NonNull Paint paint, @IntRange(from = 1, to = 6) int level)
+    {
+        if (headingTypeface == null)
+        {
             paint.setFakeBoldText(true);
-        } else {
+        } else
+        {
             paint.setTypeface(headingTypeface);
         }
         final float[] textSizes = headingTextSizeMultipliers != null
-                ? headingTextSizeMultipliers
-                : HEADING_SIZES;
+            ? headingTextSizeMultipliers
+            : HEADING_SIZES;
 
-        if (textSizes != null && textSizes.length >= level) {
+        if (textSizes != null && textSizes.length >= level)
+        {
             paint.setTextSize(paint.getTextSize() * textSizes[level - 1]);
-        } else {
+        } else
+        {
             throw new IllegalStateException(String.format(
-                    Locale.US,
-                    "Supplied heading level: %d is invalid, where configured heading sizes are: `%s`",
-                    level, Arrays.toString(textSizes)));
+                Locale.US,
+                "Supplied heading level: %d is invalid, where configured heading sizes are: `%s`",
+                level, Arrays.toString(textSizes)));
         }
     }
 
-    public void applyHeadingBreakStyle(@NonNull Paint paint) {
+    public void applyHeadingBreakStyle(@NonNull Paint paint)
+    {
         final int color;
-        if (headingBreakColor != 0) {
+        if (headingBreakColor != 0)
+        {
             color = headingBreakColor;
-        } else {
+        } else
+        {
             color = ColorUtils.applyAlpha(paint.getColor(), HEADING_DEF_BREAK_COLOR_ALPHA);
         }
         paint.setColor(color);
         paint.setStyle(Paint.Style.FILL);
-        if (headingBreakHeight >= 0) {
+        if (headingBreakHeight >= 0)
+        {
             //noinspection SuspiciousNameCombination
             paint.setStrokeWidth(headingBreakHeight);
         }
     }
 
-    public void applyThematicBreakStyle(@NonNull Paint paint) {
+    public void applyThematicBreakStyle(@NonNull Paint paint)
+    {
         final int color;
-        if (thematicBreakColor != 0) {
+        if (thematicBreakColor != 0)
+        {
             color = thematicBreakColor;
-        } else {
+        } else
+        {
             color = ColorUtils.applyAlpha(paint.getColor(), THEMATIC_BREAK_DEF_ALPHA);
         }
         paint.setColor(color);
         paint.setStyle(Paint.Style.FILL);
 
-        if (thematicBreakHeight >= 0) {
+        if (thematicBreakHeight >= 0)
+        {
             //noinspection SuspiciousNameCombination
             paint.setStrokeWidth(thematicBreakHeight);
         }
     }
 
     @SuppressWarnings("unused")
-    public static class Builder {
+    public static class Builder
+    {
 
         private int linkColor;
         private boolean isLinkUnderlined = true; // @since 4.5.0
@@ -486,10 +518,12 @@ public class StylarTheme
         private int thematicBreakColor;
         private int thematicBreakHeight = -1;
 
-        Builder() {
+        Builder()
+        {
         }
 
-        Builder(@NonNull StylarTheme theme) {
+        Builder(@NonNull StylarTheme theme)
+        {
             this.linkColor = theme.linkColor;
             this.isLinkUnderlined = theme.isLinkedUnderlined;
             this.blockMargin = theme.blockMargin;
@@ -514,56 +548,65 @@ public class StylarTheme
         }
 
         @NonNull
-        public Builder linkColor(@ColorInt int linkColor) {
+        public Builder linkColor(@ColorInt int linkColor)
+        {
             this.linkColor = linkColor;
             return this;
         }
 
         @NonNull
-        public Builder isLinkUnderlined(boolean isLinkUnderlined) {
+        public Builder isLinkUnderlined(boolean isLinkUnderlined)
+        {
             this.isLinkUnderlined = isLinkUnderlined;
             return this;
         }
 
         @NonNull
-        public Builder blockMargin(@Px int blockMargin) {
+        public Builder blockMargin(@Px int blockMargin)
+        {
             this.blockMargin = blockMargin;
             return this;
         }
 
         @NonNull
-        public Builder blockQuoteWidth(@Px int blockQuoteWidth) {
+        public Builder blockQuoteWidth(@Px int blockQuoteWidth)
+        {
             this.blockQuoteWidth = blockQuoteWidth;
             return this;
         }
 
         @SuppressWarnings("SameParameterValue")
         @NonNull
-        public Builder blockQuoteColor(@ColorInt int blockQuoteColor) {
+        public Builder blockQuoteColor(@ColorInt int blockQuoteColor)
+        {
             this.blockQuoteColor = blockQuoteColor;
             return this;
         }
 
         @NonNull
-        public Builder listItemColor(@ColorInt int listItemColor) {
+        public Builder listItemColor(@ColorInt int listItemColor)
+        {
             this.listItemColor = listItemColor;
             return this;
         }
 
         @NonNull
-        public Builder bulletListItemStrokeWidth(@Px int bulletListItemStrokeWidth) {
+        public Builder bulletListItemStrokeWidth(@Px int bulletListItemStrokeWidth)
+        {
             this.bulletListItemStrokeWidth = bulletListItemStrokeWidth;
             return this;
         }
 
         @NonNull
-        public Builder bulletWidth(@Px int bulletWidth) {
+        public Builder bulletWidth(@Px int bulletWidth)
+        {
             this.bulletWidth = bulletWidth;
             return this;
         }
 
         @NonNull
-        public Builder codeTextColor(@ColorInt int codeTextColor) {
+        public Builder codeTextColor(@ColorInt int codeTextColor)
+        {
             this.codeTextColor = codeTextColor;
             return this;
         }
@@ -572,14 +615,16 @@ public class StylarTheme
          * @since 1.0.5
          */
         @NonNull
-        public Builder codeBlockTextColor(@ColorInt int codeBlockTextColor) {
+        public Builder codeBlockTextColor(@ColorInt int codeBlockTextColor)
+        {
             this.codeBlockTextColor = codeBlockTextColor;
             return this;
         }
 
         @SuppressWarnings({"SameParameterValue", "UnusedReturnValue"})
         @NonNull
-        public Builder codeBackgroundColor(@ColorInt int codeBackgroundColor) {
+        public Builder codeBackgroundColor(@ColorInt int codeBackgroundColor)
+        {
             this.codeBackgroundColor = codeBackgroundColor;
             return this;
         }
@@ -588,19 +633,22 @@ public class StylarTheme
          * @since 1.0.5
          */
         @NonNull
-        public Builder codeBlockBackgroundColor(@ColorInt int codeBlockBackgroundColor) {
+        public Builder codeBlockBackgroundColor(@ColorInt int codeBlockBackgroundColor)
+        {
             this.codeBlockBackgroundColor = codeBlockBackgroundColor;
             return this;
         }
 
         @NonNull
-        public Builder codeBlockMargin(@Px int codeBlockMargin) {
+        public Builder codeBlockMargin(@Px int codeBlockMargin)
+        {
             this.codeBlockMargin = codeBlockMargin;
             return this;
         }
 
         @NonNull
-        public Builder codeTypeface(@NonNull Typeface codeTypeface) {
+        public Builder codeTypeface(@NonNull Typeface codeTypeface)
+        {
             this.codeTypeface = codeTypeface;
             return this;
         }
@@ -609,13 +657,15 @@ public class StylarTheme
          * @since 3.0.0
          */
         @NonNull
-        public Builder codeBlockTypeface(@NonNull Typeface typeface) {
+        public Builder codeBlockTypeface(@NonNull Typeface typeface)
+        {
             this.codeBlockTypeface = typeface;
             return this;
         }
 
         @NonNull
-        public Builder codeTextSize(@Px int codeTextSize) {
+        public Builder codeTextSize(@Px int codeTextSize)
+        {
             this.codeTextSize = codeTextSize;
             return this;
         }
@@ -624,19 +674,22 @@ public class StylarTheme
          * @since 3.0.0
          */
         @NonNull
-        public Builder codeBlockTextSize(@Px int codeTextSize) {
+        public Builder codeBlockTextSize(@Px int codeTextSize)
+        {
             this.codeBlockTextSize = codeTextSize;
             return this;
         }
 
         @NonNull
-        public Builder headingBreakHeight(@Px int headingBreakHeight) {
+        public Builder headingBreakHeight(@Px int headingBreakHeight)
+        {
             this.headingBreakHeight = headingBreakHeight;
             return this;
         }
 
         @NonNull
-        public Builder headingBreakColor(@ColorInt int headingBreakColor) {
+        public Builder headingBreakColor(@ColorInt int headingBreakColor)
+        {
             this.headingBreakColor = headingBreakColor;
             return this;
         }
@@ -647,7 +700,8 @@ public class StylarTheme
          * @since 1.1.0
          */
         @NonNull
-        public Builder headingTypeface(@NonNull Typeface headingTypeface) {
+        public Builder headingTypeface(@NonNull Typeface headingTypeface)
+        {
             this.headingTypeface = headingTypeface;
             return this;
         }
@@ -660,25 +714,29 @@ public class StylarTheme
          */
         @SuppressWarnings("UnusedReturnValue")
         @NonNull
-        public Builder headingTextSizeMultipliers(@Size(6) @NonNull float[] headingTextSizeMultipliers) {
+        public Builder headingTextSizeMultipliers(@Size(6) @NonNull float[] headingTextSizeMultipliers)
+        {
             this.headingTextSizeMultipliers = headingTextSizeMultipliers;
             return this;
         }
 
         @NonNull
-        public Builder thematicBreakColor(@ColorInt int thematicBreakColor) {
+        public Builder thematicBreakColor(@ColorInt int thematicBreakColor)
+        {
             this.thematicBreakColor = thematicBreakColor;
             return this;
         }
 
         @NonNull
-        public Builder thematicBreakHeight(@Px int thematicBreakHeight) {
+        public Builder thematicBreakHeight(@Px int thematicBreakHeight)
+        {
             this.thematicBreakHeight = thematicBreakHeight;
             return this;
         }
 
         @NonNull
-        public StylarTheme build() {
+        public StylarTheme build()
+        {
             return new StylarTheme(this);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/BlockQuoteSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/BlockQuoteSpanFactory.java
@@ -3,15 +3,17 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.core.spans.BlockQuoteSpan;
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.core.spans.BlockQuoteSpan;
 
-public class BlockQuoteSpanFactory implements SpanFactory {
+public class BlockQuoteSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new BlockQuoteSpan(configuration.theme());
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/CodeBlockSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/CodeBlockSpanFactory.java
@@ -3,15 +3,17 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.spans.CodeBlockSpan;
 
-public class CodeBlockSpanFactory implements SpanFactory {
+public class CodeBlockSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new CodeBlockSpan(configuration.theme());
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/CodeSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/CodeSpanFactory.java
@@ -3,15 +3,17 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.spans.CodeSpan;
 
-public class CodeSpanFactory implements SpanFactory {
+public class CodeSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new CodeSpan(configuration.theme());
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/EmphasisSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/EmphasisSpanFactory.java
@@ -3,15 +3,17 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.spans.EmphasisSpan;
 
-public class EmphasisSpanFactory implements SpanFactory {
+public class EmphasisSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new EmphasisSpan();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/HeadingSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/HeadingSpanFactory.java
@@ -3,19 +3,21 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.CoreProps;
 import com.zeoflow.stylar.core.spans.HeadingSpan;
 
-public class HeadingSpanFactory implements SpanFactory {
+public class HeadingSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new HeadingSpan(
-                configuration.theme(),
-                CoreProps.HEADING_LEVEL.require(props)
+            configuration.theme(),
+            CoreProps.HEADING_LEVEL.require(props)
         );
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/LinkSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/LinkSpanFactory.java
@@ -3,20 +3,22 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.CoreProps;
 import com.zeoflow.stylar.core.spans.LinkSpan;
 
-public class LinkSpanFactory implements SpanFactory {
+public class LinkSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new LinkSpan(
-                configuration.theme(),
-                CoreProps.LINK_DESTINATION.require(props),
-                configuration.linkResolver()
+            configuration.theme(),
+            CoreProps.LINK_DESTINATION.require(props),
+            configuration.linkResolver()
         );
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/ListItemSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/ListItemSpanFactory.java
@@ -3,38 +3,42 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.CoreProps;
 import com.zeoflow.stylar.core.spans.BulletListItemSpan;
 import com.zeoflow.stylar.core.spans.OrderedListItemSpan;
 
-public class ListItemSpanFactory implements SpanFactory {
+public class ListItemSpanFactory implements SpanFactory
+{
 
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
 
         // type of list item
         // bullet : level
         // ordered: number
         final Object spans;
 
-        if (CoreProps.ListItemType.BULLET == CoreProps.LIST_ITEM_TYPE.require(props)) {
+        if (CoreProps.ListItemType.BULLET == CoreProps.LIST_ITEM_TYPE.require(props))
+        {
             spans = new BulletListItemSpan(
-                    configuration.theme(),
-                    CoreProps.BULLET_LIST_ITEM_LEVEL.require(props)
+                configuration.theme(),
+                CoreProps.BULLET_LIST_ITEM_LEVEL.require(props)
             );
-        } else {
+        } else
+        {
 
             // todo| in order to provide real RTL experience there must be a way to provide this string
             final String number = String.valueOf(CoreProps.ORDERED_LIST_ITEM_NUMBER.require(props))
-                    + "." + '\u00a0';
+                + "." + '\u00a0';
 
             spans = new OrderedListItemSpan(
-                    configuration.theme(),
-                    number
+                configuration.theme(),
+                number
             );
         }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/StrongEmphasisSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/StrongEmphasisSpanFactory.java
@@ -3,15 +3,17 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.spans.StrongEmphasisSpan;
 
-public class StrongEmphasisSpanFactory implements SpanFactory {
+public class StrongEmphasisSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new StrongEmphasisSpan();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/factory/ThematicBreakSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/factory/ThematicBreakSpanFactory.java
@@ -3,15 +3,17 @@ package com.zeoflow.stylar.core.factory;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.core.spans.ThematicBreakSpan;
 
-public class ThematicBreakSpanFactory implements SpanFactory {
+public class ThematicBreakSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new ThematicBreakSpan(configuration.theme());
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/BlockQuoteSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/BlockQuoteSpan.java
@@ -10,35 +10,39 @@ import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.core.StylarTheme;
 
-public class BlockQuoteSpan implements LeadingMarginSpan {
+public class BlockQuoteSpan implements LeadingMarginSpan
+{
 
     private final StylarTheme theme;
     private final Rect rect = ObjectsPool.rect();
     private final Paint paint = ObjectsPool.paint();
 
-    public BlockQuoteSpan(@NonNull StylarTheme theme) {
+    public BlockQuoteSpan(@NonNull StylarTheme theme)
+    {
         this.theme = theme;
     }
 
     @Override
-    public int getLeadingMargin(boolean first) {
+    public int getLeadingMargin(boolean first)
+    {
         return theme.getBlockMargin();
     }
 
     @Override
     public void drawLeadingMargin(
-            Canvas c,
-            Paint p,
-            int x,
-            int dir,
-            int top,
-            int baseline,
-            int bottom,
-            CharSequence text,
-            int start,
-            int end,
-            boolean first,
-            Layout layout) {
+        Canvas c,
+        Paint p,
+        int x,
+        int dir,
+        int top,
+        int baseline,
+        int bottom,
+        CharSequence text,
+        int start,
+        int end,
+        boolean first,
+        Layout layout)
+    {
 
         final int width = theme.getBlockQuoteWidth();
 

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/BulletListItemSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/BulletListItemSpan.java
@@ -14,41 +14,45 @@ import androidx.annotation.NonNull;
 import com.zeoflow.stylar.core.StylarTheme;
 import com.zeoflow.stylar.utils.LeadingMarginUtils;
 
-public class BulletListItemSpan implements LeadingMarginSpan {
+public class BulletListItemSpan implements LeadingMarginSpan
+{
 
     private static final boolean IS_NOUGAT;
 
-    static {
+    static
+    {
         final int sdk = Build.VERSION.SDK_INT;
         IS_NOUGAT = Build.VERSION_CODES.N == sdk || Build.VERSION_CODES.N_MR1 == sdk;
     }
 
-    private StylarTheme theme;
-
     private final Paint paint = ObjectsPool.paint();
     private final RectF circle = ObjectsPool.rectF();
     private final Rect rectangle = ObjectsPool.rect();
-
     private final int level;
+    private StylarTheme theme;
 
     public BulletListItemSpan(
-            @NonNull StylarTheme theme,
-            @IntRange(from = 0) int level) {
+        @NonNull StylarTheme theme,
+        @IntRange(from = 0) int level)
+    {
         this.theme = theme;
         this.level = level;
     }
 
     @Override
-    public int getLeadingMargin(boolean first) {
+    public int getLeadingMargin(boolean first)
+    {
         return theme.getBlockMargin();
     }
 
     @Override
-    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout) {
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout)
+    {
 
         // if there was a line break, we don't need to draw anything
         if (!first
-                || !LeadingMarginUtils.selfStart(start, text, this)) {
+            || !LeadingMarginUtils.selfStart(start, text, this))
+        {
             return;
         }
 
@@ -57,7 +61,8 @@ public class BulletListItemSpan implements LeadingMarginSpan {
         theme.applyListItemStyle(paint);
 
         final int save = c.save();
-        try {
+        try
+        {
 
             final int width = theme.getBlockMargin();
 
@@ -76,7 +81,8 @@ public class BulletListItemSpan implements LeadingMarginSpan {
             {
                 // @since 4.2.1 to correctly position bullet
                 // when nested inside other LeadingMarginSpans (sorry, Nougat)
-                if (IS_NOUGAT) {
+                if (IS_NOUGAT)
+                {
 
                     // @since 2.0.2
                     // There is a bug in Android Nougat, when this span receives an `x` that
@@ -85,10 +91,12 @@ public class BulletListItemSpan implements LeadingMarginSpan {
                     // and add this difference to resulting left/right values. If everything goes well
                     // we do not encounter a bug -> this `diff` value will be 0
                     final int diff;
-                    if (dir < 0) {
+                    if (dir < 0)
+                    {
                         // rtl
                         diff = x - (layout.getWidth() - (width * level));
-                    } else {
+                    } else
+                    {
                         diff = (width * level) - x;
                     }
 
@@ -97,10 +105,13 @@ public class BulletListItemSpan implements LeadingMarginSpan {
                     l = Math.min(left, right) + (dir * diff);
                     r = Math.max(left, right) + (dir * diff);
 
-                } else {
-                    if (dir > 0) {
+                } else
+                {
+                    if (dir > 0)
+                    {
                         l = x + marginLeft;
-                    } else {
+                    } else
+                    {
                         l = x - width + marginLeft;
                     }
                     r = l + side;
@@ -111,17 +122,19 @@ public class BulletListItemSpan implements LeadingMarginSpan {
             final int b = t + side;
 
             if (level == 0
-                    || level == 1) {
+                || level == 1)
+            {
 
                 circle.set(l, t, r, b);
 
                 final Paint.Style style = level == 0
-                        ? Paint.Style.FILL
-                        : Paint.Style.STROKE;
+                    ? Paint.Style.FILL
+                    : Paint.Style.STROKE;
                 paint.setStyle(style);
 
                 c.drawOval(circle, paint);
-            } else {
+            } else
+            {
 
                 rectangle.set(l, t, r, b);
 
@@ -130,7 +143,8 @@ public class BulletListItemSpan implements LeadingMarginSpan {
                 c.drawRect(rectangle, paint);
             }
 
-        } finally {
+        } finally
+        {
             c.restoreToCount(save);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/CodeBlockSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/CodeBlockSpan.java
@@ -15,47 +15,56 @@ import com.zeoflow.stylar.core.StylarTheme;
 /**
  * @since 3.0.0 split inline and block spans
  */
-public class CodeBlockSpan extends MetricAffectingSpan implements LeadingMarginSpan {
+public class CodeBlockSpan extends MetricAffectingSpan implements LeadingMarginSpan
+{
 
     private final StylarTheme theme;
     private final Rect rect = ObjectsPool.rect();
     private final Paint paint = ObjectsPool.paint();
 
-    public CodeBlockSpan(@NonNull StylarTheme theme) {
+    public CodeBlockSpan(@NonNull StylarTheme theme)
+    {
         this.theme = theme;
     }
 
     @Override
-    public void updateMeasureState(TextPaint p) {
+    public void updateMeasureState(TextPaint p)
+    {
         apply(p);
     }
 
     @Override
-    public void updateDrawState(TextPaint ds) {
+    public void updateDrawState(TextPaint ds)
+    {
         apply(ds);
     }
 
-    private void apply(TextPaint p) {
+    private void apply(TextPaint p)
+    {
         theme.applyCodeBlockTextStyle(p);
     }
 
     @Override
-    public int getLeadingMargin(boolean first) {
+    public int getLeadingMargin(boolean first)
+    {
         return theme.getCodeBlockMargin();
     }
 
     @Override
-    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout) {
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout)
+    {
 
         paint.setStyle(Paint.Style.FILL);
         paint.setColor(theme.getCodeBlockBackgroundColor(p));
 
         final int left;
         final int right;
-        if (dir > 0) {
+        if (dir > 0)
+        {
             left = x;
             right = c.getWidth();
-        } else {
+        } else
+        {
             left = x - c.getWidth();
             right = x;
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/CodeSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/CodeSpan.java
@@ -10,26 +10,31 @@ import com.zeoflow.stylar.core.StylarTheme;
 /**
  * @since 3.0.0 split inline and block spans
  */
-public class CodeSpan extends MetricAffectingSpan {
+public class CodeSpan extends MetricAffectingSpan
+{
 
     private final StylarTheme theme;
 
-    public CodeSpan(@NonNull StylarTheme theme) {
+    public CodeSpan(@NonNull StylarTheme theme)
+    {
         this.theme = theme;
     }
 
     @Override
-    public void updateMeasureState(TextPaint p) {
+    public void updateMeasureState(TextPaint p)
+    {
         apply(p);
     }
 
     @Override
-    public void updateDrawState(TextPaint ds) {
+    public void updateDrawState(TextPaint ds)
+    {
         apply(ds);
         ds.bgColor = theme.getCodeBackgroundColor(ds);
     }
 
-    private void apply(TextPaint p) {
+    private void apply(TextPaint p)
+    {
         theme.applyCodeTextStyle(p);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/CustomTypefaceSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/CustomTypefaceSpan.java
@@ -15,30 +15,36 @@ import androidx.annotation.NonNull;
  *
  * @since 3.0.0
  */
-public class CustomTypefaceSpan extends MetricAffectingSpan {
-
-    @NonNull
-    public static CustomTypefaceSpan create(@NonNull Typeface typeface) {
-        return new CustomTypefaceSpan(typeface);
-    }
+public class CustomTypefaceSpan extends MetricAffectingSpan
+{
 
     private final Typeface typeface;
 
-    public CustomTypefaceSpan(@NonNull Typeface typeface) {
+    public CustomTypefaceSpan(@NonNull Typeface typeface)
+    {
         this.typeface = typeface;
     }
 
+    @NonNull
+    public static CustomTypefaceSpan create(@NonNull Typeface typeface)
+    {
+        return new CustomTypefaceSpan(typeface);
+    }
+
     @Override
-    public void updateMeasureState(@NonNull TextPaint p) {
+    public void updateMeasureState(@NonNull TextPaint p)
+    {
         updatePaint(p);
     }
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(TextPaint tp)
+    {
         updatePaint(tp);
     }
 
-    private void updatePaint(@NonNull TextPaint paint) {
+    private void updatePaint(@NonNull TextPaint paint)
+    {
         paint.setTypeface(typeface);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/EmphasisSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/EmphasisSpan.java
@@ -3,15 +3,18 @@ package com.zeoflow.stylar.core.spans;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
 
-public class EmphasisSpan extends MetricAffectingSpan {
+public class EmphasisSpan extends MetricAffectingSpan
+{
 
     @Override
-    public void updateMeasureState(TextPaint p) {
+    public void updateMeasureState(TextPaint p)
+    {
         p.setTextSkewX(-0.25F);
     }
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(TextPaint tp)
+    {
         tp.setTextSkewX(-0.25F);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/HeadingSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/HeadingSpan.java
@@ -14,43 +14,51 @@ import androidx.annotation.NonNull;
 import com.zeoflow.stylar.core.StylarTheme;
 import com.zeoflow.stylar.utils.LeadingMarginUtils;
 
-public class HeadingSpan extends MetricAffectingSpan implements LeadingMarginSpan {
+public class HeadingSpan extends MetricAffectingSpan implements LeadingMarginSpan
+{
 
     private final StylarTheme theme;
     private final Rect rect = ObjectsPool.rect();
     private final Paint paint = ObjectsPool.paint();
     private final int level;
 
-    public HeadingSpan(@NonNull StylarTheme theme, @IntRange(from = 1, to = 6) int level) {
+    public HeadingSpan(@NonNull StylarTheme theme, @IntRange(from = 1, to = 6) int level)
+    {
         this.theme = theme;
         this.level = level;
     }
 
     @Override
-    public void updateMeasureState(TextPaint p) {
+    public void updateMeasureState(TextPaint p)
+    {
         apply(p);
     }
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(TextPaint tp)
+    {
         apply(tp);
     }
 
-    private void apply(TextPaint paint) {
+    private void apply(TextPaint paint)
+    {
         theme.applyHeadingTextStyle(paint, level);
     }
 
     @Override
-    public int getLeadingMargin(boolean first) {
+    public int getLeadingMargin(boolean first)
+    {
         // no margin actually, but we need to access Canvas to draw break
         return 0;
     }
 
     @Override
-    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout) {
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout)
+    {
 
         if ((level == 1 || level == 2 || level == 3)
-                && LeadingMarginUtils.selfEnd(end, text, this)) {
+            && LeadingMarginUtils.selfEnd(end, text, this))
+        {
 
             paint.set(p);
 
@@ -58,20 +66,24 @@ public class HeadingSpan extends MetricAffectingSpan implements LeadingMarginSpa
 
             final float height = paint.getStrokeWidth();
 
-            if (height > .0F) {
+            if (height > .0F)
+            {
 
                 final int b = (int) (bottom - height + .5F);
 
                 int left;
                 int right;
-                if (dir > 0) {
+                if (dir > 0)
+                {
                     left = x;
                     right = c.getWidth();
-                } else {
+                } else
+                {
                     left = x - c.getWidth();
                     right = x;
                 }
-                if (left > right) {
+                if (left > right)
+                {
                     int cLeft = left;
                     left = right;
                     right = cLeft;
@@ -88,7 +100,8 @@ public class HeadingSpan extends MetricAffectingSpan implements LeadingMarginSpa
     /**
      * @since 4.2.0
      */
-    public int getLevel() {
+    public int getLevel()
+    {
         return level;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/LastLineSpacingSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/LastLineSpacingSpan.java
@@ -10,34 +10,40 @@ import androidx.annotation.Px;
 /**
  * @since 4.0.0
  */
-public class LastLineSpacingSpan implements LineHeightSpan {
-
-    @NonNull
-    public static LastLineSpacingSpan create(@Px int spacing) {
-        return new LastLineSpacingSpan(spacing);
-    }
+public class LastLineSpacingSpan implements LineHeightSpan
+{
 
     private final int spacing;
 
-    public LastLineSpacingSpan(@Px int spacing) {
+    public LastLineSpacingSpan(@Px int spacing)
+    {
         this.spacing = spacing;
     }
 
-    @Override
-    public void chooseHeight(CharSequence text, int start, int end, int spanstartv, int v, Paint.FontMetricsInt fm) {
-        if (selfEnd(end, text, this)) {
-            // let's just add what we want
-            fm.descent += spacing;
-            fm.bottom += spacing;
-        }
+    @NonNull
+    public static LastLineSpacingSpan create(@Px int spacing)
+    {
+        return new LastLineSpacingSpan(spacing);
     }
 
-    private static boolean selfEnd(int end, CharSequence text, Object span) {
+    private static boolean selfEnd(int end, CharSequence text, Object span)
+    {
         // this is some kind of interesting magic here... only the last
         // span will receive correct _end_ argument, but previous spans
         // receive it tilted by one (1). Most likely it's just a new-line character... and
         // if needed we could check for that
         final int spanEnd = ((Spanned) text).getSpanEnd(span);
         return spanEnd == end || spanEnd == end - 1;
+    }
+
+    @Override
+    public void chooseHeight(CharSequence text, int start, int end, int spanstartv, int v, Paint.FontMetricsInt fm)
+    {
+        if (selfEnd(end, text, this))
+        {
+            // let's just add what we want
+            fm.descent += spacing;
+            fm.bottom += spacing;
+        }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/LinkSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/LinkSpan.java
@@ -9,16 +9,18 @@ import androidx.annotation.NonNull;
 import com.zeoflow.stylar.LinkResolver;
 import com.zeoflow.stylar.core.StylarTheme;
 
-public class LinkSpan extends URLSpan {
+public class LinkSpan extends URLSpan
+{
 
     private final StylarTheme theme;
     private final String link;
     private final LinkResolver resolver;
 
     public LinkSpan(
-            @NonNull StylarTheme theme,
-            @NonNull String link,
-            @NonNull LinkResolver resolver) {
+        @NonNull StylarTheme theme,
+        @NonNull String link,
+        @NonNull LinkResolver resolver)
+    {
         super(link);
         this.theme = theme;
         this.link = link;
@@ -26,12 +28,14 @@ public class LinkSpan extends URLSpan {
     }
 
     @Override
-    public void onClick(View widget) {
+    public void onClick(View widget)
+    {
         resolver.resolve(widget, link);
     }
 
     @Override
-    public void updateDrawState(@NonNull TextPaint ds) {
+    public void updateDrawState(@NonNull TextPaint ds)
+    {
         theme.applyLinkStyle(ds);
     }
 
@@ -39,7 +43,8 @@ public class LinkSpan extends URLSpan {
      * @since 4.2.0
      */
     @NonNull
-    public String getLink() {
+    public String getLink()
+    {
         return link;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/ObjectsPool.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/ObjectsPool.java
@@ -4,7 +4,8 @@ import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.RectF;
 
-abstract class ObjectsPool {
+abstract class ObjectsPool
+{
 
     // maybe it's premature optimization, but as all the drawing is done in one thread
     // and we apply needed values before actual drawing it's (I assume) safe to reuse some frequently used objects
@@ -16,18 +17,22 @@ abstract class ObjectsPool {
     private static final RectF RECT_F = new RectF();
     private static final Paint PAINT = new Paint(Paint.ANTI_ALIAS_FLAG);
 
-    static Rect rect() {
+    private ObjectsPool()
+    {
+    }
+
+    static Rect rect()
+    {
         return RECT;
     }
 
-    static RectF rectF() {
+    static RectF rectF()
+    {
         return RECT_F;
     }
 
-    static Paint paint() {
+    static Paint paint()
+    {
         return PAINT;
-    }
-
-    private ObjectsPool() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/OrderedListItemSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/OrderedListItemSpan.java
@@ -10,10 +10,28 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
-import com.zeoflow.stylar.utils.LeadingMarginUtils;
 import com.zeoflow.stylar.core.StylarTheme;
+import com.zeoflow.stylar.utils.LeadingMarginUtils;
 
-public class OrderedListItemSpan implements LeadingMarginSpan {
+public class OrderedListItemSpan implements LeadingMarginSpan
+{
+
+    private final StylarTheme theme;
+    private final String number;
+    private final Paint paint = ObjectsPool.paint();
+    // we will use this variable to check if our order number text exceeds block margin,
+    // so we will use it instead of block margin
+    // @since 1.0.3
+    private int margin;
+
+    public OrderedListItemSpan(
+        @NonNull StylarTheme theme,
+        @NonNull String number
+    )
+    {
+        this.theme = theme;
+        this.number = number;
+    }
 
     /**
      * Process supplied `text` argument and supply TextView paint to all OrderedListItemSpans
@@ -26,55 +44,45 @@ public class OrderedListItemSpan implements LeadingMarginSpan {
      * @param text     parsed markdown to process
      * @since 2.0.1
      */
-    public static void measure(@NonNull TextView textView, @NonNull CharSequence text) {
+    public static void measure(@NonNull TextView textView, @NonNull CharSequence text)
+    {
 
-        if (!(text instanceof Spanned)) {
+        if (!(text instanceof Spanned))
+        {
             // nothing to do here
             return;
         }
 
         final OrderedListItemSpan[] spans = ((Spanned) text).getSpans(
-                0,
-                text.length(),
-                OrderedListItemSpan.class);
+            0,
+            text.length(),
+            OrderedListItemSpan.class);
 
-        if (spans != null) {
+        if (spans != null)
+        {
             final TextPaint paint = textView.getPaint();
-            for (OrderedListItemSpan span : spans) {
+            for (OrderedListItemSpan span : spans)
+            {
                 span.margin = (int) (paint.measureText(span.number) + .5F);
             }
         }
     }
 
-    private final StylarTheme theme;
-    private final String number;
-    private final Paint paint = ObjectsPool.paint();
-
-    // we will use this variable to check if our order number text exceeds block margin,
-    // so we will use it instead of block margin
-    // @since 1.0.3
-    private int margin;
-
-    public OrderedListItemSpan(
-            @NonNull StylarTheme theme,
-            @NonNull String number
-    ) {
-        this.theme = theme;
-        this.number = number;
-    }
-
     @Override
-    public int getLeadingMargin(boolean first) {
+    public int getLeadingMargin(boolean first)
+    {
         // @since 2.0.1 we return maximum value of both (now we should measure number before)
         return Math.max(margin, theme.getBlockMargin());
     }
 
     @Override
-    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout) {
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout)
+    {
 
         // if there was a line break, we don't need to draw anything
         if (!first
-                || !LeadingMarginUtils.selfStart(start, text, this)) {
+            || !LeadingMarginUtils.selfStart(start, text, this))
+        {
             return;
         }
 
@@ -89,19 +97,23 @@ public class OrderedListItemSpan implements LeadingMarginSpan {
 
         // @since 1.0.3
         int width = theme.getBlockMargin();
-        if (numberWidth > width) {
+        if (numberWidth > width)
+        {
             // let's keep this logic here in case a user decided not to call #measure and is fine
             // with current implementation
             width = numberWidth;
             margin = numberWidth;
-        } else {
+        } else
+        {
             margin = 0;
         }
 
         final int left;
-        if (dir > 0) {
+        if (dir > 0)
+        {
             left = x + (width * dir) - numberWidth;
-        } else {
+        } else
+        {
             left = x + (width * dir) + (width - numberWidth);
         }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/StrongEmphasisSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/StrongEmphasisSpan.java
@@ -3,15 +3,18 @@ package com.zeoflow.stylar.core.spans;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
 
-public class StrongEmphasisSpan extends MetricAffectingSpan {
+public class StrongEmphasisSpan extends MetricAffectingSpan
+{
 
     @Override
-    public void updateMeasureState(TextPaint p) {
+    public void updateMeasureState(TextPaint p)
+    {
         p.setFakeBoldText(true);
     }
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(TextPaint tp)
+    {
         tp.setFakeBoldText(true);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/TextLayoutSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/TextLayoutSpan.java
@@ -12,59 +12,68 @@ import java.lang.ref.WeakReference;
 /**
  * @since 4.4.0
  */
-public class TextLayoutSpan {
+public class TextLayoutSpan
+{
+
+    private final WeakReference<Layout> reference;
+
+    @SuppressWarnings("WeakerAccess")
+    TextLayoutSpan(@NonNull Layout layout)
+    {
+        this.reference = new WeakReference<>(layout);
+    }
 
     /**
      * @see #applyTo(Spannable, Layout)
      */
     @Nullable
-    public static Layout layoutOf(@NonNull CharSequence cs) {
-        if (cs instanceof Spanned) {
+    public static Layout layoutOf(@NonNull CharSequence cs)
+    {
+        if (cs instanceof Spanned)
+        {
             return layoutOf((Spanned) cs);
         }
         return null;
     }
 
     @Nullable
-    public static Layout layoutOf(@NonNull Spanned spanned) {
+    public static Layout layoutOf(@NonNull Spanned spanned)
+    {
         final TextLayoutSpan[] spans = spanned.getSpans(
-                0,
-                spanned.length(),
-                TextLayoutSpan.class
+            0,
+            spanned.length(),
+            TextLayoutSpan.class
         );
         return spans != null && spans.length > 0
-                ? spans[0].layout()
-                : null;
+            ? spans[0].layout()
+            : null;
     }
 
-    public static void applyTo(@NonNull Spannable spannable, @NonNull Layout layout) {
+    public static void applyTo(@NonNull Spannable spannable, @NonNull Layout layout)
+    {
 
         // remove all current ones (only one should be present)
         final TextLayoutSpan[] spans = spannable.getSpans(0, spannable.length(), TextLayoutSpan.class);
-        if (spans != null) {
-            for (TextLayoutSpan span : spans) {
+        if (spans != null)
+        {
+            for (TextLayoutSpan span : spans)
+            {
                 spannable.removeSpan(span);
             }
         }
 
         final TextLayoutSpan span = new TextLayoutSpan(layout);
         spannable.setSpan(
-                span,
-                0,
-                spannable.length(),
-                Spanned.SPAN_INCLUSIVE_INCLUSIVE
+            span,
+            0,
+            spannable.length(),
+            Spanned.SPAN_INCLUSIVE_INCLUSIVE
         );
     }
 
-    private final WeakReference<Layout> reference;
-
-    @SuppressWarnings("WeakerAccess")
-    TextLayoutSpan(@NonNull Layout layout) {
-        this.reference = new WeakReference<>(layout);
-    }
-
     @Nullable
-    public Layout layout() {
+    public Layout layout()
+    {
         return reference.get();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/TextViewSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/TextViewSpan.java
@@ -14,29 +14,43 @@ import java.lang.ref.WeakReference;
  *
  * @since 4.4.0
  */
-public class TextViewSpan {
+public class TextViewSpan
+{
+
+    private final WeakReference<TextView> reference;
+
+    public TextViewSpan(@NonNull TextView textView)
+    {
+        this.reference = new WeakReference<>(textView);
+    }
 
     @Nullable
-    public static TextView textViewOf(@NonNull CharSequence cs) {
-        if (cs instanceof Spanned) {
+    public static TextView textViewOf(@NonNull CharSequence cs)
+    {
+        if (cs instanceof Spanned)
+        {
             return textViewOf((Spanned) cs);
         }
         return null;
     }
 
     @Nullable
-    public static TextView textViewOf(@NonNull Spanned spanned) {
+    public static TextView textViewOf(@NonNull Spanned spanned)
+    {
         final TextViewSpan[] spans = spanned.getSpans(0, spanned.length(), TextViewSpan.class);
         return spans != null && spans.length > 0
-                ? spans[0].textView()
-                : null;
+            ? spans[0].textView()
+            : null;
     }
 
-    public static void applyTo(@NonNull Spannable spannable, @NonNull TextView textView) {
+    public static void applyTo(@NonNull Spannable spannable, @NonNull TextView textView)
+    {
 
         final TextViewSpan[] spans = spannable.getSpans(0, spannable.length(), TextViewSpan.class);
-        if (spans != null) {
-            for (TextViewSpan span : spans) {
+        if (spans != null)
+        {
+            for (TextViewSpan span : spans)
+            {
                 spannable.removeSpan(span);
             }
         }
@@ -44,21 +58,16 @@ public class TextViewSpan {
         final TextViewSpan span = new TextViewSpan(textView);
         // `SPAN_INCLUSIVE_INCLUSIVE` to persist in case of possible text change (deletion, etc)
         spannable.setSpan(
-                span,
-                0,
-                spannable.length(),
-                Spanned.SPAN_INCLUSIVE_INCLUSIVE
+            span,
+            0,
+            spannable.length(),
+            Spanned.SPAN_INCLUSIVE_INCLUSIVE
         );
     }
 
-    private final WeakReference<TextView> reference;
-
-    public TextViewSpan(@NonNull TextView textView) {
-        this.reference = new WeakReference<>(textView);
-    }
-
     @Nullable
-    public TextView textView() {
+    public TextView textView()
+    {
         return reference.get();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/core/spans/ThematicBreakSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/core/spans/ThematicBreakSpan.java
@@ -10,23 +10,27 @@ import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.core.StylarTheme;
 
-public class ThematicBreakSpan implements LeadingMarginSpan {
+public class ThematicBreakSpan implements LeadingMarginSpan
+{
 
     private final StylarTheme theme;
     private final Rect rect = ObjectsPool.rect();
     private final Paint paint = ObjectsPool.paint();
 
-    public ThematicBreakSpan(@NonNull StylarTheme theme) {
+    public ThematicBreakSpan(@NonNull StylarTheme theme)
+    {
         this.theme = theme;
     }
 
     @Override
-    public int getLeadingMargin(boolean first) {
+    public int getLeadingMargin(boolean first)
+    {
         return 0;
     }
 
     @Override
-    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout) {
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout)
+    {
 
         final int middle = top + ((bottom - top) / 2);
 
@@ -38,10 +42,12 @@ public class ThematicBreakSpan implements LeadingMarginSpan {
 
         final int left;
         final int right;
-        if (dir > 0) {
+        if (dir > 0)
+        {
             left = x;
             right = c.getWidth();
-        } else {
+        } else
+        {
             left = x - c.getWidth();
             right = x;
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/EditHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/EditHandler.java
@@ -13,7 +13,8 @@ import com.zeoflow.stylar.editor.handler.StrongEmphasisEditHandler;
  * @see StrongEmphasisEditHandler
  * @since 4.2.0
  */
-public interface EditHandler<T> {
+public interface EditHandler<T>
+{
 
     void init(@NonNull Stylar stylar);
 
@@ -35,12 +36,12 @@ public interface EditHandler<T> {
      * @see StylarEditorUtils
      */
     void handleMarkdownSpan(
-            @NonNull PersistedSpans persistedSpans,
-            @NonNull Editable editable,
-            @NonNull String input,
-            @NonNull T span,
-            int spanStart,
-            int spanTextLength);
+        @NonNull PersistedSpans persistedSpans,
+        @NonNull Editable editable,
+        @NonNull String input,
+        @NonNull T span,
+        int spanStart,
+        int spanTextLength);
 
     @NonNull
     Class<T> markdownSpanType();

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/PersistedSpans.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/PersistedSpans.java
@@ -20,17 +20,13 @@ import java.util.Map;
  * @see EditHandler#configurePersistedSpans(Builder)
  * @since 4.2.0
  */
-public abstract class PersistedSpans {
+public abstract class PersistedSpans
+{
 
-    public interface SpanFactory<T> {
-        @NonNull
-        T create();
-    }
-
-    public interface Builder {
-        @SuppressWarnings("UnusedReturnValue")
-        @NonNull
-        <T> Builder persistSpan(@NonNull Class<T> type, @NonNull SpanFactory<T> spanFactory);
+    @NonNull
+    static Provider provider()
+    {
+        return new Provider();
     }
 
     @NonNull
@@ -38,40 +34,54 @@ public abstract class PersistedSpans {
 
     abstract void removeUnused();
 
-
-    @NonNull
-    static Provider provider() {
-        return new Provider();
+    public interface SpanFactory<T>
+    {
+        @NonNull
+        T create();
     }
 
-    static class Provider implements Builder {
+
+    public interface Builder
+    {
+        @SuppressWarnings("UnusedReturnValue")
+        @NonNull
+        <T> Builder persistSpan(@NonNull Class<T> type, @NonNull SpanFactory<T> spanFactory);
+    }
+
+    static class Provider implements Builder
+    {
 
         private final Map<Class<?>, SpanFactory> map = new HashMap<>(3);
 
         @NonNull
         @Override
-        public <T> Builder persistSpan(@NonNull Class<T> type, @NonNull SpanFactory<T> spanFactory) {
-            if (map.put(type, spanFactory) != null) {
+        public <T> Builder persistSpan(@NonNull Class<T> type, @NonNull SpanFactory<T> spanFactory)
+        {
+            if (map.put(type, spanFactory) != null)
+            {
                 Log.e("MD-EDITOR", String.format(
-                        Locale.ROOT,
-                        "Re-declaration of persisted span for '%s'", type.getName()));
+                    Locale.ROOT,
+                    "Re-declaration of persisted span for '%s'", type.getName()));
             }
             return this;
         }
 
         @NonNull
-        PersistedSpans provide(@NonNull Spannable spannable) {
+        PersistedSpans provide(@NonNull Spannable spannable)
+        {
             return new Impl(spannable, map);
         }
     }
 
-    static class Impl extends PersistedSpans {
+    static class Impl extends PersistedSpans
+    {
 
         private final Spannable spannable;
         private final Map<Class<?>, SpanFactory> spans;
         private final Map<Class<?>, List<Object>> map;
 
-        Impl(@NonNull Spannable spannable, @NonNull Map<Class<?>, SpanFactory> spans) {
+        Impl(@NonNull Spannable spannable, @NonNull Map<Class<?>, SpanFactory> spans)
+        {
             this.spannable = spannable;
             this.spans = spans;
             this.map = StylarEditorUtils.extractSpans(spannable, spans.keySet());
@@ -79,18 +89,22 @@ public abstract class PersistedSpans {
 
         @NonNull
         @Override
-        public <T> T get(@NonNull Class<T> type) {
+        public <T> T get(@NonNull Class<T> type)
+        {
 
             final Object span;
 
             final List<Object> list = map.get(type);
-            if (list != null && list.size() > 0) {
+            if (list != null && list.size() > 0)
+            {
                 span = list.remove(0);
-            } else {
+            } else
+            {
                 final SpanFactory spanFactory = spans.get(type);
-                if (spanFactory == null) {
+                if (spanFactory == null)
+                {
                     throw new IllegalStateException("Requested type `" + type.getName() + "` was " +
-                            "not registered, use PersistedSpans.Builder#persistSpan method to register");
+                        "not registered, use PersistedSpans.Builder#persistSpan method to register");
                 }
                 span = spanFactory.create();
             }
@@ -100,11 +114,15 @@ public abstract class PersistedSpans {
         }
 
         @Override
-        void removeUnused() {
-            for (List<Object> spans : map.values()) {
+        void removeUnused()
+        {
+            for (List<Object> spans : map.values())
+            {
                 if (spans != null
-                        && spans.size() > 0) {
-                    for (Object span : spans) {
+                    && spans.size() > 0)
+                {
+                    for (Object span : spans)
+                    {
                         spannable.removeSpan(span);
                     }
                 }

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/PunctuationSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/PunctuationSpan.java
@@ -5,12 +5,14 @@ import android.text.style.CharacterStyle;
 
 import com.zeoflow.stylar.utils.ColorUtils;
 
-class PunctuationSpan extends CharacterStyle {
+class PunctuationSpan extends CharacterStyle
+{
 
     private static final int DEF_PUNCTUATION_ALPHA = 75;
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(TextPaint tp)
+    {
         final int color = ColorUtils.applyAlpha(tp.getColor(), DEF_PUNCTUATION_ALPHA);
         tp.setColor(color);
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditor.java
@@ -20,40 +20,14 @@ public abstract class StylarEditor
 {
 
     /**
-     * @see #preRender(Editable, PreRenderResultListener)
-     */
-    public interface PreRenderResult {
-
-        /**
-         * @return Editable instance for which result was calculated. This must not be
-         * actual Editable of EditText
-         */
-        @NonNull
-        Editable resultEditable();
-
-        /**
-         * Dispatch pre-rendering result to EditText
-         *
-         * @param editable to dispatch result to
-         */
-        void dispatchTo(@NonNull Editable editable);
-    }
-
-    /**
-     * @see #preRender(Editable, PreRenderResultListener)
-     */
-    public interface PreRenderResultListener {
-        void onPreRenderResult(@NonNull PreRenderResult result);
-    }
-
-    /**
      * Creates default instance of {@link StylarEditor}. By default it will handle only
      * punctuation spans (highlight markdown punctuation and nothing more).
      *
      * @see #builder(Stylar)
      */
     @NonNull
-    public static StylarEditor create(@NonNull Stylar stylar) {
+    public static StylarEditor create(@NonNull Stylar stylar)
+    {
         return builder(stylar).build();
     }
 
@@ -62,7 +36,8 @@ public abstract class StylarEditor
      * @see Builder
      */
     @NonNull
-    public static Builder builder(@NonNull Stylar stylar) {
+    public static Builder builder(@NonNull Stylar stylar)
+    {
         return new Builder(stylar);
     }
 
@@ -89,8 +64,49 @@ public abstract class StylarEditor
      */
     public abstract void preRender(@NonNull Editable editable, @NonNull PreRenderResultListener preRenderListener);
 
+    /**
+     * @see #preRender(Editable, PreRenderResultListener)
+     */
+    public interface PreRenderResult
+    {
 
-    public static class Builder {
+        /**
+         * @return Editable instance for which result was calculated. This must not be
+         * actual Editable of EditText
+         */
+        @NonNull
+        Editable resultEditable();
+
+        /**
+         * Dispatch pre-rendering result to EditText
+         *
+         * @param editable to dispatch result to
+         */
+        void dispatchTo(@NonNull Editable editable);
+    }
+
+    /**
+     * @see #preRender(Editable, PreRenderResultListener)
+     */
+    public interface PreRenderResultListener
+    {
+        void onPreRenderResult(@NonNull PreRenderResult result);
+    }
+
+
+    interface SpansHandler
+    {
+        void handle(
+            @NonNull PersistedSpans spans,
+            @NonNull Editable editable,
+            @NonNull String input,
+            @NonNull Object span,
+            int spanStart,
+            int spanTextLength);
+    }
+
+    public static class Builder
+    {
 
         private final Stylar stylar;
         private final PersistedSpans.Provider persistedSpansProvider = PersistedSpans.provider();
@@ -98,12 +114,14 @@ public abstract class StylarEditor
 
         private Class<?> punctuationSpanType;
 
-        Builder(@NonNull Stylar stylar) {
+        Builder(@NonNull Stylar stylar)
+        {
             this.stylar = stylar;
         }
 
         @NonNull
-        public <T> Builder useEditHandler(@NonNull EditHandler<T> handler) {
+        public <T> Builder useEditHandler(@NonNull EditHandler<T> handler)
+        {
             this.editHandlers.put(handler.markdownSpanType(), handler);
             return this;
         }
@@ -116,72 +134,72 @@ public abstract class StylarEditor
          * @param factory to create a new instance of the span
          */
         @NonNull
-        public <T> Builder punctuationSpan(@NonNull Class<T> type, @NonNull PersistedSpans.SpanFactory<T> factory) {
+        public <T> Builder punctuationSpan(@NonNull Class<T> type, @NonNull PersistedSpans.SpanFactory<T> factory)
+        {
             this.punctuationSpanType = type;
             this.persistedSpansProvider.persistSpan(type, factory);
             return this;
         }
 
         @NonNull
-        public StylarEditor build() {
+        public StylarEditor build()
+        {
 
             Class<?> punctuationSpanType = this.punctuationSpanType;
-            if (punctuationSpanType == null) {
-                punctuationSpan(PunctuationSpan.class, new PersistedSpans.SpanFactory<PunctuationSpan>() {
+            if (punctuationSpanType == null)
+            {
+                punctuationSpan(PunctuationSpan.class, new PersistedSpans.SpanFactory<PunctuationSpan>()
+                {
                     @NonNull
                     @Override
-                    public PunctuationSpan create() {
+                    public PunctuationSpan create()
+                    {
                         return new PunctuationSpan();
                     }
                 });
                 punctuationSpanType = this.punctuationSpanType;
             }
 
-            for (EditHandler handler : editHandlers.values()) {
+            for (EditHandler handler : editHandlers.values())
+            {
                 handler.init(stylar);
                 handler.configurePersistedSpans(persistedSpansProvider);
             }
 
             final SpansHandler spansHandler = editHandlers.size() == 0
-                    ? null
-                    : new SpansHandlerImpl(editHandlers);
+                ? null
+                : new SpansHandlerImpl(editHandlers);
 
             return new StylarEditorImpl(
                 stylar,
-                    persistedSpansProvider,
-                    punctuationSpanType,
-                    spansHandler);
+                persistedSpansProvider,
+                punctuationSpanType,
+                spansHandler);
         }
     }
 
-    interface SpansHandler {
-        void handle(
-                @NonNull PersistedSpans spans,
-                @NonNull Editable editable,
-                @NonNull String input,
-                @NonNull Object span,
-                int spanStart,
-                int spanTextLength);
-    }
-
-    static class SpansHandlerImpl implements SpansHandler {
+    static class SpansHandlerImpl implements SpansHandler
+    {
 
         private final Map<Class<?>, EditHandler> spanHandlers;
 
-        SpansHandlerImpl(@NonNull Map<Class<?>, EditHandler> spanHandlers) {
+        SpansHandlerImpl(@NonNull Map<Class<?>, EditHandler> spanHandlers)
+        {
             this.spanHandlers = spanHandlers;
         }
 
         @Override
         public void handle(
-                @NonNull PersistedSpans spans,
-                @NonNull Editable editable,
-                @NonNull String input,
-                @NonNull Object span,
-                int spanStart,
-                int spanTextLength) {
+            @NonNull PersistedSpans spans,
+            @NonNull Editable editable,
+            @NonNull String input,
+            @NonNull Object span,
+            int spanStart,
+            int spanTextLength)
+        {
             final EditHandler handler = spanHandlers.get(span.getClass());
-            if (handler != null) {
+            if (handler != null)
+            {
                 //noinspection unchecked
                 handler.handleMarkdownSpan(spans, editable, input, span, spanStart, spanTextLength);
             }

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditorImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditorImpl.java
@@ -24,10 +24,11 @@ class StylarEditorImpl extends StylarEditor
     private final SpansHandler spansHandler;
 
     StylarEditorImpl(
-            @NonNull Stylar stylar,
-            @NonNull PersistedSpans.Provider persistedSpansProvider,
-            @NonNull Class<?> punctuationSpanType,
-            @Nullable SpansHandler spansHandler) {
+        @NonNull Stylar stylar,
+        @NonNull PersistedSpans.Provider persistedSpansProvider,
+        @NonNull Class<?> punctuationSpanType,
+        @Nullable SpansHandler spansHandler)
+    {
         this.stylar = stylar;
         this.persistedSpansProvider = persistedSpansProvider;
         this.punctuationSpanType = punctuationSpanType;
@@ -35,7 +36,8 @@ class StylarEditorImpl extends StylarEditor
     }
 
     @Override
-    public void process(@NonNull Editable editable) {
+    public void process(@NonNull Editable editable)
+    {
 
         final String input = editable.toString();
 
@@ -50,16 +52,19 @@ class StylarEditorImpl extends StylarEditor
         final boolean hasAdditionalSpans = spansHandler != null;
 
         final PersistedSpans persistedSpans = persistedSpansProvider.provide(editable);
-        try {
+        try
+        {
 
             final List<diff_match_patch.Diff> diffs = diff_match_patch.diff_main(input, markdown);
 
             int inputLength = 0;
             int markdownLength = 0;
 
-            for (diff_match_patch.Diff diff : diffs) {
+            for (diff_match_patch.Diff diff : diffs)
+            {
 
-                switch (diff.operation) {
+                switch (diff.operation)
+                {
 
                     case DELETE:
 
@@ -67,28 +72,31 @@ class StylarEditorImpl extends StylarEditor
                         inputLength += diff.text.length();
 
                         editable.setSpan(
-                                persistedSpans.get(punctuationSpanType),
-                                start,
-                                inputLength,
-                                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                            persistedSpans.get(punctuationSpanType),
+                            start,
+                            inputLength,
+                            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                         );
 
-                        if (hasAdditionalSpans) {
+                        if (hasAdditionalSpans)
+                        {
                             // obtain spans for a single character of renderedMarkdown
                             //  editable here should return all spans that are contained in specified
                             //  region. Later we match if span starts at current position
                             //  and notify additional span handler about it
                             final Object[] spans = renderedMarkdown.getSpans(markdownLength, markdownLength + 1, Object.class);
-                            for (Object span : spans) {
-                                if (markdownLength == renderedMarkdown.getSpanStart(span)) {
+                            for (Object span : spans)
+                            {
+                                if (markdownLength == renderedMarkdown.getSpanStart(span))
+                                {
 
                                     spansHandler.handle(
-                                            persistedSpans,
-                                            editable,
-                                            input,
-                                            span,
-                                            start,
-                                            renderedMarkdown.getSpanEnd(span) - markdownLength);
+                                        persistedSpans,
+                                        editable,
+                                        input,
+                                        span,
+                                        start,
+                                        renderedMarkdown.getSpanEnd(span) - markdownLength);
                                     // NB, we do not break here in case of SpanFactory
                                     // returns multiple spans for a markdown node, this way
                                     // we will handle all of them
@@ -116,22 +124,26 @@ class StylarEditorImpl extends StylarEditor
                         // it is possible that there are spans for the text that is the same
                         //  for example, if some links were _autolinked_ (text is the same,
                         //  but there is an additional URLSpan)
-                        if (hasAdditionalSpans) {
+                        if (hasAdditionalSpans)
+                        {
                             final Object[] spans = renderedMarkdown.getSpans(markdownStart, markdownLength, Object.class);
-                            for (Object span : spans) {
+                            for (Object span : spans)
+                            {
                                 final int spanStart = renderedMarkdown.getSpanStart(span);
-                                if (spanStart >= markdownStart) {
+                                if (spanStart >= markdownStart)
+                                {
                                     final int end = renderedMarkdown.getSpanEnd(span);
-                                    if (end <= markdownLength) {
+                                    if (end <= markdownLength)
+                                    {
 
                                         spansHandler.handle(
-                                                persistedSpans,
-                                                editable,
-                                                input,
-                                                span,
-                                                // shift span to input position (can be different from the text itself)
-                                                inputStart + (spanStart - markdownStart),
-                                                end - spanStart
+                                            persistedSpans,
+                                            editable,
+                                            input,
+                                            span,
+                                            // shift span to input position (can be different from the text itself)
+                                            inputStart + (spanStart - markdownStart),
+                                            end - spanStart
                                         );
 
                                         renderedMarkdown.removeSpan(span);
@@ -146,42 +158,51 @@ class StylarEditorImpl extends StylarEditor
                 }
             }
 
-        } finally {
+        } finally
+        {
             persistedSpans.removeUnused();
         }
     }
 
     @Override
-    public void preRender(@NonNull final Editable editable, @NonNull PreRenderResultListener listener) {
+    public void preRender(@NonNull final Editable editable, @NonNull PreRenderResultListener listener)
+    {
         final RecordingSpannableStringBuilder builder = new RecordingSpannableStringBuilder(editable);
         process(builder);
-        listener.onPreRenderResult(new PreRenderResult() {
+        listener.onPreRenderResult(new PreRenderResult()
+        {
             @NonNull
             @Override
-            public Editable resultEditable() {
+            public Editable resultEditable()
+            {
                 // if they are the same, they should be equals then (what about additional spans?? like cursor? it should not interfere....)
                 return builder;
             }
 
             @Override
-            public void dispatchTo(@NonNull Editable e) {
-                for (Span span : builder.applied) {
+            public void dispatchTo(@NonNull Editable e)
+            {
+                for (Span span : builder.applied)
+                {
                     e.setSpan(span.what, span.start, span.end, span.flags);
                 }
-                for (Object span : builder.removed) {
+                for (Object span : builder.removed)
+                {
                     e.removeSpan(span);
                 }
             }
         });
     }
 
-    private static class Span {
+    private static class Span
+    {
         final Object what;
         final int start;
         final int end;
         final int flags;
 
-        Span(Object what, int start, int end, int flags) {
+        Span(Object what, int start, int end, int flags)
+        {
             this.what = what;
             this.start = start;
             this.end = end;
@@ -189,23 +210,27 @@ class StylarEditorImpl extends StylarEditor
         }
     }
 
-    private static class RecordingSpannableStringBuilder extends SpannableStringBuilder {
+    private static class RecordingSpannableStringBuilder extends SpannableStringBuilder
+    {
 
         final List<Span> applied = new ArrayList<>(3);
         final List<Object> removed = new ArrayList<>(0);
 
-        RecordingSpannableStringBuilder(CharSequence text) {
+        RecordingSpannableStringBuilder(CharSequence text)
+        {
             super(text);
         }
 
         @Override
-        public void setSpan(Object what, int start, int end, int flags) {
+        public void setSpan(Object what, int start, int end, int flags)
+        {
             super.setSpan(what, start, end, flags);
             applied.add(new Span(what, start, end, flags));
         }
 
         @Override
-        public void removeSpan(Object what) {
+        public void removeSpan(Object what)
+        {
             super.removeSpan(what);
             removed.add(what);
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditorTextWatcher.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditorTextWatcher.java
@@ -22,18 +22,21 @@ import java.util.concurrent.Future;
  * @see #withPreRender(StylarEditor, ExecutorService, EditText)
  * @since 4.2.0
  */
-public abstract class StylarEditorTextWatcher implements TextWatcher {
+public abstract class StylarEditorTextWatcher implements TextWatcher
+{
 
     @NonNull
-    public static StylarEditorTextWatcher withProcess(@NonNull StylarEditor editor) {
+    public static StylarEditorTextWatcher withProcess(@NonNull StylarEditor editor)
+    {
         return new WithProcess(editor);
     }
 
     @NonNull
     public static StylarEditorTextWatcher withPreRender(
-            @NonNull StylarEditor editor,
-            @NonNull ExecutorService executorService,
-            @NonNull EditText editText) {
+        @NonNull StylarEditor editor,
+        @NonNull ExecutorService executorService,
+        @NonNull EditText editText)
+    {
         return new WithPreRender(editor, executorService, editText);
     }
 
@@ -41,12 +44,14 @@ public abstract class StylarEditorTextWatcher implements TextWatcher {
     public abstract void afterTextChanged(Editable s);
 
     @Override
-    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    public void beforeTextChanged(CharSequence s, int start, int count, int after)
+    {
 
     }
 
     @Override
-    public void onTextChanged(CharSequence s, int start, int before, int count) {
+    public void onTextChanged(CharSequence s, int start, int before, int count)
+    {
 
     }
 
@@ -58,21 +63,26 @@ public abstract class StylarEditorTextWatcher implements TextWatcher {
 
         private boolean selfChange;
 
-        WithProcess(@NonNull StylarEditor editor) {
+        WithProcess(@NonNull StylarEditor editor)
+        {
             this.editor = editor;
         }
 
         @Override
-        public void afterTextChanged(Editable s) {
+        public void afterTextChanged(Editable s)
+        {
 
-            if (selfChange) {
+            if (selfChange)
+            {
                 return;
             }
 
             selfChange = true;
-            try {
+            try
+            {
                 editor.process(s);
-            } finally {
+            } finally
+            {
                 selfChange = false;
             }
         }
@@ -96,61 +106,80 @@ public abstract class StylarEditorTextWatcher implements TextWatcher {
         private boolean selfChange;
 
         WithPreRender(
-                @NonNull StylarEditor editor,
-                @NonNull ExecutorService executorService,
-                @NonNull EditText editText) {
+            @NonNull StylarEditor editor,
+            @NonNull ExecutorService executorService,
+            @NonNull EditText editText)
+        {
             this.editor = editor;
             this.executorService = executorService;
             this.editText = editText;
-            this.editText.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+            this.editText.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener()
+            {
                 @Override
-                public void onViewAttachedToWindow(View v) {
+                public void onViewAttachedToWindow(View v)
+                {
 
                 }
 
                 @Override
-                public void onViewDetachedFromWindow(View v) {
+                public void onViewDetachedFromWindow(View v)
+                {
                     WithPreRender.this.editText = null;
                 }
             });
         }
 
         @Override
-        public void afterTextChanged(Editable s) {
+        public void afterTextChanged(Editable s)
+        {
 
-            if (selfChange) {
+            if (selfChange)
+            {
                 return;
             }
 
             // both will be the same here (generator incremented and key assigned incremented value)
             final int key = ++this.generator;
 
-            if (future != null) {
+            if (future != null)
+            {
                 future.cancel(true);
             }
 
             // copy current content (it's not good to pass EditText editable to other thread)
             final SpannableStringBuilder builder = new SpannableStringBuilder(s);
 
-            future = executorService.submit(new Runnable() {
+            future = executorService.submit(new Runnable()
+            {
                 @Override
-                public void run() {
-                    try {
-                        editor.preRender(builder, new StylarEditor.PreRenderResultListener() {
+                public void run()
+                {
+                    try
+                    {
+                        editor.preRender(builder, new StylarEditor.PreRenderResultListener()
+                        {
                             @Override
-                            public void onPreRenderResult(@NonNull final StylarEditor.PreRenderResult result) {
+                            public void onPreRenderResult(@NonNull final StylarEditor.PreRenderResult result)
+                            {
                                 final EditText et = editText;
-                                if (et != null) {
-                                    et.post(new Runnable() {
+                                if (et != null)
+                                {
+                                    et.post(new Runnable()
+                                    {
                                         @Override
-                                        public void run() {
-                                            if (key == generator) {
+                                        public void run()
+                                        {
+                                            if (key == generator)
+                                            {
                                                 final EditText et = editText;
-                                                if (et != null) {
+                                                if (et != null)
+                                                {
                                                     selfChange = true;
-                                                    try {
+                                                    try
+                                                    {
                                                         result.dispatchTo(editText.getText());
-                                                    } finally {
+                                                    } finally
+                                                    {
                                                         selfChange = false;
                                                     }
                                                 }
@@ -160,13 +189,17 @@ public abstract class StylarEditorTextWatcher implements TextWatcher {
                                 }
                             }
                         });
-                    } catch (final Throwable t) {
+                    } catch (final Throwable t)
+                    {
                         final EditText et = editText;
-                        if (et != null) {
+                        if (et != null)
+                        {
                             // propagate exception to main thread
-                            et.post(new Runnable() {
+                            et.post(new Runnable()
+                            {
                                 @Override
-                                public void run() {
+                                public void run()
+                                {
                                     throw new RuntimeException(t);
                                 }
                             });

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditorUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/StylarEditorUtils.java
@@ -17,19 +17,27 @@ import java.util.Map;
 public abstract class StylarEditorUtils
 {
 
+    private StylarEditorUtils()
+    {
+    }
+
     @NonNull
-    public static Map<Class<?>, List<Object>> extractSpans(@NonNull Spanned spanned, @NonNull Collection<Class<?>> types) {
+    public static Map<Class<?>, List<Object>> extractSpans(@NonNull Spanned spanned, @NonNull Collection<Class<?>> types)
+    {
 
         final Object[] spans = spanned.getSpans(0, spanned.length(), Object.class);
         final Map<Class<?>, List<Object>> map = new HashMap<>(3);
 
         Class<?> type;
 
-        for (Object span : spans) {
+        for (Object span : spans)
+        {
             type = span.getClass();
-            if (types.contains(type)) {
+            if (types.contains(type))
+            {
                 List<Object> list = map.get(type);
-                if (list == null) {
+                if (list == null)
+                {
                     list = new ArrayList<>(3);
                     map.put(type, list);
                 }
@@ -40,23 +48,16 @@ public abstract class StylarEditorUtils
         return map;
     }
 
-    public interface Match {
-
-        @NonNull
-        String delimiter();
-
-        int start();
-
-        int end();
-    }
-
     @Nullable
-    public static Match findDelimited(@NonNull String input, int startFrom, @NonNull String delimiter) {
+    public static Match findDelimited(@NonNull String input, int startFrom, @NonNull String delimiter)
+    {
         final int start = input.indexOf(delimiter, startFrom);
-        if (start > -1) {
+        if (start > -1)
+        {
             final int length = delimiter.length();
             final int end = input.indexOf(delimiter, start + length);
-            if (end > -1) {
+            if (end > -1)
+            {
                 return new MatchImpl(delimiter, start, end + length);
             }
         }
@@ -65,10 +66,11 @@ public abstract class StylarEditorUtils
 
     @Nullable
     public static Match findDelimited(
-            @NonNull String input,
-            int start,
-            @NonNull String delimiter1,
-            @NonNull String delimiter2) {
+        @NonNull String input,
+        int start,
+        @NonNull String delimiter1,
+        @NonNull String delimiter2)
+    {
 
         final int l1 = delimiter1.length();
         final int l2 = delimiter2.length();
@@ -81,22 +83,28 @@ public abstract class StylarEditorUtils
 
         Match match;
 
-        for (int i = start, length = input.length(); i < length; i++) {
+        for (int i = start, length = input.length(); i < length; i++)
+        {
             c = input.charAt(i);
 
             // if this char is the same as previous (and we obviously have no match) -> skip
-            if (c == previousC) {
+            if (c == previousC)
+            {
                 continue;
             }
 
-            if (c == c1) {
+            if (c == c1)
+            {
                 match = matchDelimiter(input, i, length, delimiter1, l1);
-                if (match != null) {
+                if (match != null)
+                {
                     return match;
                 }
-            } else if (c == c2) {
+            } else if (c == c2)
+            {
                 match = matchDelimiter(input, i, length, delimiter2, l2);
-                if (match != null) {
+                if (match != null)
+                {
                     return match;
                 }
             }
@@ -110,28 +118,34 @@ public abstract class StylarEditorUtils
     // This method assumes that first char is matched already
     @Nullable
     private static Match matchDelimiter(
-            @NonNull String input,
-            int start,
-            int length,
-            @NonNull String delimiter,
-            int delimiterLength) {
+        @NonNull String input,
+        int start,
+        int length,
+        @NonNull String delimiter,
+        int delimiterLength)
+    {
 
-        if (start + delimiterLength < length) {
+        if (start + delimiterLength < length)
+        {
 
             boolean result = true;
 
-            for (int i = 1; i < delimiterLength; i++) {
-                if (input.charAt(start + i) != delimiter.charAt(i)) {
+            for (int i = 1; i < delimiterLength; i++)
+            {
+                if (input.charAt(start + i) != delimiter.charAt(i))
+                {
                     result = false;
                     break;
                 }
             }
 
-            if (result) {
+            if (result)
+            {
                 // find end
                 final int end = input.indexOf(delimiter, start + delimiterLength);
                 // it's important to check if match has content
-                if (end > -1 && (end - start) > delimiterLength) {
+                if (end > -1 && (end - start) > delimiterLength)
+                {
                     return new MatchImpl(delimiter, start, end + delimiterLength);
                 }
             }
@@ -140,16 +154,26 @@ public abstract class StylarEditorUtils
         return null;
     }
 
-    private StylarEditorUtils() {
+    public interface Match
+    {
+
+        @NonNull
+        String delimiter();
+
+        int start();
+
+        int end();
     }
 
-    private static class MatchImpl implements Match {
+    private static class MatchImpl implements Match
+    {
 
         private final String delimiter;
         private final int start;
         private final int end;
 
-        MatchImpl(@NonNull String delimiter, int start, int end) {
+        MatchImpl(@NonNull String delimiter, int start, int end)
+        {
             this.delimiter = delimiter;
             this.start = start;
             this.end = end;
@@ -157,28 +181,32 @@ public abstract class StylarEditorUtils
 
         @NonNull
         @Override
-        public String delimiter() {
+        public String delimiter()
+        {
             return delimiter;
         }
 
         @Override
-        public int start() {
+        public int start()
+        {
             return start;
         }
 
         @Override
-        public int end() {
+        public int end()
+        {
             return end;
         }
 
         @Override
         @NonNull
-        public String toString() {
+        public String toString()
+        {
             return "MatchImpl{" +
-                    "delimiter='" + delimiter + '\'' +
-                    ", start=" + start +
-                    ", end=" + end +
-                    '}';
+                "delimiter='" + delimiter + '\'' +
+                ", start=" + start +
+                ", end=" + end +
+                '}';
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/diff_match_patch.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/diff_match_patch.java
@@ -40,7 +40,8 @@ import java.util.regex.Pattern;
  * Class containing the diff, match and patch methods.
  * Also contains the behaviour settings.
  */
-class diff_match_patch {
+class diff_match_patch
+{
 
     // Defaults.
     // Set these on your diff_match_patch instance to override the defaults.
@@ -80,38 +81,14 @@ class diff_match_patch {
 //     */
 //    private short Match_MaxBits = 32;
 
-    /**
-     * Internal class for returning results from diff_linesToChars().
-     * Other less paranoid languages just use a three-element array.
-     */
-    protected static class LinesToCharsResult {
-        protected String chars1;
-        protected String chars2;
-        protected List<String> lineArray;
-
-        protected LinesToCharsResult(String chars1, String chars2,
-                                     List<String> lineArray) {
-            this.chars1 = chars1;
-            this.chars2 = chars2;
-            this.lineArray = lineArray;
-        }
-    }
+    // Define some regex patterns for matching boundaries.
+    private static final Pattern BLANKLINEEND
+        = Pattern.compile("\\n\\r?\\n\\Z", Pattern.DOTALL);
 
 
     //  DIFF FUNCTIONS
-
-
-    /**
-     * The data structure representing a diff is a Linked list of Diff objects:
-     * {Diff(Operation.DELETE, "Hello"), Diff(Operation.INSERT, "Goodbye"),
-     * Diff(Operation.EQUAL, " world.")}
-     * which means: delete "Hello", add "Goodbye" and keep " world."
-     */
-    public enum Operation {
-        DELETE,
-        INSERT,
-        EQUAL
-    }
+    private static final Pattern BLANKLINESTART
+        = Pattern.compile("\\A\\r?\\n\\r?\\n", Pattern.DOTALL);
 
     /**
      * Find the differences between two texts.
@@ -123,7 +100,8 @@ class diff_match_patch {
      * @param text2 New string to be diffed.
      * @return Linked List of Diff objects.
      */
-    static LinkedList<Diff> diff_main(String text1, String text2) {
+    static LinkedList<Diff> diff_main(String text1, String text2)
+    {
         return diff_main(text1, text2, true);
     }
 
@@ -153,17 +131,21 @@ class diff_match_patch {
      *                   If true, then run a faster slightly less optimal diff.
      * @return Linked List of Diff objects.
      */
-    private static LinkedList<Diff> diff_main(String text1, String text2, boolean checklines) {
+    private static LinkedList<Diff> diff_main(String text1, String text2, boolean checklines)
+    {
         // Check for null inputs.
-        if (text1 == null || text2 == null) {
+        if (text1 == null || text2 == null)
+        {
             throw new IllegalArgumentException("Null inputs. (diff_main)");
         }
 
         // Check for equality (speedup).
         LinkedList<Diff> diffs;
-        if (text1.equals(text2)) {
+        if (text1.equals(text2))
+        {
             diffs = new LinkedList<Diff>();
-            if (text1.length() != 0) {
+            if (text1.length() != 0)
+            {
                 diffs.add(new Diff(Operation.EQUAL, text1));
             }
             return diffs;
@@ -185,10 +167,12 @@ class diff_match_patch {
         diffs = diff_compute(text1, text2, checklines);
 
         // Restore the prefix and suffix.
-        if (commonprefix.length() != 0) {
+        if (commonprefix.length() != 0)
+        {
             diffs.addFirst(new Diff(Operation.EQUAL, commonprefix));
         }
-        if (commonsuffix.length() != 0) {
+        if (commonsuffix.length() != 0)
+        {
             diffs.addLast(new Diff(Operation.EQUAL, commonsuffix));
         }
 
@@ -208,16 +192,19 @@ class diff_match_patch {
      * @return Linked List of Diff objects.
      */
     private static LinkedList<Diff> diff_compute(String text1, String text2,
-                                          boolean checklines) {
+                                                 boolean checklines)
+    {
         LinkedList<Diff> diffs = new LinkedList<Diff>();
 
-        if (text1.length() == 0) {
+        if (text1.length() == 0)
+        {
             // Just add some text (speedup).
             diffs.add(new Diff(Operation.INSERT, text2));
             return diffs;
         }
 
-        if (text2.length() == 0) {
+        if (text2.length() == 0)
+        {
             // Just delete some text (speedup).
             diffs.add(new Diff(Operation.DELETE, text1));
             return diffs;
@@ -226,17 +213,19 @@ class diff_match_patch {
         String longtext = text1.length() > text2.length() ? text1 : text2;
         String shorttext = text1.length() > text2.length() ? text2 : text1;
         int i = longtext.indexOf(shorttext);
-        if (i != -1) {
+        if (i != -1)
+        {
             // Shorter text is inside the longer text (speedup).
             Operation op = (text1.length() > text2.length()) ?
-                    Operation.DELETE : Operation.INSERT;
+                Operation.DELETE : Operation.INSERT;
             diffs.add(new Diff(op, longtext.substring(0, i)));
             diffs.add(new Diff(Operation.EQUAL, shorttext));
             diffs.add(new Diff(op, longtext.substring(i + shorttext.length())));
             return diffs;
         }
 
-        if (shorttext.length() == 1) {
+        if (shorttext.length() == 1)
+        {
             // Single character string.
             // After the previous speedup, the character can't be an equality.
             diffs.add(new Diff(Operation.DELETE, text1));
@@ -246,7 +235,8 @@ class diff_match_patch {
 
         // Check to see if the problem can be split in two.
         String[] hm = diff_halfMatch(text1, text2);
-        if (hm != null) {
+        if (hm != null)
+        {
             // A half-match was found, sort out the return data.
             String text1_a = hm[0];
             String text1_b = hm[1];
@@ -255,9 +245,9 @@ class diff_match_patch {
             String mid_common = hm[4];
             // Send both pairs off for separate processing.
             LinkedList<Diff> diffs_a = diff_main(text1_a, text2_a,
-                    checklines);
+                checklines);
             LinkedList<Diff> diffs_b = diff_main(text1_b, text2_b,
-                    checklines);
+                checklines);
             // Merge the results.
             diffs = diffs_a;
             diffs.add(new Diff(Operation.EQUAL, mid_common));
@@ -265,7 +255,8 @@ class diff_match_patch {
             return diffs;
         }
 
-        if (checklines && text1.length() > 100 && text2.length() > 100) {
+        if (checklines && text1.length() > 100 && text2.length() > 100)
+        {
             return diff_lineMode(text1, text2);
         }
 
@@ -277,11 +268,12 @@ class diff_match_patch {
      * greater accuracy.
      * This speedup can produce non-minimal diffs.
      *
-     * @param text1    Old string to be diffed.
-     * @param text2    New string to be diffed.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
      * @return Linked List of Diff objects.
      */
-    private static LinkedList<Diff> diff_lineMode(String text1, String text2) {
+    private static LinkedList<Diff> diff_lineMode(String text1, String text2)
+    {
         // Scan the text on a line-by-line basis first.
         LinesToCharsResult a = diff_linesToChars(text1, text2);
         text1 = a.chars1;
@@ -304,8 +296,10 @@ class diff_match_patch {
         String text_insert = "";
         ListIterator<Diff> pointer = diffs.listIterator();
         Diff thisDiff = pointer.next();
-        while (thisDiff != null) {
-            switch (thisDiff.operation) {
+        while (thisDiff != null)
+        {
+            switch (thisDiff.operation)
+            {
                 case INSERT:
                     count_insert++;
                     text_insert += thisDiff.text;
@@ -316,14 +310,17 @@ class diff_match_patch {
                     break;
                 case EQUAL:
                     // Upon reaching an equality, check for prior redundancies.
-                    if (count_delete >= 1 && count_insert >= 1) {
+                    if (count_delete >= 1 && count_insert >= 1)
+                    {
                         // Delete the offending records and add the merged ones.
                         pointer.previous();
-                        for (int j = 0; j < count_delete + count_insert; j++) {
+                        for (int j = 0; j < count_delete + count_insert; j++)
+                        {
                             pointer.previous();
                             pointer.remove();
                         }
-                        for (Diff subDiff : diff_main(text_delete, text_insert, false)) {
+                        for (Diff subDiff : diff_main(text_delete, text_insert, false))
+                        {
                             pointer.add(subDiff);
                         }
                     }
@@ -345,11 +342,12 @@ class diff_match_patch {
      * and return the recursively constructed diff.
      * See Myers 1986 paper: An O(ND) Difference Algorithm and Its Variations.
      *
-     * @param text1    Old string to be diffed.
-     * @param text2    New string to be diffed.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
      * @return LinkedList of Diff objects.
      */
-    private static LinkedList<Diff> diff_bisect(String text1, String text2) {
+    private static LinkedList<Diff> diff_bisect(String text1, String text2)
+    {
         // Cache the text lengths to prevent multiple calls.
         int text1_length = text1.length();
         int text2_length = text2.length();
@@ -358,7 +356,8 @@ class diff_match_patch {
         int v_length = 2 * max_d;
         int[] v1 = new int[v_length];
         int[] v2 = new int[v_length];
-        for (int x = 0; x < v_length; x++) {
+        for (int x = 0; x < v_length; x++)
+        {
             v1[x] = -1;
             v2[x] = -1;
         }
@@ -374,40 +373,50 @@ class diff_match_patch {
         int k1end = 0;
         int k2start = 0;
         int k2end = 0;
-        for (int d = 0; d < max_d; d++) {
+        for (int d = 0; d < max_d; d++)
+        {
 //            // Bail out if deadline is reached.
 //            if (System.currentTimeMillis() > deadline) {
 //                break;
 //            }
 
             // Walk the front path one step.
-            for (int k1 = -d + k1start; k1 <= d - k1end; k1 += 2) {
+            for (int k1 = -d + k1start; k1 <= d - k1end; k1 += 2)
+            {
                 int k1_offset = v_offset + k1;
                 int x1;
-                if (k1 == -d || (k1 != d && v1[k1_offset - 1] < v1[k1_offset + 1])) {
+                if (k1 == -d || (k1 != d && v1[k1_offset - 1] < v1[k1_offset + 1]))
+                {
                     x1 = v1[k1_offset + 1];
-                } else {
+                } else
+                {
                     x1 = v1[k1_offset - 1] + 1;
                 }
                 int y1 = x1 - k1;
                 while (x1 < text1_length && y1 < text2_length
-                        && text1.charAt(x1) == text2.charAt(y1)) {
+                    && text1.charAt(x1) == text2.charAt(y1))
+                {
                     x1++;
                     y1++;
                 }
                 v1[k1_offset] = x1;
-                if (x1 > text1_length) {
+                if (x1 > text1_length)
+                {
                     // Ran off the right of the graph.
                     k1end += 2;
-                } else if (y1 > text2_length) {
+                } else if (y1 > text2_length)
+                {
                     // Ran off the bottom of the graph.
                     k1start += 2;
-                } else if (front) {
+                } else if (front)
+                {
                     int k2_offset = v_offset + delta - k1;
-                    if (k2_offset >= 0 && k2_offset < v_length && v2[k2_offset] != -1) {
+                    if (k2_offset >= 0 && k2_offset < v_length && v2[k2_offset] != -1)
+                    {
                         // Mirror x2 onto top-left coordinate system.
                         int x2 = text1_length - v2[k2_offset];
-                        if (x1 >= x2) {
+                        if (x1 >= x2)
+                        {
                             // Overlap detected.
                             return diff_bisectSplit(text1, text2, x1, y1);
                         }
@@ -416,36 +425,45 @@ class diff_match_patch {
             }
 
             // Walk the reverse path one step.
-            for (int k2 = -d + k2start; k2 <= d - k2end; k2 += 2) {
+            for (int k2 = -d + k2start; k2 <= d - k2end; k2 += 2)
+            {
                 int k2_offset = v_offset + k2;
                 int x2;
-                if (k2 == -d || (k2 != d && v2[k2_offset - 1] < v2[k2_offset + 1])) {
+                if (k2 == -d || (k2 != d && v2[k2_offset - 1] < v2[k2_offset + 1]))
+                {
                     x2 = v2[k2_offset + 1];
-                } else {
+                } else
+                {
                     x2 = v2[k2_offset - 1] + 1;
                 }
                 int y2 = x2 - k2;
                 while (x2 < text1_length && y2 < text2_length
-                        && text1.charAt(text1_length - x2 - 1)
-                        == text2.charAt(text2_length - y2 - 1)) {
+                    && text1.charAt(text1_length - x2 - 1)
+                    == text2.charAt(text2_length - y2 - 1))
+                {
                     x2++;
                     y2++;
                 }
                 v2[k2_offset] = x2;
-                if (x2 > text1_length) {
+                if (x2 > text1_length)
+                {
                     // Ran off the left of the graph.
                     k2end += 2;
-                } else if (y2 > text2_length) {
+                } else if (y2 > text2_length)
+                {
                     // Ran off the top of the graph.
                     k2start += 2;
-                } else if (!front) {
+                } else if (!front)
+                {
                     int k1_offset = v_offset + delta - k2;
-                    if (k1_offset >= 0 && k1_offset < v_length && v1[k1_offset] != -1) {
+                    if (k1_offset >= 0 && k1_offset < v_length && v1[k1_offset] != -1)
+                    {
                         int x1 = v1[k1_offset];
                         int y1 = v_offset + x1 - k1_offset;
                         // Mirror x2 onto top-left coordinate system.
                         x2 = text1_length - x2;
-                        if (x1 >= x2) {
+                        if (x1 >= x2)
+                        {
                             // Overlap detected.
                             return diff_bisectSplit(text1, text2, x1, y1);
                         }
@@ -465,14 +483,15 @@ class diff_match_patch {
      * Given the location of the 'middle snake', split the diff in two parts
      * and recurse.
      *
-     * @param text1    Old string to be diffed.
-     * @param text2    New string to be diffed.
-     * @param x        Index of split point in text1.
-     * @param y        Index of split point in text2.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param x     Index of split point in text1.
+     * @param y     Index of split point in text2.
      * @return LinkedList of Diff objects.
      */
     private static LinkedList<Diff> diff_bisectSplit(String text1, String text2,
-                                              int x, int y) {
+                                                     int x, int y)
+    {
         String text1a = text1.substring(0, x);
         String text2a = text2.substring(0, y);
         String text1b = text1.substring(x);
@@ -496,7 +515,8 @@ class diff_match_patch {
      * the List of unique strings.  The zeroth element of the List of
      * unique strings is intentionally blank.
      */
-    private static LinesToCharsResult diff_linesToChars(String text1, String text2) {
+    private static LinesToCharsResult diff_linesToChars(String text1, String text2)
+    {
         List<String> lineArray = new ArrayList<String>();
         Map<String, Integer> lineHash = new HashMap<String, Integer>();
         // e.g. linearray[4] == "Hello\n"
@@ -523,7 +543,8 @@ class diff_match_patch {
      * @return Encoded string.
      */
     private static String diff_linesToCharsMunge(String text, List<String> lineArray,
-                                          Map<String, Integer> lineHash, int maxLines) {
+                                                 Map<String, Integer> lineHash, int maxLines)
+    {
         int lineStart = 0;
         int lineEnd = -1;
         String line;
@@ -531,17 +552,22 @@ class diff_match_patch {
         // Walk the text, pulling out a substring for each line.
         // text.split('\n') would would temporarily double our memory footprint.
         // Modifying text would create many large strings to garbage collect.
-        while (lineEnd < text.length() - 1) {
+        while (lineEnd < text.length() - 1)
+        {
             lineEnd = text.indexOf('\n', lineStart);
-            if (lineEnd == -1) {
+            if (lineEnd == -1)
+            {
                 lineEnd = text.length() - 1;
             }
             line = text.substring(lineStart, lineEnd + 1);
 
-            if (lineHash.containsKey(line)) {
+            if (lineHash.containsKey(line))
+            {
                 chars.append(String.valueOf((char) (int) lineHash.get(line)));
-            } else {
-                if (lineArray.size() == maxLines) {
+            } else
+            {
+                if (lineArray.size() == maxLines)
+                {
                     // Bail out at 65535 because
                     // String.valueOf((char) 65536).equals(String.valueOf(((char) 0)))
                     line = text.substring(lineStart);
@@ -564,11 +590,14 @@ class diff_match_patch {
      * @param lineArray List of unique strings.
      */
     private static void diff_charsToLines(List<Diff> diffs,
-                                     List<String> lineArray) {
+                                          List<String> lineArray)
+    {
         StringBuilder text;
-        for (Diff diff : diffs) {
+        for (Diff diff : diffs)
+        {
             text = new StringBuilder();
-            for (int j = 0; j < diff.text.length(); j++) {
+            for (int j = 0; j < diff.text.length(); j++)
+            {
                 text.append(lineArray.get(diff.text.charAt(j)));
             }
             diff.text = text.toString();
@@ -582,11 +611,14 @@ class diff_match_patch {
      * @param text2 Second string.
      * @return The number of characters common to the start of each string.
      */
-    public static int diff_commonPrefix(String text1, String text2) {
+    public static int diff_commonPrefix(String text1, String text2)
+    {
         // Performance analysis: https://neil.fraser.name/news/2007/10/09/
         int n = Math.min(text1.length(), text2.length());
-        for (int i = 0; i < n; i++) {
-            if (text1.charAt(i) != text2.charAt(i)) {
+        for (int i = 0; i < n; i++)
+        {
+            if (text1.charAt(i) != text2.charAt(i))
+            {
                 return i;
             }
         }
@@ -600,13 +632,16 @@ class diff_match_patch {
      * @param text2 Second string.
      * @return The number of characters common to the end of each string.
      */
-    private static int diff_commonSuffix(String text1, String text2) {
+    private static int diff_commonSuffix(String text1, String text2)
+    {
         // Performance analysis: https://neil.fraser.name/news/2007/10/09/
         int text1_length = text1.length();
         int text2_length = text2.length();
         int n = Math.min(text1_length, text2_length);
-        for (int i = 1; i <= n; i++) {
-            if (text1.charAt(text1_length - i) != text2.charAt(text2_length - i)) {
+        for (int i = 1; i <= n; i++)
+        {
+            if (text1.charAt(text1_length - i) != text2.charAt(text2_length - i))
+            {
                 return i - 1;
             }
         }
@@ -621,23 +656,28 @@ class diff_match_patch {
      * @return The number of characters common to the end of the first
      * string and the start of the second string.
      */
-    private static int diff_commonOverlap(String text1, String text2) {
+    private static int diff_commonOverlap(String text1, String text2)
+    {
         // Cache the text lengths to prevent multiple calls.
         int text1_length = text1.length();
         int text2_length = text2.length();
         // Eliminate the null case.
-        if (text1_length == 0 || text2_length == 0) {
+        if (text1_length == 0 || text2_length == 0)
+        {
             return 0;
         }
         // Truncate the longer string.
-        if (text1_length > text2_length) {
+        if (text1_length > text2_length)
+        {
             text1 = text1.substring(text1_length - text2_length);
-        } else if (text1_length < text2_length) {
+        } else if (text1_length < text2_length)
+        {
             text2 = text2.substring(0, text1_length);
         }
         int text_length = Math.min(text1_length, text2_length);
         // Quick check for the worst case.
-        if (text1.equals(text2)) {
+        if (text1.equals(text2))
+        {
             return text_length;
         }
 
@@ -646,15 +686,18 @@ class diff_match_patch {
         // Performance analysis: https://neil.fraser.name/news/2010/11/04/
         int best = 0;
         int length = 1;
-        while (true) {
+        while (true)
+        {
             String pattern = text1.substring(text_length - length);
             int found = text2.indexOf(pattern);
-            if (found == -1) {
+            if (found == -1)
+            {
                 return best;
             }
             length += found;
             if (found == 0 || text1.substring(text_length - length).equals(
-                    text2.substring(0, length))) {
+                text2.substring(0, length)))
+            {
                 best = length;
                 length++;
             }
@@ -672,40 +715,48 @@ class diff_match_patch {
      * suffix of text1, the prefix of text2, the suffix of text2 and the
      * common middle.  Or null if there was no match.
      */
-    private static String[] diff_halfMatch(String text1, String text2) {
+    private static String[] diff_halfMatch(String text1, String text2)
+    {
 //        if (Diff_Timeout <= 0) {
 //            // Don't risk returning a non-optimal diff if we have unlimited time.
 //            return null;
 //        }
         String longtext = text1.length() > text2.length() ? text1 : text2;
         String shorttext = text1.length() > text2.length() ? text2 : text1;
-        if (longtext.length() < 4 || shorttext.length() * 2 < longtext.length()) {
+        if (longtext.length() < 4 || shorttext.length() * 2 < longtext.length())
+        {
             return null;  // Pointless.
         }
 
         // First check if the second quarter is the seed for a half-match.
         String[] hm1 = diff_halfMatchI(longtext, shorttext,
-                (longtext.length() + 3) / 4);
+            (longtext.length() + 3) / 4);
         // Check again based on the third quarter.
         String[] hm2 = diff_halfMatchI(longtext, shorttext,
-                (longtext.length() + 1) / 2);
+            (longtext.length() + 1) / 2);
         String[] hm;
-        if (hm1 == null && hm2 == null) {
+        if (hm1 == null && hm2 == null)
+        {
             return null;
-        } else if (hm2 == null) {
+        } else if (hm2 == null)
+        {
             hm = hm1;
-        } else if (hm1 == null) {
+        } else if (hm1 == null)
+        {
             hm = hm2;
-        } else {
+        } else
+        {
             // Both matched.  Select the longest.
             hm = hm1[4].length() > hm2[4].length() ? hm1 : hm2;
         }
 
         // A half-match was found, sort out the return data.
-        if (text1.length() > text2.length()) {
+        if (text1.length() > text2.length())
+        {
             return hm;
             //return new String[]{hm[0], hm[1], hm[2], hm[3], hm[4]};
-        } else {
+        } else
+        {
             return new String[]{hm[2], hm[3], hm[0], hm[1], hm[4]};
         }
     }
@@ -721,31 +772,36 @@ class diff_match_patch {
      * suffix of longtext, the prefix of shorttext, the suffix of shorttext
      * and the common middle.  Or null if there was no match.
      */
-    private static String[] diff_halfMatchI(String longtext, String shorttext, int i) {
+    private static String[] diff_halfMatchI(String longtext, String shorttext, int i)
+    {
         // Start with a 1/4 length substring at position i as a seed.
         String seed = longtext.substring(i, i + longtext.length() / 4);
         int j = -1;
         String best_common = "";
         String best_longtext_a = "", best_longtext_b = "";
         String best_shorttext_a = "", best_shorttext_b = "";
-        while ((j = shorttext.indexOf(seed, j + 1)) != -1) {
+        while ((j = shorttext.indexOf(seed, j + 1)) != -1)
+        {
             int prefixLength = diff_commonPrefix(longtext.substring(i),
-                    shorttext.substring(j));
+                shorttext.substring(j));
             int suffixLength = diff_commonSuffix(longtext.substring(0, i),
-                    shorttext.substring(0, j));
-            if (best_common.length() < suffixLength + prefixLength) {
+                shorttext.substring(0, j));
+            if (best_common.length() < suffixLength + prefixLength)
+            {
                 best_common = shorttext.substring(j - suffixLength, j)
-                        + shorttext.substring(j, j + prefixLength);
+                    + shorttext.substring(j, j + prefixLength);
                 best_longtext_a = longtext.substring(0, i - suffixLength);
                 best_longtext_b = longtext.substring(i + prefixLength);
                 best_shorttext_a = shorttext.substring(0, j - suffixLength);
                 best_shorttext_b = shorttext.substring(j + prefixLength);
             }
         }
-        if (best_common.length() * 2 >= longtext.length()) {
+        if (best_common.length() * 2 >= longtext.length())
+        {
             return new String[]{best_longtext_a, best_longtext_b,
-                    best_shorttext_a, best_shorttext_b, best_common};
-        } else {
+                best_shorttext_a, best_shorttext_b, best_common};
+        } else
+        {
             return null;
         }
     }
@@ -755,8 +811,10 @@ class diff_match_patch {
      *
      * @param diffs LinkedList of Diff objects.
      */
-    private static void diff_cleanupSemantic(LinkedList<Diff> diffs) {
-        if (diffs.isEmpty()) {
+    private static void diff_cleanupSemantic(LinkedList<Diff> diffs)
+    {
+        if (diffs.isEmpty())
+        {
             return;
         }
         boolean changes = false;
@@ -770,8 +828,10 @@ class diff_match_patch {
         int length_insertions2 = 0;
         int length_deletions2 = 0;
         Diff thisDiff = pointer.next();
-        while (thisDiff != null) {
-            if (thisDiff.operation == Operation.EQUAL) {
+        while (thisDiff != null)
+        {
+            if (thisDiff.operation == Operation.EQUAL)
+            {
                 // Equality found.
                 equalities.push(thisDiff);
                 length_insertions1 = length_insertions2;
@@ -779,22 +839,27 @@ class diff_match_patch {
                 length_insertions2 = 0;
                 length_deletions2 = 0;
                 lastEquality = thisDiff.text;
-            } else {
+            } else
+            {
                 // An insertion or deletion.
-                if (thisDiff.operation == Operation.INSERT) {
+                if (thisDiff.operation == Operation.INSERT)
+                {
                     length_insertions2 += thisDiff.text.length();
-                } else {
+                } else
+                {
                     length_deletions2 += thisDiff.text.length();
                 }
                 // Eliminate an equality that is smaller or equal to the edits on both
                 // sides of it.
                 if (lastEquality != null && (lastEquality.length()
-                        <= Math.max(length_insertions1, length_deletions1))
-                        && (lastEquality.length()
-                        <= Math.max(length_insertions2, length_deletions2))) {
+                    <= Math.max(length_insertions1, length_deletions1))
+                    && (lastEquality.length()
+                    <= Math.max(length_insertions2, length_deletions2)))
+                {
                     //System.out.println("Splitting: '" + lastEquality + "'");
                     // Walk back to offending equality.
-                    while (thisDiff != equalities.peek()) {
+                    while (thisDiff != equalities.peek())
+                    {
                         thisDiff = pointer.previous();
                     }
                     pointer.next();
@@ -805,19 +870,24 @@ class diff_match_patch {
                     pointer.add(new Diff(Operation.INSERT, lastEquality));
 
                     equalities.pop();  // Throw away the equality we just deleted.
-                    if (!equalities.isEmpty()) {
+                    if (!equalities.isEmpty())
+                    {
                         // Throw away the previous equality (it needs to be reevaluated).
                         equalities.pop();
                     }
-                    if (equalities.isEmpty()) {
+                    if (equalities.isEmpty())
+                    {
                         // There are no previous equalities, walk back to the start.
-                        while (pointer.hasPrevious()) {
+                        while (pointer.hasPrevious())
+                        {
                             pointer.previous();
                         }
-                    } else {
+                    } else
+                    {
                         // There is a safe equality we can fall back to.
                         thisDiff = equalities.peek();
-                        while (thisDiff != pointer.previous()) {
+                        while (thisDiff != pointer.previous())
+                        {
                             // Intentionally empty loop.
                         }
                     }
@@ -834,7 +904,8 @@ class diff_match_patch {
         }
 
         // Normalize the diff.
-        if (changes) {
+        if (changes)
+        {
             diff_cleanupMerge(diffs);
         }
         diff_cleanupSemanticLossless(diffs);
@@ -848,43 +919,51 @@ class diff_match_patch {
         pointer = diffs.listIterator();
         Diff prevDiff = null;
         thisDiff = null;
-        if (pointer.hasNext()) {
+        if (pointer.hasNext())
+        {
             prevDiff = pointer.next();
-            if (pointer.hasNext()) {
+            if (pointer.hasNext())
+            {
                 thisDiff = pointer.next();
             }
         }
-        while (thisDiff != null) {
+        while (thisDiff != null)
+        {
             if (prevDiff.operation == Operation.DELETE &&
-                    thisDiff.operation == Operation.INSERT) {
+                thisDiff.operation == Operation.INSERT)
+            {
                 String deletion = prevDiff.text;
                 String insertion = thisDiff.text;
                 int overlap_length1 = diff_commonOverlap(deletion, insertion);
                 int overlap_length2 = diff_commonOverlap(insertion, deletion);
-                if (overlap_length1 >= overlap_length2) {
+                if (overlap_length1 >= overlap_length2)
+                {
                     if (overlap_length1 >= deletion.length() / 2.0 ||
-                            overlap_length1 >= insertion.length() / 2.0) {
+                        overlap_length1 >= insertion.length() / 2.0)
+                    {
                         // Overlap found. Insert an equality and trim the surrounding edits.
                         pointer.previous();
                         pointer.add(new Diff(Operation.EQUAL,
-                                insertion.substring(0, overlap_length1)));
+                            insertion.substring(0, overlap_length1)));
                         prevDiff.text =
-                                deletion.substring(0, deletion.length() - overlap_length1);
+                            deletion.substring(0, deletion.length() - overlap_length1);
                         thisDiff.text = insertion.substring(overlap_length1);
                         // pointer.add inserts the element before the cursor, so there is
                         // no need to step past the new element.
                     }
-                } else {
+                } else
+                {
                     if (overlap_length2 >= deletion.length() / 2.0 ||
-                            overlap_length2 >= insertion.length() / 2.0) {
+                        overlap_length2 >= insertion.length() / 2.0)
+                    {
                         // Reverse overlap found.
                         // Insert an equality and swap and trim the surrounding edits.
                         pointer.previous();
                         pointer.add(new Diff(Operation.EQUAL,
-                                deletion.substring(0, overlap_length2)));
+                            deletion.substring(0, overlap_length2)));
                         prevDiff.operation = Operation.INSERT;
                         prevDiff.text =
-                                insertion.substring(0, insertion.length() - overlap_length2);
+                            insertion.substring(0, insertion.length() - overlap_length2);
                         thisDiff.operation = Operation.DELETE;
                         thisDiff.text = deletion.substring(overlap_length2);
                         // pointer.add inserts the element before the cursor, so there is
@@ -905,7 +984,8 @@ class diff_match_patch {
      *
      * @param diffs LinkedList of Diff objects.
      */
-    private static void diff_cleanupSemanticLossless(LinkedList<Diff> diffs) {
+    private static void diff_cleanupSemanticLossless(LinkedList<Diff> diffs)
+    {
         String equality1, edit, equality2;
         String commonString;
         int commonOffset;
@@ -917,9 +997,11 @@ class diff_match_patch {
         Diff thisDiff = pointer.hasNext() ? pointer.next() : null;
         Diff nextDiff = pointer.hasNext() ? pointer.next() : null;
         // Intentionally ignore the first and last element (don't need checking).
-        while (nextDiff != null) {
+        while (nextDiff != null)
+        {
             if (prevDiff.operation == Operation.EQUAL &&
-                    nextDiff.operation == Operation.EQUAL) {
+                nextDiff.operation == Operation.EQUAL)
+            {
                 // This is a single edit surrounded by equalities.
                 equality1 = prevDiff.text;
                 edit = thisDiff.text;
@@ -927,7 +1009,8 @@ class diff_match_patch {
 
                 // First, shift the edit as far left as possible.
                 commonOffset = diff_commonSuffix(equality1, edit);
-                if (commonOffset != 0) {
+                if (commonOffset != 0)
+                {
                     commonString = edit.substring(edit.length() - commonOffset);
                     equality1 = equality1.substring(0, equality1.length() - commonOffset);
                     edit = commonString + edit.substring(0, edit.length() - commonOffset);
@@ -939,16 +1022,18 @@ class diff_match_patch {
                 bestEdit = edit;
                 bestEquality2 = equality2;
                 bestScore = diff_cleanupSemanticScore(equality1, edit)
-                        + diff_cleanupSemanticScore(edit, equality2);
+                    + diff_cleanupSemanticScore(edit, equality2);
                 while (edit.length() != 0 && equality2.length() != 0
-                        && edit.charAt(0) == equality2.charAt(0)) {
+                    && edit.charAt(0) == equality2.charAt(0))
+                {
                     equality1 += edit.charAt(0);
                     edit = edit.substring(1) + equality2.charAt(0);
                     equality2 = equality2.substring(1);
                     score = diff_cleanupSemanticScore(equality1, edit)
-                            + diff_cleanupSemanticScore(edit, equality2);
+                        + diff_cleanupSemanticScore(edit, equality2);
                     // The >= encourages trailing rather than leading whitespace on edits.
-                    if (score >= bestScore) {
+                    if (score >= bestScore)
+                    {
                         bestScore = score;
                         bestEquality1 = equality1;
                         bestEdit = edit;
@@ -956,11 +1041,14 @@ class diff_match_patch {
                     }
                 }
 
-                if (!prevDiff.text.equals(bestEquality1)) {
+                if (!prevDiff.text.equals(bestEquality1))
+                {
                     // We have an improvement, save it back to the diff.
-                    if (bestEquality1.length() != 0) {
+                    if (bestEquality1.length() != 0)
+                    {
                         prevDiff.text = bestEquality1;
-                    } else {
+                    } else
+                    {
                         pointer.previous(); // Walk past nextDiff.
                         pointer.previous(); // Walk past thisDiff.
                         pointer.previous(); // Walk past prevDiff.
@@ -969,9 +1057,11 @@ class diff_match_patch {
                         pointer.next(); // Walk past nextDiff.
                     }
                     thisDiff.text = bestEdit;
-                    if (bestEquality2.length() != 0) {
+                    if (bestEquality2.length() != 0)
+                    {
                         nextDiff.text = bestEquality2;
-                    } else {
+                    } else
+                    {
                         pointer.remove(); // Delete nextDiff.
                         nextDiff = thisDiff;
                         thisDiff = prevDiff;
@@ -993,8 +1083,10 @@ class diff_match_patch {
      * @param two Second string.
      * @return The score.
      */
-    private static int diff_cleanupSemanticScore(String one, String two) {
-        if (one.length() == 0 || two.length() == 0) {
+    private static int diff_cleanupSemanticScore(String one, String two)
+    {
+        if (one.length() == 0 || two.length() == 0)
+        {
             // Edges are the best.
             return 6;
         }
@@ -1011,36 +1103,218 @@ class diff_match_patch {
         boolean whitespace1 = nonAlphaNumeric1 && Character.isWhitespace(char1);
         boolean whitespace2 = nonAlphaNumeric2 && Character.isWhitespace(char2);
         boolean lineBreak1 = whitespace1
-                && Character.getType(char1) == Character.CONTROL;
+            && Character.getType(char1) == Character.CONTROL;
         boolean lineBreak2 = whitespace2
-                && Character.getType(char2) == Character.CONTROL;
+            && Character.getType(char2) == Character.CONTROL;
         boolean blankLine1 = lineBreak1 && BLANKLINEEND.matcher(one).find();
         boolean blankLine2 = lineBreak2 && BLANKLINESTART.matcher(two).find();
 
-        if (blankLine1 || blankLine2) {
+        if (blankLine1 || blankLine2)
+        {
             // Five points for blank lines.
             return 5;
-        } else if (lineBreak1 || lineBreak2) {
+        } else if (lineBreak1 || lineBreak2)
+        {
             // Four points for line breaks.
             return 4;
-        } else if (nonAlphaNumeric1 && !whitespace1 && whitespace2) {
+        } else if (nonAlphaNumeric1 && !whitespace1 && whitespace2)
+        {
             // Three points for end of sentences.
             return 3;
-        } else if (whitespace1 || whitespace2) {
+        } else if (whitespace1 || whitespace2)
+        {
             // Two points for whitespace.
             return 2;
-        } else if (nonAlphaNumeric1 || nonAlphaNumeric2) {
+        } else if (nonAlphaNumeric1 || nonAlphaNumeric2)
+        {
             // One point for non-alphanumeric.
             return 1;
         }
         return 0;
     }
 
-    // Define some regex patterns for matching boundaries.
-    private static final Pattern BLANKLINEEND
-            = Pattern.compile("\\n\\r?\\n\\Z", Pattern.DOTALL);
-    private static final Pattern BLANKLINESTART
-            = Pattern.compile("\\A\\r?\\n\\r?\\n", Pattern.DOTALL);
+    /**
+     * Reorder and merge like edit sections.  Merge equalities.
+     * Any edit section can move as long as it doesn't cross an equality.
+     *
+     * @param diffs LinkedList of Diff objects.
+     */
+    private static void diff_cleanupMerge(LinkedList<Diff> diffs)
+    {
+        diffs.add(new Diff(Operation.EQUAL, ""));  // Add a dummy entry at the end.
+        ListIterator<Diff> pointer = diffs.listIterator();
+        int count_delete = 0;
+        int count_insert = 0;
+        String text_delete = "";
+        String text_insert = "";
+        Diff thisDiff = pointer.next();
+        Diff prevEqual = null;
+        int commonlength;
+        while (thisDiff != null)
+        {
+            switch (thisDiff.operation)
+            {
+                case INSERT:
+                    count_insert++;
+                    text_insert += thisDiff.text;
+                    prevEqual = null;
+                    break;
+                case DELETE:
+                    count_delete++;
+                    text_delete += thisDiff.text;
+                    prevEqual = null;
+                    break;
+                case EQUAL:
+                    if (count_delete + count_insert > 1)
+                    {
+                        boolean both_types = count_delete != 0 && count_insert != 0;
+                        // Delete the offending records.
+                        pointer.previous();  // Reverse direction.
+                        while (count_delete-- > 0)
+                        {
+                            pointer.previous();
+                            pointer.remove();
+                        }
+                        while (count_insert-- > 0)
+                        {
+                            pointer.previous();
+                            pointer.remove();
+                        }
+                        if (both_types)
+                        {
+                            // Factor out any common prefixies.
+                            commonlength = diff_commonPrefix(text_insert, text_delete);
+                            if (commonlength != 0)
+                            {
+                                if (pointer.hasPrevious())
+                                {
+                                    thisDiff = pointer.previous();
+                                    assert thisDiff.operation == Operation.EQUAL
+                                        : "Previous diff should have been an equality.";
+                                    thisDiff.text += text_insert.substring(0, commonlength);
+                                    pointer.next();
+                                } else
+                                {
+                                    pointer.add(new Diff(Operation.EQUAL,
+                                        text_insert.substring(0, commonlength)));
+                                }
+                                text_insert = text_insert.substring(commonlength);
+                                text_delete = text_delete.substring(commonlength);
+                            }
+                            // Factor out any common suffixies.
+                            commonlength = diff_commonSuffix(text_insert, text_delete);
+                            if (commonlength != 0)
+                            {
+                                thisDiff = pointer.next();
+                                thisDiff.text = text_insert.substring(text_insert.length()
+                                    - commonlength) + thisDiff.text;
+                                text_insert = text_insert.substring(0, text_insert.length()
+                                    - commonlength);
+                                text_delete = text_delete.substring(0, text_delete.length()
+                                    - commonlength);
+                                pointer.previous();
+                            }
+                        }
+                        // Insert the merged records.
+                        if (text_delete.length() != 0)
+                        {
+                            pointer.add(new Diff(Operation.DELETE, text_delete));
+                        }
+                        if (text_insert.length() != 0)
+                        {
+                            pointer.add(new Diff(Operation.INSERT, text_insert));
+                        }
+                        // Step forward to the equality.
+                        thisDiff = pointer.hasNext() ? pointer.next() : null;
+                    } else if (prevEqual != null)
+                    {
+                        // Merge this equality with the previous one.
+                        prevEqual.text += thisDiff.text;
+                        pointer.remove();
+                        thisDiff = pointer.previous();
+                        pointer.next();  // Forward direction
+                    }
+                    count_insert = 0;
+                    count_delete = 0;
+                    text_delete = "";
+                    text_insert = "";
+                    prevEqual = thisDiff;
+                    break;
+            }
+            thisDiff = pointer.hasNext() ? pointer.next() : null;
+        }
+        if (diffs.getLast().text.length() == 0)
+        {
+            diffs.removeLast();  // Remove the dummy entry at the end.
+        }
+
+        /*
+         * Second pass: look for single edits surrounded on both sides by equalities
+         * which can be shifted sideways to eliminate an equality.
+         * e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
+         */
+        boolean changes = false;
+        // Create a new iterator at the start.
+        // (As opposed to walking the current one back.)
+        pointer = diffs.listIterator();
+        Diff prevDiff = pointer.hasNext() ? pointer.next() : null;
+        thisDiff = pointer.hasNext() ? pointer.next() : null;
+        Diff nextDiff = pointer.hasNext() ? pointer.next() : null;
+        // Intentionally ignore the first and last element (don't need checking).
+        while (nextDiff != null)
+        {
+            if (prevDiff.operation == Operation.EQUAL &&
+                nextDiff.operation == Operation.EQUAL)
+            {
+                // This is a single edit surrounded by equalities.
+                if (thisDiff.text.endsWith(prevDiff.text))
+                {
+                    // Shift the edit over the previous equality.
+                    thisDiff.text = prevDiff.text
+                        + thisDiff.text.substring(0, thisDiff.text.length()
+                        - prevDiff.text.length());
+                    nextDiff.text = prevDiff.text + nextDiff.text;
+                    pointer.previous(); // Walk past nextDiff.
+                    pointer.previous(); // Walk past thisDiff.
+                    pointer.previous(); // Walk past prevDiff.
+                    pointer.remove(); // Delete prevDiff.
+                    pointer.next(); // Walk past thisDiff.
+                    thisDiff = pointer.next(); // Walk past nextDiff.
+                    nextDiff = pointer.hasNext() ? pointer.next() : null;
+                    changes = true;
+                } else if (thisDiff.text.startsWith(nextDiff.text))
+                {
+                    // Shift the edit over the next equality.
+                    prevDiff.text += nextDiff.text;
+                    thisDiff.text = thisDiff.text.substring(nextDiff.text.length())
+                        + nextDiff.text;
+                    pointer.remove(); // Delete nextDiff.
+                    nextDiff = pointer.hasNext() ? pointer.next() : null;
+                    changes = true;
+                }
+            }
+            prevDiff = thisDiff;
+            thisDiff = nextDiff;
+            nextDiff = pointer.hasNext() ? pointer.next() : null;
+        }
+        // If shifts were made, the diff needs reordering and another shift sweep.
+        if (changes)
+        {
+            diff_cleanupMerge(diffs);
+        }
+    }
+    /**
+     * The data structure representing a diff is a Linked list of Diff objects:
+     * {Diff(Operation.DELETE, "Hello"), Diff(Operation.INSERT, "Goodbye"),
+     * Diff(Operation.EQUAL, " world.")}
+     * which means: delete "Hello", add "Goodbye" and keep " world."
+     */
+    public enum Operation
+    {
+        DELETE,
+        INSERT,
+        EQUAL
+    }
 
 //    /**
 //     * Reduce the number of edits by eliminating operationally trivial equalities.
@@ -1151,153 +1425,21 @@ class diff_match_patch {
 //    }
 
     /**
-     * Reorder and merge like edit sections.  Merge equalities.
-     * Any edit section can move as long as it doesn't cross an equality.
-     *
-     * @param diffs LinkedList of Diff objects.
+     * Internal class for returning results from diff_linesToChars().
+     * Other less paranoid languages just use a three-element array.
      */
-    private static void diff_cleanupMerge(LinkedList<Diff> diffs) {
-        diffs.add(new Diff(Operation.EQUAL, ""));  // Add a dummy entry at the end.
-        ListIterator<Diff> pointer = diffs.listIterator();
-        int count_delete = 0;
-        int count_insert = 0;
-        String text_delete = "";
-        String text_insert = "";
-        Diff thisDiff = pointer.next();
-        Diff prevEqual = null;
-        int commonlength;
-        while (thisDiff != null) {
-            switch (thisDiff.operation) {
-                case INSERT:
-                    count_insert++;
-                    text_insert += thisDiff.text;
-                    prevEqual = null;
-                    break;
-                case DELETE:
-                    count_delete++;
-                    text_delete += thisDiff.text;
-                    prevEqual = null;
-                    break;
-                case EQUAL:
-                    if (count_delete + count_insert > 1) {
-                        boolean both_types = count_delete != 0 && count_insert != 0;
-                        // Delete the offending records.
-                        pointer.previous();  // Reverse direction.
-                        while (count_delete-- > 0) {
-                            pointer.previous();
-                            pointer.remove();
-                        }
-                        while (count_insert-- > 0) {
-                            pointer.previous();
-                            pointer.remove();
-                        }
-                        if (both_types) {
-                            // Factor out any common prefixies.
-                            commonlength = diff_commonPrefix(text_insert, text_delete);
-                            if (commonlength != 0) {
-                                if (pointer.hasPrevious()) {
-                                    thisDiff = pointer.previous();
-                                    assert thisDiff.operation == Operation.EQUAL
-                                            : "Previous diff should have been an equality.";
-                                    thisDiff.text += text_insert.substring(0, commonlength);
-                                    pointer.next();
-                                } else {
-                                    pointer.add(new Diff(Operation.EQUAL,
-                                            text_insert.substring(0, commonlength)));
-                                }
-                                text_insert = text_insert.substring(commonlength);
-                                text_delete = text_delete.substring(commonlength);
-                            }
-                            // Factor out any common suffixies.
-                            commonlength = diff_commonSuffix(text_insert, text_delete);
-                            if (commonlength != 0) {
-                                thisDiff = pointer.next();
-                                thisDiff.text = text_insert.substring(text_insert.length()
-                                        - commonlength) + thisDiff.text;
-                                text_insert = text_insert.substring(0, text_insert.length()
-                                        - commonlength);
-                                text_delete = text_delete.substring(0, text_delete.length()
-                                        - commonlength);
-                                pointer.previous();
-                            }
-                        }
-                        // Insert the merged records.
-                        if (text_delete.length() != 0) {
-                            pointer.add(new Diff(Operation.DELETE, text_delete));
-                        }
-                        if (text_insert.length() != 0) {
-                            pointer.add(new Diff(Operation.INSERT, text_insert));
-                        }
-                        // Step forward to the equality.
-                        thisDiff = pointer.hasNext() ? pointer.next() : null;
-                    } else if (prevEqual != null) {
-                        // Merge this equality with the previous one.
-                        prevEqual.text += thisDiff.text;
-                        pointer.remove();
-                        thisDiff = pointer.previous();
-                        pointer.next();  // Forward direction
-                    }
-                    count_insert = 0;
-                    count_delete = 0;
-                    text_delete = "";
-                    text_insert = "";
-                    prevEqual = thisDiff;
-                    break;
-            }
-            thisDiff = pointer.hasNext() ? pointer.next() : null;
-        }
-        if (diffs.getLast().text.length() == 0) {
-            diffs.removeLast();  // Remove the dummy entry at the end.
-        }
+    protected static class LinesToCharsResult
+    {
+        protected String chars1;
+        protected String chars2;
+        protected List<String> lineArray;
 
-        /*
-         * Second pass: look for single edits surrounded on both sides by equalities
-         * which can be shifted sideways to eliminate an equality.
-         * e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
-         */
-        boolean changes = false;
-        // Create a new iterator at the start.
-        // (As opposed to walking the current one back.)
-        pointer = diffs.listIterator();
-        Diff prevDiff = pointer.hasNext() ? pointer.next() : null;
-        thisDiff = pointer.hasNext() ? pointer.next() : null;
-        Diff nextDiff = pointer.hasNext() ? pointer.next() : null;
-        // Intentionally ignore the first and last element (don't need checking).
-        while (nextDiff != null) {
-            if (prevDiff.operation == Operation.EQUAL &&
-                    nextDiff.operation == Operation.EQUAL) {
-                // This is a single edit surrounded by equalities.
-                if (thisDiff.text.endsWith(prevDiff.text)) {
-                    // Shift the edit over the previous equality.
-                    thisDiff.text = prevDiff.text
-                            + thisDiff.text.substring(0, thisDiff.text.length()
-                            - prevDiff.text.length());
-                    nextDiff.text = prevDiff.text + nextDiff.text;
-                    pointer.previous(); // Walk past nextDiff.
-                    pointer.previous(); // Walk past thisDiff.
-                    pointer.previous(); // Walk past prevDiff.
-                    pointer.remove(); // Delete prevDiff.
-                    pointer.next(); // Walk past thisDiff.
-                    thisDiff = pointer.next(); // Walk past nextDiff.
-                    nextDiff = pointer.hasNext() ? pointer.next() : null;
-                    changes = true;
-                } else if (thisDiff.text.startsWith(nextDiff.text)) {
-                    // Shift the edit over the next equality.
-                    prevDiff.text += nextDiff.text;
-                    thisDiff.text = thisDiff.text.substring(nextDiff.text.length())
-                            + nextDiff.text;
-                    pointer.remove(); // Delete nextDiff.
-                    nextDiff = pointer.hasNext() ? pointer.next() : null;
-                    changes = true;
-                }
-            }
-            prevDiff = thisDiff;
-            thisDiff = nextDiff;
-            nextDiff = pointer.hasNext() ? pointer.next() : null;
-        }
-        // If shifts were made, the diff needs reordering and another shift sweep.
-        if (changes) {
-            diff_cleanupMerge(diffs);
+        protected LinesToCharsResult(String chars1, String chars2,
+                                     List<String> lineArray)
+        {
+            this.chars1 = chars1;
+            this.chars2 = chars2;
+            this.lineArray = lineArray;
         }
     }
 
@@ -2316,11 +2458,11 @@ class diff_match_patch {
 //        return patches;
 //    }
 
-
     /**
      * Class representing one diff operation.
      */
-    public static class Diff {
+    public static class Diff
+    {
         /**
          * One of: INSERT, DELETE or EQUAL.
          */
@@ -2336,7 +2478,8 @@ class diff_match_patch {
          * @param operation One of INSERT, DELETE or EQUAL.
          * @param text      The text being applied.
          */
-        public Diff(Operation operation, String text) {
+        public Diff(Operation operation, String text)
+        {
             // Construct a diff with the specified operation and text.
             this.operation = operation;
             this.text = text;
@@ -2347,7 +2490,8 @@ class diff_match_patch {
          *
          * @return text version.
          */
-        public String toString() {
+        public String toString()
+        {
             String prettyText = this.text.replace('\n', '\u00b6');
             return "Diff(" + this.operation + ",\"" + prettyText + "\")";
         }
@@ -2359,7 +2503,8 @@ class diff_match_patch {
          * @return Hash value.
          */
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             final int prime = 31;
             int result = (operation == null) ? 0 : operation.hashCode();
             result += prime * ((text == null) ? 0 : text.hashCode());
@@ -2373,25 +2518,33 @@ class diff_match_patch {
          * @return true or false.
          */
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
+        public boolean equals(Object obj)
+        {
+            if (this == obj)
+            {
                 return true;
             }
-            if (obj == null) {
+            if (obj == null)
+            {
                 return false;
             }
-            if (getClass() != obj.getClass()) {
+            if (getClass() != obj.getClass())
+            {
                 return false;
             }
             Diff other = (Diff) obj;
-            if (operation != other.operation) {
+            if (operation != other.operation)
+            {
                 return false;
             }
-            if (text == null) {
-                if (other.text != null) {
+            if (text == null)
+            {
+                if (other.text != null)
+                {
                     return false;
                 }
-            } else if (!text.equals(other.text)) {
+            } else if (!text.equals(other.text))
+            {
                 return false;
             }
             return true;

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/handler/EmphasisEditHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/handler/EmphasisEditHandler.java
@@ -5,10 +5,10 @@ import android.text.Spanned;
 
 import androidx.annotation.NonNull;
 
-import com.zeoflow.stylar.editor.AbstractEditHandler;
 import com.zeoflow.stylar.core.spans.EmphasisSpan;
-import com.zeoflow.stylar.editor.StylarEditorUtils;
+import com.zeoflow.stylar.editor.AbstractEditHandler;
 import com.zeoflow.stylar.editor.PersistedSpans;
+import com.zeoflow.stylar.editor.StylarEditorUtils;
 
 /**
  * @since 4.2.0
@@ -17,11 +17,14 @@ public class EmphasisEditHandler extends AbstractEditHandler<EmphasisSpan>
 {
 
     @Override
-    public void configurePersistedSpans(@NonNull PersistedSpans.Builder builder) {
-        builder.persistSpan(EmphasisSpan.class, new PersistedSpans.SpanFactory<EmphasisSpan>() {
+    public void configurePersistedSpans(@NonNull PersistedSpans.Builder builder)
+    {
+        builder.persistSpan(EmphasisSpan.class, new PersistedSpans.SpanFactory<EmphasisSpan>()
+        {
             @NonNull
             @Override
-            public EmphasisSpan create() {
+            public EmphasisSpan create()
+            {
                 return new EmphasisSpan();
             }
         });
@@ -29,27 +32,30 @@ public class EmphasisEditHandler extends AbstractEditHandler<EmphasisSpan>
 
     @Override
     public void handleMarkdownSpan(
-            @NonNull PersistedSpans persistedSpans,
-            @NonNull Editable editable,
-            @NonNull String input,
-            @NonNull EmphasisSpan span,
-            int spanStart,
-            int spanTextLength) {
+        @NonNull PersistedSpans persistedSpans,
+        @NonNull Editable editable,
+        @NonNull String input,
+        @NonNull EmphasisSpan span,
+        int spanStart,
+        int spanTextLength)
+    {
         final StylarEditorUtils.Match match =
-                StylarEditorUtils.findDelimited(input, spanStart, "*", "_");
-        if (match != null) {
+            StylarEditorUtils.findDelimited(input, spanStart, "*", "_");
+        if (match != null)
+        {
             editable.setSpan(
-                    persistedSpans.get(EmphasisSpan.class),
-                    match.start(),
-                    match.end(),
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                persistedSpans.get(EmphasisSpan.class),
+                match.start(),
+                match.end(),
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
             );
         }
     }
 
     @NonNull
     @Override
-    public Class<EmphasisSpan> markdownSpanType() {
+    public Class<EmphasisSpan> markdownSpanType()
+    {
         return EmphasisSpan.class;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/editor/handler/StrongEmphasisEditHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/editor/handler/StrongEmphasisEditHandler.java
@@ -5,10 +5,10 @@ import android.text.Spanned;
 
 import androidx.annotation.NonNull;
 
-import com.zeoflow.stylar.editor.AbstractEditHandler;
 import com.zeoflow.stylar.core.spans.StrongEmphasisSpan;
-import com.zeoflow.stylar.editor.StylarEditorUtils;
+import com.zeoflow.stylar.editor.AbstractEditHandler;
 import com.zeoflow.stylar.editor.PersistedSpans;
+import com.zeoflow.stylar.editor.StylarEditorUtils;
 
 /**
  * @since 4.2.0
@@ -17,16 +17,20 @@ public class StrongEmphasisEditHandler extends AbstractEditHandler<StrongEmphasi
 {
 
     @NonNull
-    public static StrongEmphasisEditHandler create() {
+    public static StrongEmphasisEditHandler create()
+    {
         return new StrongEmphasisEditHandler();
     }
 
     @Override
-    public void configurePersistedSpans(@NonNull PersistedSpans.Builder builder) {
-        builder.persistSpan(StrongEmphasisSpan.class, new PersistedSpans.SpanFactory<StrongEmphasisSpan>() {
+    public void configurePersistedSpans(@NonNull PersistedSpans.Builder builder)
+    {
+        builder.persistSpan(StrongEmphasisSpan.class, new PersistedSpans.SpanFactory<StrongEmphasisSpan>()
+        {
             @NonNull
             @Override
-            public StrongEmphasisSpan create() {
+            public StrongEmphasisSpan create()
+            {
                 return new StrongEmphasisSpan();
             }
         });
@@ -34,30 +38,33 @@ public class StrongEmphasisEditHandler extends AbstractEditHandler<StrongEmphasi
 
     @Override
     public void handleMarkdownSpan(
-            @NonNull PersistedSpans persistedSpans,
-            @NonNull Editable editable,
-            @NonNull String input,
-            @NonNull StrongEmphasisSpan span,
-            int spanStart,
-            int spanTextLength) {
+        @NonNull PersistedSpans persistedSpans,
+        @NonNull Editable editable,
+        @NonNull String input,
+        @NonNull StrongEmphasisSpan span,
+        int spanStart,
+        int spanTextLength)
+    {
         // inline spans can delimit other inline spans,
         //  for example: `**_~~hey~~_**`, this is why we must additionally find delimiter used
         //  and its actual start/end positions
         final StylarEditorUtils.Match match =
-                StylarEditorUtils.findDelimited(input, spanStart, "**", "__");
-        if (match != null) {
+            StylarEditorUtils.findDelimited(input, spanStart, "**", "__");
+        if (match != null)
+        {
             editable.setSpan(
-                    persistedSpans.get(StrongEmphasisSpan.class),
-                    match.start(),
-                    match.end(),
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                persistedSpans.get(StrongEmphasisSpan.class),
+                match.start(),
+                match.end(),
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
             );
         }
     }
 
     @NonNull
     @Override
-    public Class<StrongEmphasisSpan> markdownSpanType() {
+    public Class<StrongEmphasisSpan> markdownSpanType()
+    {
         return StrongEmphasisSpan.class;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexAsyncDrawableSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexAsyncDrawableSpan.java
@@ -7,26 +7,29 @@ import android.graphics.drawable.Drawable;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 
-import org.scilab.forge.jlatexmath.TeXIcon;
-
 import com.zeoflow.stylar.core.StylarTheme;
 import com.zeoflow.stylar.image.AsyncDrawableSpan;
+
+import org.scilab.forge.jlatexmath.TeXIcon;
+
 import ru.noties.jlatexmath.JLatexMathDrawable;
 import ru.noties.jlatexmath.awt.Color;
 
 /**
  * @since 4.3.0
  */
-public class JLatexAsyncDrawableSpan extends AsyncDrawableSpan {
+public class JLatexAsyncDrawableSpan extends AsyncDrawableSpan
+{
 
     private final JLatextAsyncDrawable drawable;
     private final int color;
     private boolean appliedTextColor;
 
     public JLatexAsyncDrawableSpan(
-            @NonNull StylarTheme theme,
-            @NonNull JLatextAsyncDrawable drawable,
-            @ColorInt int color) {
+        @NonNull StylarTheme theme,
+        @NonNull JLatextAsyncDrawable drawable,
+        @ColorInt int color)
+    {
         super(theme, drawable, ALIGN_CENTER, false);
         this.drawable = drawable;
         this.color = color;
@@ -35,12 +38,15 @@ public class JLatexAsyncDrawableSpan extends AsyncDrawableSpan {
     }
 
     @Override
-    public void draw(@NonNull Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, @NonNull Paint paint) {
-        if (!appliedTextColor && drawable.hasResult()) {
+    public void draw(@NonNull Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, @NonNull Paint paint)
+    {
+        if (!appliedTextColor && drawable.hasResult())
+        {
             // it is important to check for type (in case of an error, or custom placeholder or whatever
             //  this result can be of other type)
             final Drawable drawableResult = drawable.getResult();
-            if (drawableResult instanceof JLatexMathDrawable) {
+            if (drawableResult instanceof JLatexMathDrawable)
+            {
                 final JLatexMathDrawable result = (JLatexMathDrawable) drawableResult;
                 final TeXIcon icon = result.icon();
                 icon.setForeground(new Color(paint.getColor()));
@@ -51,12 +57,14 @@ public class JLatexAsyncDrawableSpan extends AsyncDrawableSpan {
     }
 
     @NonNull
-    public JLatextAsyncDrawable drawable() {
+    public JLatextAsyncDrawable drawable()
+    {
         return drawable;
     }
 
     @ColorInt
-    public int color() {
+    public int color()
+    {
         return color;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexBlockImageSizeResolver.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexBlockImageSizeResolver.java
@@ -9,27 +9,32 @@ import com.zeoflow.stylar.image.ImageSizeResolver;
 
 // we must make drawable fit canvas (if specified), but do not keep the ratio whilst scaling up
 // @since 4.0.0
-class JLatexBlockImageSizeResolver extends ImageSizeResolver {
+class JLatexBlockImageSizeResolver extends ImageSizeResolver
+{
 
     private final boolean fitCanvas;
 
-    JLatexBlockImageSizeResolver(boolean fitCanvas) {
+    JLatexBlockImageSizeResolver(boolean fitCanvas)
+    {
         this.fitCanvas = fitCanvas;
     }
 
     @NonNull
     @Override
-    public Rect resolveImageSize(@NonNull AsyncDrawable drawable) {
+    public Rect resolveImageSize(@NonNull AsyncDrawable drawable)
+    {
 
         final Rect imageBounds = drawable.getResult().getBounds();
         final int canvasWidth = drawable.getLastKnownCanvasWidth();
 
-        if (fitCanvas) {
+        if (fitCanvas)
+        {
 
             // we modify bounds only if `fitCanvas` is true
             final int w = imageBounds.width();
 
-            if (w < canvasWidth) {
+            if (w < canvasWidth)
+            {
                 // increase width and center formula (keep height as-is)
                 return new Rect(0, 0, canvasWidth, imageBounds.height());
             }
@@ -37,7 +42,8 @@ class JLatexBlockImageSizeResolver extends ImageSizeResolver {
             // @since 4.0.2 we additionally scale down the resulting formula (keeping the ratio)
             // the thing is - JLatexMathDrawable will do it anyway, but it will modify its own
             // bounds (which AsyncDrawable won't catch), thus leading to an empty space after the formula
-            if (w > canvasWidth) {
+            if (w > canvasWidth)
+            {
                 // here we must scale it down (keeping the ratio)
                 final float ratio = (float) w / imageBounds.height();
                 final int h = (int) (canvasWidth / ratio + .5F);

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexInlineAsyncDrawableSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexInlineAsyncDrawableSpan.java
@@ -14,32 +14,37 @@ import com.zeoflow.stylar.image.AsyncDrawable;
 /**
  * @since 4.3.0
  */
-class JLatexInlineAsyncDrawableSpan extends JLatexAsyncDrawableSpan {
+class JLatexInlineAsyncDrawableSpan extends JLatexAsyncDrawableSpan
+{
 
     private final AsyncDrawable drawable;
 
-    JLatexInlineAsyncDrawableSpan(@NonNull StylarTheme theme, @NonNull JLatextAsyncDrawable drawable, @ColorInt int color) {
+    JLatexInlineAsyncDrawableSpan(@NonNull StylarTheme theme, @NonNull JLatextAsyncDrawable drawable, @ColorInt int color)
+    {
         super(theme, drawable, color);
         this.drawable = drawable;
     }
 
     @Override
     public int getSize(
-            @NonNull Paint paint,
-            CharSequence text,
-            @IntRange(from = 0) int start,
-            @IntRange(from = 0) int end,
-            @Nullable Paint.FontMetricsInt fm) {
+        @NonNull Paint paint,
+        CharSequence text,
+        @IntRange(from = 0) int start,
+        @IntRange(from = 0) int end,
+        @Nullable Paint.FontMetricsInt fm)
+    {
 
         // if we have no async drawable result - we will just render text
 
         final int size;
 
-        if (drawable.hasResult()) {
+        if (drawable.hasResult())
+        {
 
             final Rect rect = drawable.getBounds();
 
-            if (fm != null) {
+            if (fm != null)
+            {
                 final int half = rect.bottom / 2;
                 fm.ascent = -half;
                 fm.descent = half;
@@ -50,7 +55,8 @@ class JLatexInlineAsyncDrawableSpan extends JLatexAsyncDrawableSpan {
 
             size = rect.right;
 
-        } else {
+        } else
+        {
 
             // NB, no specific text handling (no new lines, etc)
             size = (int) (paint.measureText(text, start, end) + .5F);

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathBlock.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathBlock.java
@@ -2,15 +2,18 @@ package com.zeoflow.stylar.ext.latex;
 
 import org.commonmark.node.CustomBlock;
 
-public class JLatexMathBlock extends CustomBlock {
+public class JLatexMathBlock extends CustomBlock
+{
 
     private String latex;
 
-    public String latex() {
+    public String latex()
+    {
         return latex;
     }
 
-    public void latex(String latex) {
+    public void latex(String latex)
+    {
         this.latex = latex;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathBlockParser.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathBlockParser.java
@@ -15,7 +15,8 @@ import org.commonmark.parser.block.ParserState;
  * @since 4.3.0 (although there was a class with the same name,
  * which is renamed now to {@link JLatexMathBlockParserLegacy})
  */
-class JLatexMathBlockParser extends AbstractBlockParser {
+class JLatexMathBlockParser extends AbstractBlockParser
+{
 
     private static final char DOLLAR = '$';
     private static final char SPACE = ' ';
@@ -26,27 +27,47 @@ class JLatexMathBlockParser extends AbstractBlockParser {
 
     private final int signs;
 
-    JLatexMathBlockParser(int signs) {
+    JLatexMathBlockParser(int signs)
+    {
         this.signs = signs;
     }
 
+    @SuppressWarnings("SameParameterValue")
+    private static int consume(char c, @NonNull CharSequence line, int start, int end)
+    {
+        for (int i = start; i < end; i++)
+        {
+            if (c != line.charAt(i))
+            {
+                return i - start;
+            }
+        }
+        // all consumed
+        return end - start;
+    }
+
     @Override
-    public Block getBlock() {
+    public Block getBlock()
+    {
         return block;
     }
 
     @Override
-    public BlockContinue tryContinue(ParserState parserState) {
+    public BlockContinue tryContinue(ParserState parserState)
+    {
         final int nextNonSpaceIndex = parserState.getNextNonSpaceIndex();
         final CharSequence line = parserState.getLine();
         final int length = line.length();
 
         // check for closing
-        if (parserState.getIndent() < Parsing.CODE_BLOCK_INDENT) {
-            if (consume(DOLLAR, line, nextNonSpaceIndex, length) == signs) {
+        if (parserState.getIndent() < Parsing.CODE_BLOCK_INDENT)
+        {
+            if (consume(DOLLAR, line, nextNonSpaceIndex, length) == signs)
+            {
                 // okay, we have our number of signs
                 // let's consume spaces until the end
-                if (Parsing.skip(SPACE, line, nextNonSpaceIndex + signs, length) == length) {
+                if (Parsing.skip(SPACE, line, nextNonSpaceIndex + signs, length) == length)
+                {
                     return BlockContinue.finished();
                 }
             }
@@ -56,20 +77,24 @@ class JLatexMathBlockParser extends AbstractBlockParser {
     }
 
     @Override
-    public void addLine(CharSequence line) {
+    public void addLine(CharSequence line)
+    {
         builder.append(line);
         builder.append('\n');
     }
 
     @Override
-    public void closeBlock() {
+    public void closeBlock()
+    {
         block.latex(builder.toString());
     }
 
-    public static class Factory extends AbstractBlockParserFactory {
+    public static class Factory extends AbstractBlockParserFactory
+    {
 
         @Override
-        public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
+        public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser)
+        {
 
             // let's define the spec:
             //  * 0-3 spaces before are allowed (Parsing.CODE_BLOCK_INDENT = 4)
@@ -81,7 +106,8 @@ class JLatexMathBlockParser extends AbstractBlockParser {
             final int indent = state.getIndent();
 
             // check if it's an indented code block
-            if (indent >= Parsing.CODE_BLOCK_INDENT) {
+            if (indent >= Parsing.CODE_BLOCK_INDENT)
+            {
                 return BlockStart.none();
             }
 
@@ -92,28 +118,19 @@ class JLatexMathBlockParser extends AbstractBlockParser {
             final int signs = consume(DOLLAR, line, nextNonSpaceIndex, length);
 
             // 2 is minimum
-            if (signs < 2) {
+            if (signs < 2)
+            {
                 return BlockStart.none();
             }
 
             // consume spaces until the end of the line, if any other content is found -> NONE
-            if (Parsing.skip(SPACE, line, nextNonSpaceIndex + signs, length) != length) {
+            if (Parsing.skip(SPACE, line, nextNonSpaceIndex + signs, length) != length)
+            {
                 return BlockStart.none();
             }
 
             return BlockStart.of(new JLatexMathBlockParser(signs))
-                    .atIndex(length + 1);
+                .atIndex(length + 1);
         }
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static int consume(char c, @NonNull CharSequence line, int start, int end) {
-        for (int i = start; i < end; i++) {
-            if (c != line.charAt(i)) {
-                return i - start;
-            }
-        }
-        // all consumed
-        return end - start;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathBlockParserLegacy.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathBlockParserLegacy.java
@@ -11,7 +11,8 @@ import org.commonmark.parser.block.ParserState;
 /**
  * @since 4.3.0 (although it is just renamed parser from previous versions)
  */
-class JLatexMathBlockParserLegacy extends AbstractBlockParser {
+class JLatexMathBlockParserLegacy extends AbstractBlockParser
+{
 
     private final JLatexMathBlock block = new JLatexMathBlock();
 
@@ -20,14 +21,17 @@ class JLatexMathBlockParserLegacy extends AbstractBlockParser {
     private boolean isClosed;
 
     @Override
-    public Block getBlock() {
+    public Block getBlock()
+    {
         return block;
     }
 
     @Override
-    public BlockContinue tryContinue(ParserState parserState) {
+    public BlockContinue tryContinue(ParserState parserState)
+    {
 
-        if (isClosed) {
+        if (isClosed)
+        {
             return BlockContinue.finished();
         }
 
@@ -35,44 +39,53 @@ class JLatexMathBlockParserLegacy extends AbstractBlockParser {
     }
 
     @Override
-    public void addLine(CharSequence line) {
+    public void addLine(CharSequence line)
+    {
 
-        if (builder.length() > 0) {
+        if (builder.length() > 0)
+        {
             builder.append('\n');
         }
 
         builder.append(line);
 
         final int length = builder.length();
-        if (length > 1) {
+        if (length > 1)
+        {
             isClosed = '$' == builder.charAt(length - 1)
-                    && '$' == builder.charAt(length - 2);
-            if (isClosed) {
+                && '$' == builder.charAt(length - 2);
+            if (isClosed)
+            {
                 builder.replace(length - 2, length, "");
             }
         }
     }
 
     @Override
-    public void closeBlock() {
+    public void closeBlock()
+    {
         block.latex(builder.toString());
     }
 
-    public static class Factory extends AbstractBlockParserFactory {
+    public static class Factory extends AbstractBlockParserFactory
+    {
 
         @Override
-        public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
+        public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser)
+        {
 
             final CharSequence line = state.getLine();
             final int length = line != null
-                    ? line.length()
-                    : 0;
+                ? line.length()
+                : 0;
 
-            if (length > 1) {
+            if (length > 1)
+            {
                 if ('$' == line.charAt(0)
-                        && '$' == line.charAt(1)) {
+                    && '$' == line.charAt(1))
+                {
                     return BlockStart.of(new JLatexMathBlockParserLegacy())
-                            .atIndex(state.getIndex() + 2);
+                        .atIndex(state.getIndex() + 2);
                 }
             }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathInlineProcessor.java
@@ -17,16 +17,19 @@ class JLatexMathInlineProcessor extends InlineProcessor
     private static final Pattern RE = Pattern.compile("(\\${2})([\\s\\S]+?)\\1");
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '$';
     }
 
     @Nullable
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
 
         final String latex = match(RE);
-        if (latex == null) {
+        if (latex == null)
+        {
             return null;
         }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathNode.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathNode.java
@@ -5,15 +5,18 @@ import org.commonmark.node.CustomNode;
 /**
  * @since 4.3.0
  */
-public class JLatexMathNode extends CustomNode {
+public class JLatexMathNode extends CustomNode
+{
 
     private String latex;
 
-    public String latex() {
+    public String latex()
+    {
         return latex;
     }
 
-    public void latex(String latex) {
+    public void latex(String latex)
+    {
         this.latex = latex;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathTheme.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatexMathTheme.java
@@ -12,83 +12,31 @@ import ru.noties.jlatexmath.JLatexMathDrawable;
 /**
  * @since 4.3.0
  */
-public abstract class JLatexMathTheme {
+public abstract class JLatexMathTheme
+{
 
     @NonNull
-    public static JLatexMathTheme create(@Px float textSize) {
+    public static JLatexMathTheme create(@Px float textSize)
+    {
         return builder(textSize).build();
     }
 
     @NonNull
-    public static JLatexMathTheme create(@Px float inlineTextSize, @Px float blockTextSize) {
+    public static JLatexMathTheme create(@Px float inlineTextSize, @Px float blockTextSize)
+    {
         return builder(inlineTextSize, blockTextSize).build();
     }
 
     @NonNull
-    public static JLatexMathTheme.Builder builder(@Px float textSize) {
+    public static JLatexMathTheme.Builder builder(@Px float textSize)
+    {
         return new JLatexMathTheme.Builder(textSize, 0F, 0F);
     }
 
     @NonNull
-    public static JLatexMathTheme.Builder builder(@Px float inlineTextSize, @Px float blockTextSize) {
+    public static JLatexMathTheme.Builder builder(@Px float inlineTextSize, @Px float blockTextSize)
+    {
         return new Builder(0F, inlineTextSize, blockTextSize);
-    }
-
-    /**
-     * Moved from {@link JLatexMathPlugin} in {@code 4.3.0} version
-     *
-     * @since 4.0.0
-     */
-    public interface BackgroundProvider {
-        @NonNull
-        Drawable provide();
-    }
-
-    /**
-     * Special immutable class to hold padding information
-     */
-    @SuppressWarnings("WeakerAccess")
-    public static class Padding {
-        public final int left;
-        public final int top;
-        public final int right;
-        public final int bottom;
-
-        public Padding(int left, int top, int right, int bottom) {
-            this.left = left;
-            this.top = top;
-            this.right = right;
-            this.bottom = bottom;
-        }
-
-        @NonNull
-        @Override
-        public String toString() {
-            return "Padding{" +
-                    "left=" + left +
-                    ", top=" + top +
-                    ", right=" + right +
-                    ", bottom=" + bottom +
-                    '}';
-        }
-
-        @NonNull
-        public static Padding all(int value) {
-            return new Padding(value, value, value, value);
-        }
-
-        @NonNull
-        public static Padding symmetric(int vertical, int horizontal) {
-            return new Padding(horizontal, vertical, horizontal, vertical);
-        }
-
-        /**
-         * @since 4.5.0
-         */
-        @NonNull
-        public static Padding of(int left, int top, int right, int bottom) {
-            return new Padding(left, top, right, bottom);
-        }
     }
 
     /**
@@ -135,8 +83,73 @@ public abstract class JLatexMathTheme {
     @ColorInt
     public abstract int blockTextColor();
 
+    /**
+     * Moved from {@link JLatexMathPlugin} in {@code 4.3.0} version
+     *
+     * @since 4.0.0
+     */
+    public interface BackgroundProvider
+    {
+        @NonNull
+        Drawable provide();
+    }
+
+    /**
+     * Special immutable class to hold padding information
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static class Padding
+    {
+        public final int left;
+        public final int top;
+        public final int right;
+        public final int bottom;
+
+        public Padding(int left, int top, int right, int bottom)
+        {
+            this.left = left;
+            this.top = top;
+            this.right = right;
+            this.bottom = bottom;
+        }
+
+        @NonNull
+        public static Padding all(int value)
+        {
+            return new Padding(value, value, value, value);
+        }
+
+        @NonNull
+        public static Padding symmetric(int vertical, int horizontal)
+        {
+            return new Padding(horizontal, vertical, horizontal, vertical);
+        }
+
+        /**
+         * @since 4.5.0
+         */
+        @NonNull
+        public static Padding of(int left, int top, int right, int bottom)
+        {
+            return new Padding(left, top, right, bottom);
+        }
+
+        @NonNull
+        @Override
+        public String toString()
+        {
+            return "Padding{" +
+                "left=" + left +
+                ", top=" + top +
+                ", right=" + right +
+                ", bottom=" + bottom +
+                '}';
+        }
+    }
+
     @SuppressWarnings({"unused", "UnusedReturnValue"})
-    public static class Builder {
+    public static class Builder
+    {
         private final float textSize;
         private final float inlineTextSize;
         private final float blockTextSize;
@@ -157,14 +170,16 @@ public abstract class JLatexMathTheme {
         private int inlineTextColor;
         private int blockTextColor;
 
-        Builder(float textSize, float inlineTextSize, float blockTextSize) {
+        Builder(float textSize, float inlineTextSize, float blockTextSize)
+        {
             this.textSize = textSize;
             this.inlineTextSize = inlineTextSize;
             this.blockTextSize = blockTextSize;
         }
 
         @NonNull
-        public Builder backgroundProvider(@Nullable BackgroundProvider backgroundProvider) {
+        public Builder backgroundProvider(@Nullable BackgroundProvider backgroundProvider)
+        {
             this.backgroundProvider = backgroundProvider;
             this.inlineBackgroundProvider = backgroundProvider;
             this.blockBackgroundProvider = backgroundProvider;
@@ -172,13 +187,15 @@ public abstract class JLatexMathTheme {
         }
 
         @NonNull
-        public Builder inlineBackgroundProvider(@Nullable BackgroundProvider inlineBackgroundProvider) {
+        public Builder inlineBackgroundProvider(@Nullable BackgroundProvider inlineBackgroundProvider)
+        {
             this.inlineBackgroundProvider = inlineBackgroundProvider;
             return this;
         }
 
         @NonNull
-        public Builder blockBackgroundProvider(@Nullable BackgroundProvider blockBackgroundProvider) {
+        public Builder blockBackgroundProvider(@Nullable BackgroundProvider blockBackgroundProvider)
+        {
             this.blockBackgroundProvider = blockBackgroundProvider;
             return this;
         }
@@ -188,19 +205,22 @@ public abstract class JLatexMathTheme {
          * By default - `true`
          */
         @NonNull
-        public Builder blockFitCanvas(boolean blockFitCanvas) {
+        public Builder blockFitCanvas(boolean blockFitCanvas)
+        {
             this.blockFitCanvas = blockFitCanvas;
             return this;
         }
 
         @NonNull
-        public Builder blockHorizontalAlignment(@JLatexMathDrawable.Align int blockHorizontalAlignment) {
+        public Builder blockHorizontalAlignment(@JLatexMathDrawable.Align int blockHorizontalAlignment)
+        {
             this.blockHorizontalAlignment = blockHorizontalAlignment;
             return this;
         }
 
         @NonNull
-        public Builder padding(@Nullable Padding padding) {
+        public Builder padding(@Nullable Padding padding)
+        {
             this.padding = padding;
             this.inlinePadding = padding;
             this.blockPadding = padding;
@@ -208,42 +228,49 @@ public abstract class JLatexMathTheme {
         }
 
         @NonNull
-        public Builder inlinePadding(@Nullable Padding inlinePadding) {
+        public Builder inlinePadding(@Nullable Padding inlinePadding)
+        {
             this.inlinePadding = inlinePadding;
             return this;
         }
 
         @NonNull
-        public Builder blockPadding(@Nullable Padding blockPadding) {
+        public Builder blockPadding(@Nullable Padding blockPadding)
+        {
             this.blockPadding = blockPadding;
             return this;
         }
 
         @NonNull
-        public Builder textColor(@ColorInt int textColor) {
+        public Builder textColor(@ColorInt int textColor)
+        {
             this.textColor = textColor;
             return this;
         }
 
         @NonNull
-        public Builder inlineTextColor(@ColorInt int inlineTextColor) {
+        public Builder inlineTextColor(@ColorInt int inlineTextColor)
+        {
             this.inlineTextColor = inlineTextColor;
             return this;
         }
 
         @NonNull
-        public Builder blockTextColor(@ColorInt int blockTextColor) {
+        public Builder blockTextColor(@ColorInt int blockTextColor)
+        {
             this.blockTextColor = blockTextColor;
             return this;
         }
 
         @NonNull
-        public JLatexMathTheme build() {
+        public JLatexMathTheme build()
+        {
             return new Impl(this);
         }
     }
 
-    static class Impl extends JLatexMathTheme {
+    static class Impl extends JLatexMathTheme
+    {
 
         private final float textSize;
         private final float inlineTextSize;
@@ -254,18 +281,17 @@ public abstract class JLatexMathTheme {
         private final BackgroundProvider blockBackgroundProvider;
 
         private final boolean blockFitCanvas;
-        // horizontal alignment (when there is additional horizontal space)
-        private int blockHorizontalAlignment;
-
         private final Padding padding;
         private final Padding inlinePadding;
         private final Padding blockPadding;
-
         private final int textColor;
         private final int inlineTextColor;
         private final int blockTextColor;
+        // horizontal alignment (when there is additional horizontal space)
+        private int blockHorizontalAlignment;
 
-        Impl(@NonNull Builder builder) {
+        Impl(@NonNull Builder builder)
+        {
             this.textSize = builder.textSize;
             this.inlineTextSize = builder.inlineTextSize;
             this.blockTextSize = builder.blockTextSize;
@@ -283,16 +309,20 @@ public abstract class JLatexMathTheme {
         }
 
         @Override
-        public float inlineTextSize() {
-            if (inlineTextSize > 0F) {
+        public float inlineTextSize()
+        {
+            if (inlineTextSize > 0F)
+            {
                 return inlineTextSize;
             }
             return textSize;
         }
 
         @Override
-        public float blockTextSize() {
-            if (blockTextSize > 0F) {
+        public float blockTextSize()
+        {
+            if (blockTextSize > 0F)
+            {
                 return blockTextSize;
             }
             return textSize;
@@ -300,8 +330,10 @@ public abstract class JLatexMathTheme {
 
         @Nullable
         @Override
-        public BackgroundProvider inlineBackgroundProvider() {
-            if (inlineBackgroundProvider != null) {
+        public BackgroundProvider inlineBackgroundProvider()
+        {
+            if (inlineBackgroundProvider != null)
+            {
                 return inlineBackgroundProvider;
             }
             return backgroundProvider;
@@ -309,27 +341,33 @@ public abstract class JLatexMathTheme {
 
         @Nullable
         @Override
-        public BackgroundProvider blockBackgroundProvider() {
-            if (blockBackgroundProvider != null) {
+        public BackgroundProvider blockBackgroundProvider()
+        {
+            if (blockBackgroundProvider != null)
+            {
                 return blockBackgroundProvider;
             }
             return backgroundProvider;
         }
 
         @Override
-        public boolean blockFitCanvas() {
+        public boolean blockFitCanvas()
+        {
             return blockFitCanvas;
         }
 
         @Override
-        public int blockHorizontalAlignment() {
+        public int blockHorizontalAlignment()
+        {
             return blockHorizontalAlignment;
         }
 
         @Nullable
         @Override
-        public Padding inlinePadding() {
-            if (inlinePadding != null) {
+        public Padding inlinePadding()
+        {
+            if (inlinePadding != null)
+            {
                 return inlinePadding;
             }
             return padding;
@@ -337,24 +375,30 @@ public abstract class JLatexMathTheme {
 
         @Nullable
         @Override
-        public Padding blockPadding() {
-            if (blockPadding != null) {
+        public Padding blockPadding()
+        {
+            if (blockPadding != null)
+            {
                 return blockPadding;
             }
             return padding;
         }
 
         @Override
-        public int inlineTextColor() {
-            if (inlineTextColor != 0) {
+        public int inlineTextColor()
+        {
+            if (inlineTextColor != 0)
+            {
                 return inlineTextColor;
             }
             return textColor;
         }
 
         @Override
-        public int blockTextColor() {
-            if (blockTextColor != 0) {
+        public int blockTextColor()
+        {
+            if (blockTextColor != 0)
+            {
                 return blockTextColor;
             }
             return textColor;

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatextAsyncDrawable.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/latex/JLatextAsyncDrawable.java
@@ -11,22 +11,25 @@ import com.zeoflow.stylar.image.ImageSizeResolver;
 /**
  * @since 4.3.0
  */
-class JLatextAsyncDrawable extends AsyncDrawable {
+class JLatextAsyncDrawable extends AsyncDrawable
+{
 
     private final boolean isBlock;
 
     JLatextAsyncDrawable(
-            @NonNull String destination,
-            @NonNull AsyncDrawableLoader loader,
-            @NonNull ImageSizeResolver imageSizeResolver,
-            @Nullable ImageSize imageSize,
-            boolean isBlock
-    ) {
+        @NonNull String destination,
+        @NonNull AsyncDrawableLoader loader,
+        @NonNull ImageSizeResolver imageSizeResolver,
+        @Nullable ImageSize imageSize,
+        boolean isBlock
+    )
+    {
         super(destination, loader, imageSizeResolver, imageSize);
         this.isBlock = isBlock;
     }
 
-    public boolean isBlock() {
+    public boolean isBlock()
+    {
         return isBlock;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/strikethrough/StrikethroughPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/strikethrough/StrikethroughPlugin.java
@@ -5,6 +5,9 @@ import android.text.style.StrikethroughSpan;
 import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.AbstractStylarPlugin;
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.StylarSpansFactory;
 import com.zeoflow.stylar.StylarVisitor;
 
@@ -13,10 +16,6 @@ import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
 import org.commonmark.parser.Parser;
 
 import java.util.Collections;
-
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpanFactory;
 
 /**
  * Plugin to add strikethrough markdown feature. This plugin will extend commonmark-java.Parser
@@ -30,30 +29,38 @@ public class StrikethroughPlugin extends AbstractStylarPlugin
 {
 
     @NonNull
-    public static StrikethroughPlugin create() {
+    public static StrikethroughPlugin create()
+    {
         return new StrikethroughPlugin();
     }
 
     @Override
-    public void configureParser(@NonNull Parser.Builder builder) {
+    public void configureParser(@NonNull Parser.Builder builder)
+    {
         builder.extensions(Collections.singleton(StrikethroughExtension.create()));
     }
 
     @Override
-    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder) {
-        builder.setFactory(Strikethrough.class, new SpanFactory() {
+    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder)
+    {
+        builder.setFactory(Strikethrough.class, new SpanFactory()
+        {
             @Override
-            public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+            public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+            {
                 return new StrikethroughSpan();
             }
         });
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
-        builder.on(Strikethrough.class, new StylarVisitor.NodeVisitor<Strikethrough>() {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(Strikethrough.class, new StylarVisitor.NodeVisitor<Strikethrough>()
+        {
             @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull Strikethrough strikethrough) {
+            public void visit(@NonNull StylarVisitor visitor, @NonNull Strikethrough strikethrough)
+            {
                 final int length = visitor.length();
                 visitor.visitChildren(strikethrough);
                 visitor.setSpansForNodeOptional(strikethrough, length);

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tables/Table.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tables/Table.java
@@ -25,17 +25,26 @@ import java.util.List;
  * @see #parse(Stylar, TableBlock)
  * @since 3.0.0
  */
-public class Table {
+public class Table
+{
+
+    private final List<Row> rows;
+
+    public Table(@NonNull List<Row> rows)
+    {
+        this.rows = rows;
+    }
 
     /**
      * Factory method to obtain an instance of {@link Table}
      *
-     * @param stylar    Markwon
+     * @param stylar     Markwon
      * @param tableBlock TableBlock to parse
      * @return parsed {@link Table} or null
      */
     @Nullable
-    public static Table parse(@NonNull Stylar stylar, @NonNull TableBlock tableBlock) {
+    public static Table parse(@NonNull Stylar stylar, @NonNull TableBlock tableBlock)
+    {
 
         final Table table;
 
@@ -43,99 +52,109 @@ public class Table {
         tableBlock.accept(visitor);
         final List<Row> rows = visitor.rows();
 
-        if (rows == null) {
+        if (rows == null)
+        {
             table = null;
-        } else {
+        } else
+        {
             table = new Table(rows);
         }
 
         return table;
     }
 
-    public static class Row {
-
-        private final boolean isHeader;
-        private final List<Column> columns;
-
-        public Row(
-                boolean isHeader,
-                @NonNull List<Column> columns) {
-            this.isHeader = isHeader;
-            this.columns = columns;
-        }
-
-        public boolean header() {
-            return isHeader;
-        }
-
-        @NonNull
-        public List<Column> columns() {
-            return columns;
-        }
-
-        @Override
-        public String toString() {
-            return "Row{" +
-                    "isHeader=" + isHeader +
-                    ", columns=" + columns +
-                    '}';
-        }
+    @NonNull
+    public List<Row> rows()
+    {
+        return rows;
     }
 
-    public static class Column {
-
-        private final Alignment alignment;
-        private final Spanned content;
-
-        public Column(@NonNull Alignment alignment, @NonNull Spanned content) {
-            this.alignment = alignment;
-            this.content = content;
-        }
-
-        @NonNull
-        public Alignment alignment() {
-            return alignment;
-        }
-
-        @NonNull
-        public Spanned content() {
-            return content;
-        }
-
-        @Override
-        public String toString() {
-            return "Column{" +
-                    "alignment=" + alignment +
-                    ", content=" + content +
-                    '}';
-        }
+    @Override
+    public String toString()
+    {
+        return "Table{" +
+            "rows=" + rows +
+            '}';
     }
 
-    public enum Alignment {
+    public enum Alignment
+    {
         LEFT,
         CENTER,
         RIGHT
     }
 
-    private final List<Row> rows;
+    public static class Row
+    {
 
-    public Table(@NonNull List<Row> rows) {
-        this.rows = rows;
-    }
+        private final boolean isHeader;
+        private final List<Column> columns;
 
-    @NonNull
-    public List<Row> rows() {
-        return rows;
-    }
+        public Row(
+            boolean isHeader,
+            @NonNull List<Column> columns)
+        {
+            this.isHeader = isHeader;
+            this.columns = columns;
+        }
 
-    @Override
-    public String toString() {
-        return "Table{" +
-                "rows=" + rows +
+        public boolean header()
+        {
+            return isHeader;
+        }
+
+        @NonNull
+        public List<Column> columns()
+        {
+            return columns;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Row{" +
+                "isHeader=" + isHeader +
+                ", columns=" + columns +
                 '}';
+        }
     }
 
-    static class ParseVisitor extends AbstractVisitor {
+    public static class Column
+    {
+
+        private final Alignment alignment;
+        private final Spanned content;
+
+        public Column(@NonNull Alignment alignment, @NonNull Spanned content)
+        {
+            this.alignment = alignment;
+            this.content = content;
+        }
+
+        @NonNull
+        public Alignment alignment()
+        {
+            return alignment;
+        }
+
+        @NonNull
+        public Spanned content()
+        {
+            return content;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Column{" +
+                "alignment=" + alignment +
+                ", content=" + content +
+                '}';
+        }
+    }
+
+    static class ParseVisitor extends AbstractVisitor
+    {
 
         private final Stylar stylar;
 
@@ -144,23 +163,45 @@ public class Table {
         private List<Column> pendingRow;
         private boolean pendingRowIsHeader;
 
-        ParseVisitor(@NonNull Stylar stylar) {
+        ParseVisitor(@NonNull Stylar stylar)
+        {
             this.stylar = stylar;
         }
 
+        @NonNull
+        private static Table.Alignment alignment(@NonNull TableCell.Alignment alignment)
+        {
+            final Table.Alignment out;
+            if (TableCell.Alignment.RIGHT == alignment)
+            {
+                out = Table.Alignment.RIGHT;
+            } else if (TableCell.Alignment.CENTER == alignment)
+            {
+                out = Table.Alignment.CENTER;
+            } else
+            {
+                out = Table.Alignment.LEFT;
+            }
+            return out;
+        }
+
         @Nullable
-        public List<Row> rows() {
+        public List<Row> rows()
+        {
             return rows;
         }
 
         @Override
-        public void visit(CustomNode customNode) {
+        public void visit(CustomNode customNode)
+        {
 
-            if (customNode instanceof TableCell) {
+            if (customNode instanceof TableCell)
+            {
 
                 final TableCell cell = (TableCell) customNode;
 
-                if (pendingRow == null) {
+                if (pendingRow == null)
+                {
                     pendingRow = new ArrayList<>(2);
                 }
 
@@ -171,14 +212,17 @@ public class Table {
             }
 
             if (customNode instanceof TableHead
-                    || customNode instanceof TableRow) {
+                || customNode instanceof TableRow)
+            {
 
                 visitChildren(customNode);
 
                 // this can happen, ignore such row
-                if (pendingRow != null && pendingRow.size() > 0) {
+                if (pendingRow != null && pendingRow.size() > 0)
+                {
 
-                    if (rows == null) {
+                    if (rows == null)
+                    {
                         rows = new ArrayList<>(2);
                     }
 
@@ -192,19 +236,6 @@ public class Table {
             }
 
             visitChildren(customNode);
-        }
-
-        @NonNull
-        private static Table.Alignment alignment(@NonNull TableCell.Alignment alignment) {
-            final Table.Alignment out;
-            if (TableCell.Alignment.RIGHT == alignment) {
-                out = Table.Alignment.RIGHT;
-            } else if (TableCell.Alignment.CENTER == alignment) {
-                out = Table.Alignment.CENTER;
-            } else {
-                out = Table.Alignment.LEFT;
-            }
-            return out;
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableAwareMovementMethod.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableAwareMovementMethod.java
@@ -15,10 +15,19 @@ import androidx.annotation.NonNull;
 /**
  * @since 4.6.0
  */
-public class TableAwareMovementMethod implements MovementMethod {
+public class TableAwareMovementMethod implements MovementMethod
+{
+
+    private final MovementMethod wrapped;
+
+    public TableAwareMovementMethod(@NonNull MovementMethod wrapped)
+    {
+        this.wrapped = wrapped;
+    }
 
     @NonNull
-    public static TableAwareMovementMethod wrap(@NonNull MovementMethod movementMethod) {
+    public static TableAwareMovementMethod wrap(@NonNull MovementMethod movementMethod)
+    {
         return new TableAwareMovementMethod(movementMethod);
     }
 
@@ -26,17 +35,20 @@ public class TableAwareMovementMethod implements MovementMethod {
      * Wraps LinkMovementMethod
      */
     @NonNull
-    public static TableAwareMovementMethod create() {
+    public static TableAwareMovementMethod create()
+    {
         return new TableAwareMovementMethod(LinkMovementMethod.getInstance());
     }
 
     public static boolean handleTableRowTouchEvent(
-            @NonNull TextView widget,
-            @NonNull Spannable buffer,
-            @NonNull MotionEvent event) {
+        @NonNull TextView widget,
+        @NonNull Spannable buffer,
+        @NonNull MotionEvent event)
+    {
         // handle only action up (originally action down is used in order to handle selection,
         //  which tables do no have)
-        if (event.getAction() != MotionEvent.ACTION_UP) {
+        if (event.getAction() != MotionEvent.ACTION_UP)
+        {
             return false;
         }
 
@@ -52,7 +64,8 @@ public class TableAwareMovementMethod implements MovementMethod {
         final int off = layout.getOffsetForHorizontal(line, x);
 
         final TableRowSpan[] spans = buffer.getSpans(off, off, TableRowSpan.class);
-        if (spans.length == 0) {
+        if (spans.length == 0)
+        {
             return false;
         }
 
@@ -60,14 +73,16 @@ public class TableAwareMovementMethod implements MovementMethod {
 
         // okay, we can calculate the x to obtain span, but what about y?
         final Layout rowLayout = span.findLayoutForHorizontalOffset(x);
-        if (rowLayout != null) {
+        if (rowLayout != null)
+        {
             // line top as basis
             final int rowY = layout.getLineTop(line);
             final int rowLine = rowLayout.getLineForVertical(y - rowY);
             final int rowOffset = rowLayout.getOffsetForHorizontal(rowLine, x % span.cellWidth());
             final ClickableSpan[] rowClickableSpans = ((Spanned) rowLayout.getText())
-                    .getSpans(rowOffset, rowOffset, ClickableSpan.class);
-            if (rowClickableSpans.length > 0) {
+                .getSpans(rowOffset, rowOffset, ClickableSpan.class);
+            if (rowClickableSpans.length > 0)
+            {
                 rowClickableSpans[0].onClick(widget);
                 return true;
             }
@@ -76,56 +91,59 @@ public class TableAwareMovementMethod implements MovementMethod {
         return false;
     }
 
-    private final MovementMethod wrapped;
-
-    public TableAwareMovementMethod(@NonNull MovementMethod wrapped) {
-        this.wrapped = wrapped;
-    }
-
     @Override
-    public void initialize(TextView widget, Spannable text) {
+    public void initialize(TextView widget, Spannable text)
+    {
         wrapped.initialize(widget, text);
     }
 
     @Override
-    public boolean onKeyDown(TextView widget, Spannable text, int keyCode, KeyEvent event) {
+    public boolean onKeyDown(TextView widget, Spannable text, int keyCode, KeyEvent event)
+    {
         return wrapped.onKeyDown(widget, text, keyCode, event);
     }
 
     @Override
-    public boolean onKeyUp(TextView widget, Spannable text, int keyCode, KeyEvent event) {
+    public boolean onKeyUp(TextView widget, Spannable text, int keyCode, KeyEvent event)
+    {
         return wrapped.onKeyUp(widget, text, keyCode, event);
     }
 
     @Override
-    public boolean onKeyOther(TextView view, Spannable text, KeyEvent event) {
+    public boolean onKeyOther(TextView view, Spannable text, KeyEvent event)
+    {
         return wrapped.onKeyOther(view, text, event);
     }
 
     @Override
-    public void onTakeFocus(TextView widget, Spannable text, int direction) {
+    public void onTakeFocus(TextView widget, Spannable text, int direction)
+    {
         wrapped.onTakeFocus(widget, text, direction);
     }
 
     @Override
-    public boolean onTrackballEvent(TextView widget, Spannable text, MotionEvent event) {
+    public boolean onTrackballEvent(TextView widget, Spannable text, MotionEvent event)
+    {
         return wrapped.onTrackballEvent(widget, text, event);
     }
 
     @Override
-    public boolean onTouchEvent(TextView widget, Spannable buffer, MotionEvent event) {
+    public boolean onTouchEvent(TextView widget, Spannable buffer, MotionEvent event)
+    {
         // let wrapped handle first, then if super handles nothing, search for table row spans
         return wrapped.onTouchEvent(widget, buffer, event)
-                || handleTableRowTouchEvent(widget, buffer, event);
+            || handleTableRowTouchEvent(widget, buffer, event);
     }
 
     @Override
-    public boolean onGenericMotionEvent(TextView widget, Spannable text, MotionEvent event) {
+    public boolean onGenericMotionEvent(TextView widget, Spannable text, MotionEvent event)
+    {
         return wrapped.onGenericMotionEvent(widget, text, event);
     }
 
     @Override
-    public boolean canSelectArbitrarily() {
+    public boolean canSelectArbitrarily()
+    {
         return wrapped.canSelectArbitrarily();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TablePlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TablePlugin.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.AbstractStylarPlugin;
+import com.zeoflow.stylar.SpannableBuilder;
 import com.zeoflow.stylar.StylarVisitor;
 
 import org.commonmark.ext.gfm.tables.TableBlock;
@@ -22,16 +23,20 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.zeoflow.stylar.SpannableBuilder;
-
 /**
  * @since 3.0.0
  */
 public class TablePlugin extends AbstractStylarPlugin
 {
 
-    public interface ThemeConfigure {
-        void configureTheme(@NonNull TableTheme.Builder builder);
+    private final TableTheme theme;
+    private final TableVisitor visitor;
+
+    @SuppressWarnings("WeakerAccess")
+    TablePlugin(@NonNull TableTheme tableTheme)
+    {
+        this.theme = tableTheme;
+        this.visitor = new TableVisitor(tableTheme);
     }
 
     /**
@@ -42,63 +47,69 @@ public class TablePlugin extends AbstractStylarPlugin
      * @see #create(ThemeConfigure)
      */
     @NonNull
-    public static TablePlugin create(@NonNull Context context) {
+    public static TablePlugin create(@NonNull Context context)
+    {
         return new TablePlugin(TableTheme.create(context));
     }
 
     @NonNull
-    public static TablePlugin create(@NonNull TableTheme tableTheme) {
+    public static TablePlugin create(@NonNull TableTheme tableTheme)
+    {
         return new TablePlugin(tableTheme);
     }
 
     @NonNull
-    public static TablePlugin create(@NonNull ThemeConfigure themeConfigure) {
+    public static TablePlugin create(@NonNull ThemeConfigure themeConfigure)
+    {
         final TableTheme.Builder builder = new TableTheme.Builder();
         themeConfigure.configureTheme(builder);
         return new TablePlugin(builder.build());
     }
 
-    private final TableTheme theme;
-    private final TableVisitor visitor;
-
-    @SuppressWarnings("WeakerAccess")
-    TablePlugin(@NonNull TableTheme tableTheme) {
-        this.theme = tableTheme;
-        this.visitor = new TableVisitor(tableTheme);
-    }
-
     @NonNull
-    public TableTheme theme() {
+    public TableTheme theme()
+    {
         return theme;
     }
 
     @Override
-    public void configureParser(@NonNull Parser.Builder builder) {
+    public void configureParser(@NonNull Parser.Builder builder)
+    {
         builder.extensions(Collections.singleton(TablesExtension.create()));
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
         visitor.configure(builder);
     }
 
     @Override
-    public void beforeRender(@NonNull Node node) {
+    public void beforeRender(@NonNull Node node)
+    {
         // clear before rendering (as visitor has some internal mutable state)
         visitor.clear();
     }
 
     @Override
-    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown) {
+    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown)
+    {
         TableRowsScheduler.unschedule(textView);
     }
 
     @Override
-    public void afterSetText(@NonNull TextView textView) {
+    public void afterSetText(@NonNull TextView textView)
+    {
         TableRowsScheduler.schedule(textView);
     }
 
-    private static class TableVisitor {
+    public interface ThemeConfigure
+    {
+        void configureTheme(@NonNull TableTheme.Builder builder);
+    }
+
+    private static class TableVisitor
+    {
 
         private final TableTheme tableTheme;
 
@@ -106,126 +117,19 @@ public class TablePlugin extends AbstractStylarPlugin
         private boolean tableRowIsHeader;
         private int tableRows;
 
-        TableVisitor(@NonNull TableTheme tableTheme) {
+        TableVisitor(@NonNull TableTheme tableTheme)
+        {
             this.tableTheme = tableTheme;
         }
 
-        void clear() {
-            pendingTableRow = null;
-            tableRowIsHeader = false;
-            tableRows = 0;
-        }
-
-        void configure(@NonNull StylarVisitor.Builder builder) {
-            builder
-                    // @since 4.1.1 we use TableBlock instead of TableBody to add new lines
-                    .on(TableBlock.class, new StylarVisitor.NodeVisitor<TableBlock>() {
-                        @Override
-                        public void visit(@NonNull StylarVisitor visitor, @NonNull TableBlock tableBlock) {
-
-                            visitor.blockStart(tableBlock);
-
-                            final int length = visitor.length();
-
-                            visitor.visitChildren(tableBlock);
-
-                            // @since 4.3.1 apply table span for the full table
-                            visitor.setSpans(length, new TableSpan());
-
-                            visitor.blockEnd(tableBlock);
-                        }
-                    })
-                    .on(TableBody.class, new StylarVisitor.NodeVisitor<TableBody>() {
-                        @Override
-                        public void visit(@NonNull StylarVisitor visitor, @NonNull TableBody tableBody) {
-                            visitor.visitChildren(tableBody);
-                            tableRows = 0;
-                        }
-                    })
-                    .on(TableRow.class, new StylarVisitor.NodeVisitor<TableRow>() {
-                        @Override
-                        public void visit(@NonNull StylarVisitor visitor, @NonNull TableRow tableRow) {
-                            visitRow(visitor, tableRow);
-                        }
-                    })
-                    .on(TableHead.class, new StylarVisitor.NodeVisitor<TableHead>() {
-                        @Override
-                        public void visit(@NonNull StylarVisitor visitor, @NonNull TableHead tableHead) {
-                            visitRow(visitor, tableHead);
-                        }
-                    })
-                    .on(TableCell.class, new StylarVisitor.NodeVisitor<TableCell>() {
-                        @Override
-                        public void visit(@NonNull StylarVisitor visitor, @NonNull TableCell tableCell) {
-
-                            final int length = visitor.length();
-
-                            visitor.visitChildren(tableCell);
-
-                            if (pendingTableRow == null) {
-                                pendingTableRow = new ArrayList<>(2);
-                            }
-
-                            pendingTableRow.add(new TableRowSpan.Cell(
-                                    tableCellAlignment(tableCell.getAlignment()),
-                                    visitor.builder().removeFromEnd(length)
-                            ));
-
-                            tableRowIsHeader = tableCell.isHeader();
-                        }
-                    });
-        }
-
-        private void visitRow(@NonNull StylarVisitor visitor, @NonNull Node node) {
-
-            final int length = visitor.length();
-
-            visitor.visitChildren(node);
-
-            if (pendingTableRow != null) {
-
-                final SpannableBuilder builder = visitor.builder();
-
-                // @since 2.0.0
-                // we cannot rely on hasNext(TableHead) as it's not reliable
-                // we must apply new line manually and then exclude it from tableRow span
-                final boolean addNewLine;
-                {
-                    final int builderLength = builder.length();
-                    addNewLine = builderLength > 0
-                            && '\n' != builder.charAt(builderLength - 1);
-                }
-
-                if (addNewLine) {
-                    visitor.forceNewLine();
-                }
-
-                // @since 1.0.4 Replace table char with non-breakable space
-                // we need this because if table is at the end of the text, then it will be
-                // trimmed from the final result
-                builder.append('\u00a0');
-
-                final Object span = new TableRowSpan(
-                        tableTheme,
-                        pendingTableRow,
-                        tableRowIsHeader,
-                        tableRows % 2 == 1);
-
-                tableRows = tableRowIsHeader
-                        ? 0
-                        : tableRows + 1;
-
-                visitor.setSpans(addNewLine ? length + 1 : length, span);
-
-                pendingTableRow = null;
-            }
-        }
-
         @TableRowSpan.Alignment
-        private static int tableCellAlignment(TableCell.Alignment alignment) {
+        private static int tableCellAlignment(TableCell.Alignment alignment)
+        {
             final int out;
-            if (alignment != null) {
-                switch (alignment) {
+            if (alignment != null)
+            {
+                switch (alignment)
+                {
                     case CENTER:
                         out = TableRowSpan.ALIGN_CENTER;
                         break;
@@ -236,10 +140,138 @@ public class TablePlugin extends AbstractStylarPlugin
                         out = TableRowSpan.ALIGN_LEFT;
                         break;
                 }
-            } else {
+            } else
+            {
                 out = TableRowSpan.ALIGN_LEFT;
             }
             return out;
+        }
+
+        void clear()
+        {
+            pendingTableRow = null;
+            tableRowIsHeader = false;
+            tableRows = 0;
+        }
+
+        void configure(@NonNull StylarVisitor.Builder builder)
+        {
+            builder
+                // @since 4.1.1 we use TableBlock instead of TableBody to add new lines
+                .on(TableBlock.class, new StylarVisitor.NodeVisitor<TableBlock>()
+                {
+                    @Override
+                    public void visit(@NonNull StylarVisitor visitor, @NonNull TableBlock tableBlock)
+                    {
+
+                        visitor.blockStart(tableBlock);
+
+                        final int length = visitor.length();
+
+                        visitor.visitChildren(tableBlock);
+
+                        // @since 4.3.1 apply table span for the full table
+                        visitor.setSpans(length, new TableSpan());
+
+                        visitor.blockEnd(tableBlock);
+                    }
+                })
+                .on(TableBody.class, new StylarVisitor.NodeVisitor<TableBody>()
+                {
+                    @Override
+                    public void visit(@NonNull StylarVisitor visitor, @NonNull TableBody tableBody)
+                    {
+                        visitor.visitChildren(tableBody);
+                        tableRows = 0;
+                    }
+                })
+                .on(TableRow.class, new StylarVisitor.NodeVisitor<TableRow>()
+                {
+                    @Override
+                    public void visit(@NonNull StylarVisitor visitor, @NonNull TableRow tableRow)
+                    {
+                        visitRow(visitor, tableRow);
+                    }
+                })
+                .on(TableHead.class, new StylarVisitor.NodeVisitor<TableHead>()
+                {
+                    @Override
+                    public void visit(@NonNull StylarVisitor visitor, @NonNull TableHead tableHead)
+                    {
+                        visitRow(visitor, tableHead);
+                    }
+                })
+                .on(TableCell.class, new StylarVisitor.NodeVisitor<TableCell>()
+                {
+                    @Override
+                    public void visit(@NonNull StylarVisitor visitor, @NonNull TableCell tableCell)
+                    {
+
+                        final int length = visitor.length();
+
+                        visitor.visitChildren(tableCell);
+
+                        if (pendingTableRow == null)
+                        {
+                            pendingTableRow = new ArrayList<>(2);
+                        }
+
+                        pendingTableRow.add(new TableRowSpan.Cell(
+                            tableCellAlignment(tableCell.getAlignment()),
+                            visitor.builder().removeFromEnd(length)
+                        ));
+
+                        tableRowIsHeader = tableCell.isHeader();
+                    }
+                });
+        }
+
+        private void visitRow(@NonNull StylarVisitor visitor, @NonNull Node node)
+        {
+
+            final int length = visitor.length();
+
+            visitor.visitChildren(node);
+
+            if (pendingTableRow != null)
+            {
+
+                final SpannableBuilder builder = visitor.builder();
+
+                // @since 2.0.0
+                // we cannot rely on hasNext(TableHead) as it's not reliable
+                // we must apply new line manually and then exclude it from tableRow span
+                final boolean addNewLine;
+                {
+                    final int builderLength = builder.length();
+                    addNewLine = builderLength > 0
+                        && '\n' != builder.charAt(builderLength - 1);
+                }
+
+                if (addNewLine)
+                {
+                    visitor.forceNewLine();
+                }
+
+                // @since 1.0.4 Replace table char with non-breakable space
+                // we need this because if table is at the end of the text, then it will be
+                // trimmed from the final result
+                builder.append('\u00a0');
+
+                final Object span = new TableRowSpan(
+                    tableTheme,
+                    pendingTableRow,
+                    tableRowIsHeader,
+                    tableRows % 2 == 1);
+
+                tableRows = tableRowIsHeader
+                    ? 0
+                    : tableRows + 1;
+
+                visitor.setSpans(addNewLine ? length + 1 : length, span);
+
+                pendingTableRow = null;
+            }
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableRowSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableRowSpan.java
@@ -18,80 +18,41 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.zeoflow.stylar.core.spans.TextLayoutSpan;
 import com.zeoflow.stylar.image.AsyncDrawable;
 import com.zeoflow.stylar.image.AsyncDrawableSpan;
 import com.zeoflow.stylar.utils.LeadingMarginUtils;
 import com.zeoflow.stylar.utils.SpanUtils;
 
-public class TableRowSpan extends ReplacementSpan {
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TableRowSpan extends ReplacementSpan
+{
 
     public static final int ALIGN_LEFT = 0;
     public static final int ALIGN_CENTER = 1;
     public static final int ALIGN_RIGHT = 2;
-
-    @IntDef(value = {ALIGN_LEFT, ALIGN_CENTER, ALIGN_RIGHT})
-    @Retention(RetentionPolicy.SOURCE)
-    public @interface Alignment {
-    }
-
-    public interface Invalidator {
-        void invalidate();
-    }
-
-    public static class Cell {
-
-        final int alignment;
-        final CharSequence text;
-
-        public Cell(@Alignment int alignment, CharSequence text) {
-            this.alignment = alignment;
-            this.text = text;
-        }
-
-        @Alignment
-        public int alignment() {
-            return alignment;
-        }
-
-        public CharSequence text() {
-            return text;
-        }
-
-        @NonNull
-        @Override
-        public String toString() {
-            return "Cell{" +
-                    "alignment=" + alignment +
-                    ", text=" + text +
-                    '}';
-        }
-    }
-
     private final TableTheme theme;
     private final List<Cell> cells;
     private final List<Layout> layouts;
     private final TextPaint textPaint;
     private final boolean header;
     private final boolean odd;
-
     private final Rect rect = new Rect();
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
-
     private int width;
     private int height;
     private Invalidator invalidator;
 
     public TableRowSpan(
-            @NonNull TableTheme theme,
-            @NonNull List<Cell> cells,
-            boolean header,
-            boolean odd) {
+        @NonNull TableTheme theme,
+        @NonNull List<Cell> cells,
+        boolean header,
+        boolean odd)
+    {
         this.theme = theme;
         this.cells = cells;
         this.layouts = new ArrayList<>(cells.size());
@@ -100,25 +61,49 @@ public class TableRowSpan extends ReplacementSpan {
         this.odd = odd;
     }
 
+    @SuppressLint("SwitchIntDef")
+    private static Layout.Alignment alignment(@Alignment int alignment)
+    {
+        final Layout.Alignment out;
+        switch (alignment)
+        {
+            case ALIGN_CENTER:
+                out = Layout.Alignment.ALIGN_CENTER;
+                break;
+            case ALIGN_RIGHT:
+                out = Layout.Alignment.ALIGN_OPPOSITE;
+                break;
+            default:
+                out = Layout.Alignment.ALIGN_NORMAL;
+                break;
+        }
+        return out;
+    }
+
     @Override
     public int getSize(
-            @NonNull Paint paint,
-            CharSequence text,
-            @IntRange(from = 0) int start,
-            @IntRange(from = 0) int end,
-            @Nullable Paint.FontMetricsInt fm) {
+        @NonNull Paint paint,
+        CharSequence text,
+        @IntRange(from = 0) int start,
+        @IntRange(from = 0) int end,
+        @Nullable Paint.FontMetricsInt fm)
+    {
 
         // it's our absolute requirement to have width of the canvas here... because, well, it changes
         // the way we draw text. So, if we do not know the width of canvas we cannot correctly measure our text
 
-        if (layouts.size() > 0) {
+        if (layouts.size() > 0)
+        {
 
-            if (fm != null) {
+            if (fm != null)
+            {
 
                 int max = 0;
-                for (Layout layout : layouts) {
+                for (Layout layout : layouts)
+                {
                     final int height = layout.getHeight();
-                    if (height > max) {
+                    if (height > max)
+                    {
                         max = height;
                     }
                 }
@@ -142,24 +127,28 @@ public class TableRowSpan extends ReplacementSpan {
 
     @Override
     public void draw(
-            @NonNull Canvas canvas,
-            CharSequence text,
-            @IntRange(from = 0) int start,
-            @IntRange(from = 0) int end,
-            float x,
-            int top,
-            int y,
-            int bottom,
-            @NonNull Paint p) {
+        @NonNull Canvas canvas,
+        CharSequence text,
+        @IntRange(from = 0) int start,
+        @IntRange(from = 0) int end,
+        float x,
+        int top,
+        int y,
+        int bottom,
+        @NonNull Paint p)
+    {
 
         final int spanWidth = SpanUtils.width(canvas, text);
-        if (recreateLayouts(spanWidth)) {
+        if (recreateLayouts(spanWidth))
+        {
             width = spanWidth;
             // @since 4.3.1 it's important to cast to TextPaint in order to display links, etc
-            if (p instanceof TextPaint) {
+            if (p instanceof TextPaint)
+            {
                 // there must be a reason why this method receives Paint instead of TextPaint...
                 textPaint.set((TextPaint) p);
-            } else {
+            } else
+            {
                 textPaint.set(p);
             }
             makeNewLayouts();
@@ -179,23 +168,29 @@ public class TableRowSpan extends ReplacementSpan {
         // @since 1.1.1
         // draw backgrounds
         {
-            if (header) {
+            if (header)
+            {
                 theme.applyTableHeaderRowStyle(paint);
-            } else if (odd) {
+            } else if (odd)
+            {
                 theme.applyTableOddRowStyle(paint);
-            } else {
+            } else
+            {
                 // even
                 theme.applyTableEvenRowStyle(paint);
             }
 
             // if present (0 is transparent)
-            if (paint.getColor() != 0) {
+            if (paint.getColor() != 0)
+            {
                 final int save = canvas.save();
-                try {
+                try
+                {
                     rect.set(0, 0, width, bottom - top);
                     canvas.translate(x, top);
                     canvas.drawRect(rect, paint);
-                } finally {
+                } finally
+                {
                     canvas.restoreToCount(save);
                 }
             }
@@ -217,15 +212,18 @@ public class TableRowSpan extends ReplacementSpan {
         final boolean isFirstTableRow;
 
         // @since 4.3.1
-        if (drawBorder) {
+        if (drawBorder)
+        {
             boolean first = false;
             // only if first draw the line
             {
                 final Spanned spanned = (Spanned) text;
                 final TableSpan[] spans = spanned.getSpans(start, end, TableSpan.class);
-                if (spans != null && spans.length > 0) {
+                if (spans != null && spans.length > 0)
+                {
                     final TableSpan span = spans[0];
-                    if (LeadingMarginUtils.selfStart(start, text, span)) {
+                    if (LeadingMarginUtils.selfStart(start, text, span))
+                    {
                         first = true;
                         rect.set((int) x, top, width, top + borderWidth);
                         canvas.drawRect(rect, paint);
@@ -238,7 +236,8 @@ public class TableRowSpan extends ReplacementSpan {
             canvas.drawRect(rect, paint);
 
             isFirstTableRow = first;
-        } else {
+        } else
+        {
             isFirstTableRow = false;
         }
 
@@ -249,31 +248,37 @@ public class TableRowSpan extends ReplacementSpan {
         final int borderBottom = bottom - top - borderWidth;
 
         Layout layout;
-        for (int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++)
+        {
             layout = layouts.get(i);
             final int save = canvas.save();
-            try {
+            try
+            {
 
                 canvas.translate(x + (i * w), top);
 
                 // @since 4.3.1
-                if (drawBorder) {
+                if (drawBorder)
+                {
                     // first vertical border will have full width (it cannot exceed canvas)
-                    if (i == 0) {
+                    if (i == 0)
+                    {
                         rect.set(0, borderTop, borderWidth, borderBottom);
-                    } else {
+                    } else
+                    {
                         rect.set(-borderWidthHalf, borderTop, borderWidthHalf, borderBottom);
                     }
 
                     canvas.drawRect(rect, paint);
 
-                    if (i == (size - 1)) {
+                    if (i == (size - 1))
+                    {
                         // @since 4.6.0 subtract rounding offset for the last vertical divider
                         rect.set(
-                                w - borderWidth - roundingDiff,
-                                borderTop,
-                                w - roundingDiff,
-                                borderBottom
+                            w - borderWidth - roundingDiff,
+                            borderTop,
+                            w - roundingDiff,
+                            borderBottom
                         );
                         canvas.drawRect(rect, paint);
                     }
@@ -282,27 +287,33 @@ public class TableRowSpan extends ReplacementSpan {
                 canvas.translate(padding, padding + heightDiff);
                 layout.draw(canvas);
 
-                if (layout.getHeight() > maxHeight) {
+                if (layout.getHeight() > maxHeight)
+                {
                     maxHeight = layout.getHeight();
                 }
 
-            } finally {
+            } finally
+            {
                 canvas.restoreToCount(save);
             }
         }
 
-        if (height != maxHeight) {
-            if (invalidator != null) {
+        if (height != maxHeight)
+        {
+            if (invalidator != null)
+            {
                 invalidator.invalidate();
             }
         }
     }
 
-    private boolean recreateLayouts(int newWidth) {
+    private boolean recreateLayouts(int newWidth)
+    {
         return width != newWidth;
     }
 
-    private void makeNewLayouts() {
+    private void makeNewLayouts()
+    {
 
         textPaint.setFakeBoldText(header);
 
@@ -312,18 +323,23 @@ public class TableRowSpan extends ReplacementSpan {
 
         this.layouts.clear();
 
-        for (int i = 0, size = cells.size(); i < size; i++) {
+        for (int i = 0, size = cells.size(); i < size; i++)
+        {
             makeLayout(i, w, cells.get(i));
         }
     }
 
-    private void makeLayout(final int index, final int width, @NonNull final Cell cell) {
+    private void makeLayout(final int index, final int width, @NonNull final Cell cell)
+    {
 
-        final Runnable recreate = new Runnable() {
+        final Runnable recreate = new Runnable()
+        {
             @Override
-            public void run() {
+            public void run()
+            {
                 final Invalidator invalidator = TableRowSpan.this.invalidator;
-                if (invalidator != null) {
+                if (invalidator != null)
+                {
                     layouts.remove(index);
                     makeLayout(index, width, cell);
                     invalidator.invalidate();
@@ -333,20 +349,22 @@ public class TableRowSpan extends ReplacementSpan {
 
         final Spannable spannable;
 
-        if (cell.text instanceof Spannable) {
+        if (cell.text instanceof Spannable)
+        {
             spannable = (Spannable) cell.text;
-        } else {
+        } else
+        {
             spannable = new SpannableString(cell.text);
         }
 
         final Layout layout = new StaticLayout(
-                spannable,
-                textPaint,
-                width,
-                alignment(cell.alignment),
-                1.0F,
-                0.0F,
-                false
+            spannable,
+            textPaint,
+            width,
+            alignment(cell.alignment),
+            1.0F,
+            0.0F,
+            false
         );
 
         // @since 4.4.0
@@ -358,25 +376,31 @@ public class TableRowSpan extends ReplacementSpan {
         layouts.add(index, layout);
     }
 
-    private void scheduleAsyncDrawables(@NonNull Spannable spannable, @NonNull final Runnable recreate) {
+    private void scheduleAsyncDrawables(@NonNull Spannable spannable, @NonNull final Runnable recreate)
+    {
 
         final AsyncDrawableSpan[] spans = spannable.getSpans(0, spannable.length(), AsyncDrawableSpan.class);
         if (spans != null
-                && spans.length > 0) {
+            && spans.length > 0)
+        {
 
-            for (AsyncDrawableSpan span : spans) {
+            for (AsyncDrawableSpan span : spans)
+            {
 
                 final AsyncDrawable drawable = span.getDrawable();
 
                 // it is absolutely crucial to check if drawable is already attached,
                 //  otherwise we would end up with a loop
-                if (drawable.isAttached()) {
+                if (drawable.isAttached())
+                {
                     continue;
                 }
 
-                drawable.setCallback2(new CallbackAdapter() {
+                drawable.setCallback2(new CallbackAdapter()
+                {
                     @Override
-                    public void invalidateDrawable(@NonNull Drawable who) {
+                    public void invalidateDrawable(@NonNull Drawable who)
+                    {
                         recreate.run();
                     }
                 });
@@ -390,11 +414,13 @@ public class TableRowSpan extends ReplacementSpan {
      * @since 4.6.0
      */
     @Nullable
-    public Layout findLayoutForHorizontalOffset(int x) {
+    public Layout findLayoutForHorizontalOffset(int x)
+    {
         final int size = layouts.size();
         final int w = cellWidth(size);
         final int i = x / w;
-        if (i >= size) {
+        if (i >= size)
+        {
             return null;
         }
         return layouts.get(i);
@@ -403,49 +429,84 @@ public class TableRowSpan extends ReplacementSpan {
     /**
      * @since 4.6.0
      */
-    public int cellWidth() {
+    public int cellWidth()
+    {
         return cellWidth(layouts.size());
     }
 
     // @since 4.6.0
-    protected int cellWidth(int size) {
+    protected int cellWidth(int size)
+    {
         return (int) (1F * width / size + 0.5F);
     }
 
-    @SuppressLint("SwitchIntDef")
-    private static Layout.Alignment alignment(@Alignment int alignment) {
-        final Layout.Alignment out;
-        switch (alignment) {
-            case ALIGN_CENTER:
-                out = Layout.Alignment.ALIGN_CENTER;
-                break;
-            case ALIGN_RIGHT:
-                out = Layout.Alignment.ALIGN_OPPOSITE;
-                break;
-            default:
-                out = Layout.Alignment.ALIGN_NORMAL;
-                break;
-        }
-        return out;
-    }
-
-    public void invalidator(@Nullable Invalidator invalidator) {
+    public void invalidator(@Nullable Invalidator invalidator)
+    {
         this.invalidator = invalidator;
     }
 
-    private static abstract class CallbackAdapter implements Drawable.Callback {
+    @IntDef(value = {ALIGN_LEFT, ALIGN_CENTER, ALIGN_RIGHT})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Alignment
+    {
+    }
+
+    public interface Invalidator
+    {
+        void invalidate();
+    }
+
+    public static class Cell
+    {
+
+        final int alignment;
+        final CharSequence text;
+
+        public Cell(@Alignment int alignment, CharSequence text)
+        {
+            this.alignment = alignment;
+            this.text = text;
+        }
+
+        @Alignment
+        public int alignment()
+        {
+            return alignment;
+        }
+
+        public CharSequence text()
+        {
+            return text;
+        }
+
+        @NonNull
         @Override
-        public void invalidateDrawable(@NonNull Drawable who) {
+        public String toString()
+        {
+            return "Cell{" +
+                "alignment=" + alignment +
+                ", text=" + text +
+                '}';
+        }
+    }
+
+    private static abstract class CallbackAdapter implements Drawable.Callback
+    {
+        @Override
+        public void invalidateDrawable(@NonNull Drawable who)
+        {
 
         }
 
         @Override
-        public void scheduleDrawable(@NonNull Drawable who, @NonNull Runnable what, long when) {
+        public void scheduleDrawable(@NonNull Drawable who, @NonNull Runnable what, long when)
+        {
 
         }
 
         @Override
-        public void unscheduleDrawable(@NonNull Drawable who, @NonNull Runnable what) {
+        public void unscheduleDrawable(@NonNull Drawable who, @NonNull Runnable what)
+        {
 
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableRowsScheduler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableRowsScheduler.java
@@ -10,22 +10,33 @@ import androidx.annotation.Nullable;
 
 import com.zeoflow.stylar.R;
 
-abstract class TableRowsScheduler {
+abstract class TableRowsScheduler
+{
 
-    static void schedule(@NonNull final TextView view) {
+    private TableRowsScheduler()
+    {
+    }
+
+    static void schedule(@NonNull final TextView view)
+    {
         final Object[] spans = extract(view);
         if (spans != null
-                && spans.length > 0) {
+            && spans.length > 0)
+        {
 
-            if (view.getTag(R.id.stylar_tables_scheduler) == null) {
-                final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener() {
+            if (view.getTag(R.id.stylar_tables_scheduler) == null)
+            {
+                final View.OnAttachStateChangeListener listener = new View.OnAttachStateChangeListener()
+                {
                     @Override
-                    public void onViewAttachedToWindow(View v) {
+                    public void onViewAttachedToWindow(View v)
+                    {
 
                     }
 
                     @Override
-                    public void onViewDetachedFromWindow(View v) {
+                    public void onViewDetachedFromWindow(View v)
+                    {
                         unschedule(view);
                         view.removeOnAttachStateChangeListener(this);
                         view.setTag(R.id.stylar_tables_scheduler, null);
@@ -35,54 +46,62 @@ abstract class TableRowsScheduler {
                 view.setTag(R.id.stylar_tables_scheduler, listener);
             }
 
-            final TableRowSpan.Invalidator invalidator = new TableRowSpan.Invalidator() {
+            final TableRowSpan.Invalidator invalidator = new TableRowSpan.Invalidator()
+            {
 
                 // @since 4.1.0
                 // let's stack-up invalidation calls (so invalidation happens,
                 // but not with each table-row-span draw call)
-                final Runnable runnable = new Runnable() {
+                final Runnable runnable = new Runnable()
+                {
                     @Override
-                    public void run() {
+                    public void run()
+                    {
                         view.setText(view.getText());
                     }
                 };
 
                 @Override
-                public void invalidate() {
+                public void invalidate()
+                {
                     // @since 4.1.0 post invalidation (combine multiple calls)
                     view.removeCallbacks(runnable);
                     view.post(runnable);
                 }
             };
 
-            for (Object span : spans) {
+            for (Object span : spans)
+            {
                 ((TableRowSpan) span).invalidator(invalidator);
             }
         }
     }
 
-    static void unschedule(@NonNull TextView view) {
+    static void unschedule(@NonNull TextView view)
+    {
         final Object[] spans = extract(view);
         if (spans != null
-                && spans.length > 0) {
-            for (Object span : spans) {
+            && spans.length > 0)
+        {
+            for (Object span : spans)
+            {
                 ((TableRowSpan) span).invalidator(null);
             }
         }
     }
 
     @Nullable
-    private static Object[] extract(@NonNull TextView view) {
+    private static Object[] extract(@NonNull TextView view)
+    {
         final Object[] out;
         final CharSequence text = view.getText();
-        if (!TextUtils.isEmpty(text) && text instanceof Spanned) {
+        if (!TextUtils.isEmpty(text) && text instanceof Spanned)
+        {
             out = ((Spanned) text).getSpans(0, text.length(), TableRowSpan.class);
-        } else {
+        } else
+        {
             out = null;
         }
         return out;
-    }
-
-    private TableRowsScheduler() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableSpan.java
@@ -3,5 +3,6 @@ package com.zeoflow.stylar.ext.tables;
 /**
  * @since 4.3.1
  */
-public class TableSpan {
+public class TableSpan
+{
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableTheme.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tables/TableTheme.java
@@ -11,51 +11,27 @@ import com.zeoflow.stylar.utils.ColorUtils;
 import com.zeoflow.stylar.utils.Dip;
 
 @SuppressWarnings("WeakerAccess")
-public class TableTheme {
-
-    @NonNull
-    public static TableTheme create(@NonNull Context context) {
-        return buildWithDefaults(context).build();
-    }
-
-    @NonNull
-    public static Builder buildWithDefaults(@NonNull Context context) {
-        final Dip dip = Dip.create(context);
-        return emptyBuilder()
-                .tableCellPadding(dip.toPx(4))
-                .tableBorderWidth(dip.toPx(1));
-    }
-
-    @NonNull
-    public static Builder emptyBuilder() {
-        return new Builder();
-    }
-
+public class TableTheme
+{
 
     protected static final int TABLE_BORDER_DEF_ALPHA = 75;
-
     protected static final int TABLE_ODD_ROW_DEF_ALPHA = 22;
-
     // by default 0
     protected final int tableCellPadding;
-
     // by default paint.color * TABLE_BORDER_DEF_ALPHA
     protected final int tableBorderColor;
-
     protected final int tableBorderWidth;
-
     // by default paint.color * TABLE_ODD_ROW_DEF_ALPHA
     protected final int tableOddRowBackgroundColor;
-
     // @since 1.1.1
     // by default no background
     protected final int tableEvenRowBackgroundColor;
-
     // @since 1.1.1
     // by default no background
     protected final int tableHeaderRowBackgroundColor;
 
-    protected TableTheme(@NonNull Builder builder) {
+    protected TableTheme(@NonNull Builder builder)
+    {
         this.tableCellPadding = builder.tableCellPadding;
         this.tableBorderColor = builder.tableBorderColor;
         this.tableBorderWidth = builder.tableBorderWidth;
@@ -64,40 +40,69 @@ public class TableTheme {
         this.tableHeaderRowBackgroundColor = builder.tableHeaderRowBackgroundColor;
     }
 
+    @NonNull
+    public static TableTheme create(@NonNull Context context)
+    {
+        return buildWithDefaults(context).build();
+    }
+
+    @NonNull
+    public static Builder buildWithDefaults(@NonNull Context context)
+    {
+        final Dip dip = Dip.create(context);
+        return emptyBuilder()
+            .tableCellPadding(dip.toPx(4))
+            .tableBorderWidth(dip.toPx(1));
+    }
+
+    @NonNull
+    public static Builder emptyBuilder()
+    {
+        return new Builder();
+    }
+
     /**
      * @since 3.0.0
      */
     @NonNull
-    public Builder asBuilder() {
+    public Builder asBuilder()
+    {
         return new Builder()
-                .tableCellPadding(tableCellPadding)
-                .tableBorderColor(tableBorderColor)
-                .tableBorderWidth(tableBorderWidth)
-                .tableOddRowBackgroundColor(tableOddRowBackgroundColor)
-                .tableEvenRowBackgroundColor(tableEvenRowBackgroundColor)
-                .tableHeaderRowBackgroundColor(tableHeaderRowBackgroundColor);
+            .tableCellPadding(tableCellPadding)
+            .tableBorderColor(tableBorderColor)
+            .tableBorderWidth(tableBorderWidth)
+            .tableOddRowBackgroundColor(tableOddRowBackgroundColor)
+            .tableEvenRowBackgroundColor(tableEvenRowBackgroundColor)
+            .tableHeaderRowBackgroundColor(tableHeaderRowBackgroundColor);
     }
 
-    public int tableCellPadding() {
+    public int tableCellPadding()
+    {
         return tableCellPadding;
     }
 
-    public int tableBorderWidth(@NonNull Paint paint) {
+    public int tableBorderWidth(@NonNull Paint paint)
+    {
         final int out;
-        if (tableBorderWidth == -1) {
+        if (tableBorderWidth == -1)
+        {
             out = (int) (paint.getStrokeWidth() + .5F);
-        } else {
+        } else
+        {
             out = tableBorderWidth;
         }
         return out;
     }
 
-    public void applyTableBorderStyle(@NonNull Paint paint) {
+    public void applyTableBorderStyle(@NonNull Paint paint)
+    {
 
         final int color;
-        if (tableBorderColor == 0) {
+        if (tableBorderColor == 0)
+        {
             color = ColorUtils.applyAlpha(paint.getColor(), TABLE_BORDER_DEF_ALPHA);
-        } else {
+        } else
+        {
             color = tableBorderColor;
         }
 
@@ -106,11 +111,14 @@ public class TableTheme {
         paint.setStyle(Paint.Style.FILL);
     }
 
-    public void applyTableOddRowStyle(@NonNull Paint paint) {
+    public void applyTableOddRowStyle(@NonNull Paint paint)
+    {
         final int color;
-        if (tableOddRowBackgroundColor == 0) {
+        if (tableOddRowBackgroundColor == 0)
+        {
             color = ColorUtils.applyAlpha(paint.getColor(), TABLE_ODD_ROW_DEF_ALPHA);
-        } else {
+        } else
+        {
             color = tableOddRowBackgroundColor;
         }
         paint.setColor(color);
@@ -120,7 +128,8 @@ public class TableTheme {
     /**
      * @since 1.1.1
      */
-    public void applyTableEvenRowStyle(@NonNull Paint paint) {
+    public void applyTableEvenRowStyle(@NonNull Paint paint)
+    {
         // by default to background to even row
         paint.setColor(tableEvenRowBackgroundColor);
         paint.setStyle(Paint.Style.FILL);
@@ -129,12 +138,14 @@ public class TableTheme {
     /**
      * @since 1.1.1
      */
-    public void applyTableHeaderRowStyle(@NonNull Paint paint) {
+    public void applyTableHeaderRowStyle(@NonNull Paint paint)
+    {
         paint.setColor(tableHeaderRowBackgroundColor);
         paint.setStyle(Paint.Style.FILL);
     }
 
-    public static class Builder {
+    public static class Builder
+    {
 
         private int tableCellPadding;
         private int tableBorderColor;
@@ -144,43 +155,50 @@ public class TableTheme {
         private int tableHeaderRowBackgroundColor; // @since 1.1.1
 
         @NonNull
-        public Builder tableCellPadding(@Px int tableCellPadding) {
+        public Builder tableCellPadding(@Px int tableCellPadding)
+        {
             this.tableCellPadding = tableCellPadding;
             return this;
         }
 
         @NonNull
-        public Builder tableBorderColor(@ColorInt int tableBorderColor) {
+        public Builder tableBorderColor(@ColorInt int tableBorderColor)
+        {
             this.tableBorderColor = tableBorderColor;
             return this;
         }
 
         @NonNull
-        public Builder tableBorderWidth(@Px int tableBorderWidth) {
+        public Builder tableBorderWidth(@Px int tableBorderWidth)
+        {
             this.tableBorderWidth = tableBorderWidth;
             return this;
         }
 
         @NonNull
-        public Builder tableOddRowBackgroundColor(@ColorInt int tableOddRowBackgroundColor) {
+        public Builder tableOddRowBackgroundColor(@ColorInt int tableOddRowBackgroundColor)
+        {
             this.tableOddRowBackgroundColor = tableOddRowBackgroundColor;
             return this;
         }
 
         @NonNull
-        public Builder tableEvenRowBackgroundColor(@ColorInt int tableEvenRowBackgroundColor) {
+        public Builder tableEvenRowBackgroundColor(@ColorInt int tableEvenRowBackgroundColor)
+        {
             this.tableEvenRowBackgroundColor = tableEvenRowBackgroundColor;
             return this;
         }
 
         @NonNull
-        public Builder tableHeaderRowBackgroundColor(@ColorInt int tableHeaderRowBackgroundColor) {
+        public Builder tableHeaderRowBackgroundColor(@ColorInt int tableHeaderRowBackgroundColor)
+        {
             this.tableHeaderRowBackgroundColor = tableHeaderRowBackgroundColor;
             return this;
         }
 
         @NonNull
-        public TableTheme build() {
+        public TableTheme build()
+        {
             return new TableTheme(this);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListDrawable.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListDrawable.java
@@ -18,7 +18,8 @@ import androidx.annotation.Nullable;
  * @since 1.0.1
  */
 @SuppressWarnings("WeakerAccess")
-public class TaskListDrawable extends Drawable {
+public class TaskListDrawable extends Drawable
+{
 
     // represent ratios (not exact coordinates)
     private static final Point POINT_0 = new Point(2.75F / 18, 8.25F / 18);
@@ -39,9 +40,10 @@ public class TaskListDrawable extends Drawable {
     // unfortunately we cannot rely on TextView to be LAYER_TYPE_SOFTWARE
     // if we could we would draw our checkMarkPath with PorterDuff.CLEAR
     public TaskListDrawable(
-            @ColorInt int checkedFillColor,
-            @ColorInt int normalOutlineColor,
-            @ColorInt int checkMarkColor) {
+        @ColorInt int checkedFillColor,
+        @ColorInt int normalOutlineColor,
+        @ColorInt int checkMarkColor)
+    {
         this.checkedFillColor = checkedFillColor;
         this.normalOutlineColor = normalOutlineColor;
 
@@ -50,7 +52,8 @@ public class TaskListDrawable extends Drawable {
     }
 
     @Override
-    protected void onBoundsChange(Rect bounds) {
+    protected void onBoundsChange(Rect bounds)
+    {
         super.onBoundsChange(bounds);
 
         // we should exclude stroke with from final bounds (half of the strokeWidth from all sides)
@@ -73,15 +76,18 @@ public class TaskListDrawable extends Drawable {
     }
 
     @Override
-    public void draw(@NonNull Canvas canvas) {
+    public void draw(@NonNull Canvas canvas)
+    {
 
         final Paint.Style style;
         final int color;
 
-        if (isChecked) {
+        if (isChecked)
+        {
             style = Paint.Style.FILL_AND_STROKE;
             color = checkedFillColor;
-        } else {
+        } else
+        {
             style = Paint.Style.STROKE;
             color = normalOutlineColor;
         }
@@ -96,66 +102,79 @@ public class TaskListDrawable extends Drawable {
         final float radius = rectF.width() / 8;
 
         final int save = canvas.save();
-        try {
+        try
+        {
 
             canvas.translate(left, top);
 
             canvas.drawRoundRect(rectF, radius, radius, paint);
 
-            if (isChecked) {
+            if (isChecked)
+            {
                 canvas.drawPath(checkMarkPath, checkMarkPaint);
             }
-        } finally {
+        } finally
+        {
             canvas.restoreToCount(save);
         }
     }
 
     @Override
-    public void setAlpha(@IntRange(from = 0, to = 255) int alpha) {
+    public void setAlpha(@IntRange(from = 0, to = 255) int alpha)
+    {
         paint.setAlpha(alpha);
     }
 
     @Override
-    public void setColorFilter(@Nullable ColorFilter colorFilter) {
+    public void setColorFilter(@Nullable ColorFilter colorFilter)
+    {
         paint.setColorFilter(colorFilter);
     }
 
     @Override
-    public int getOpacity() {
+    public int getOpacity()
+    {
         return PixelFormat.OPAQUE;
     }
 
     @Override
-    public boolean isStateful() {
+    public boolean isStateful()
+    {
         return true;
     }
 
     @Override
-    protected boolean onStateChange(int[] state) {
+    protected boolean onStateChange(int[] state)
+    {
 
         final boolean checked;
 
         final int length = state != null
-                ? state.length
-                : 0;
+            ? state.length
+            : 0;
 
-        if (length > 0) {
+        if (length > 0)
+        {
 
             boolean inner = false;
 
-            for (int i = 0; i < length; i++) {
-                if (android.R.attr.state_checked == state[i]) {
+            for (int i = 0; i < length; i++)
+            {
+                if (android.R.attr.state_checked == state[i])
+                {
                     inner = true;
                     break;
                 }
             }
             checked = inner;
-        } else {
+        } else
+        {
             checked = false;
         }
 
         final boolean result = checked != isChecked;
-        if (result) {
+        if (result)
+        {
             invalidateSelf();
             isChecked = checked;
         }
@@ -163,21 +182,25 @@ public class TaskListDrawable extends Drawable {
         return result;
     }
 
-    private static class Point {
+    private static class Point
+    {
 
         final float x;
         final float y;
 
-        Point(float x, float y) {
+        Point(float x, float y)
+        {
             this.x = x;
             this.y = y;
         }
 
-        void moveTo(@NonNull Path path, float side) {
+        void moveTo(@NonNull Path path, float side)
+        {
             path.moveTo(side * x, side * y);
         }
 
-        void lineTo(@NonNull Path path, float side) {
+        void lineTo(@NonNull Path path, float side)
+        {
             path.lineTo(side * x, side * y);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListItem.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListItem.java
@@ -8,23 +8,27 @@ import org.commonmark.node.CustomBlock;
  * @since 1.0.1
  */
 @SuppressWarnings("WeakerAccess")
-public class TaskListItem extends CustomBlock {
+public class TaskListItem extends CustomBlock
+{
 
     private final boolean isDone;
 
-    public TaskListItem(boolean isDone) {
+    public TaskListItem(boolean isDone)
+    {
         this.isDone = isDone;
     }
 
-    public boolean isDone() {
+    public boolean isDone()
+    {
         return isDone;
     }
 
     @Override
     @NonNull
-    public String toString() {
+    public String toString()
+    {
         return "TaskListItem{" +
-                "isDone=" + isDone +
-                '}';
+            "isDone=" + isDone +
+            '}';
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListPlugin.java
@@ -21,6 +21,13 @@ import org.commonmark.parser.Parser;
 public class TaskListPlugin extends AbstractStylarPlugin
 {
 
+    private final Drawable drawable;
+
+    private TaskListPlugin(@NonNull Drawable drawable)
+    {
+        this.drawable = drawable;
+    }
+
     /**
      * Supplied Drawable must be stateful ({@link Drawable#isStateful()} returns true). If a task
      * is marked as done, then this drawable will be updated with an {@code int[] { android.R.attr.state_checked }}
@@ -30,12 +37,14 @@ public class TaskListPlugin extends AbstractStylarPlugin
      * @see TaskListDrawable
      */
     @NonNull
-    public static TaskListPlugin create(@NonNull Drawable drawable) {
+    public static TaskListPlugin create(@NonNull Drawable drawable)
+    {
         return new TaskListPlugin(drawable);
     }
 
     @NonNull
-    public static TaskListPlugin create(@NonNull Context context) {
+    public static TaskListPlugin create(@NonNull Context context)
+    {
 
         // by default we will be using link color for the checkbox color
         // & window background as a checkMark color
@@ -47,61 +56,65 @@ public class TaskListPlugin extends AbstractStylarPlugin
 
     @NonNull
     public static TaskListPlugin create(
-            @ColorInt int checkedFillColor,
-            @ColorInt int normalOutlineColor,
-            @ColorInt int checkMarkColor) {
+        @ColorInt int checkedFillColor,
+        @ColorInt int normalOutlineColor,
+        @ColorInt int checkMarkColor)
+    {
         return new TaskListPlugin(new TaskListDrawable(
-                checkedFillColor,
-                normalOutlineColor,
-                checkMarkColor));
+            checkedFillColor,
+            normalOutlineColor,
+            checkMarkColor));
     }
 
-    private final Drawable drawable;
-
-    private TaskListPlugin(@NonNull Drawable drawable) {
-        this.drawable = drawable;
+    private static int resolve(@NonNull Context context, @AttrRes int attr)
+    {
+        final TypedValue typedValue = new TypedValue();
+        final int[] attrs = new int[]{attr};
+        final TypedArray typedArray = context.obtainStyledAttributes(typedValue.data, attrs);
+        try
+        {
+            return typedArray.getColor(0, 0);
+        } finally
+        {
+            typedArray.recycle();
+        }
     }
 
     @Override
-    public void configureParser(@NonNull Parser.Builder builder) {
+    public void configureParser(@NonNull Parser.Builder builder)
+    {
         builder.postProcessor(new TaskListPostProcessor());
     }
 
     @Override
-    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder) {
+    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder)
+    {
         builder.setFactory(TaskListItem.class, new TaskListSpanFactory(drawable));
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
         builder
-                .on(TaskListItem.class, new StylarVisitor.NodeVisitor<TaskListItem>() {
-                    @Override
-                    public void visit(@NonNull StylarVisitor visitor, @NonNull TaskListItem taskListItem) {
+            .on(TaskListItem.class, new StylarVisitor.NodeVisitor<TaskListItem>()
+            {
+                @Override
+                public void visit(@NonNull StylarVisitor visitor, @NonNull TaskListItem taskListItem)
+                {
 
-                        final int length = visitor.length();
+                    final int length = visitor.length();
 
-                        visitor.visitChildren(taskListItem);
+                    visitor.visitChildren(taskListItem);
 
-                        TaskListProps.DONE.set(visitor.renderProps(), taskListItem.isDone());
+                    TaskListProps.DONE.set(visitor.renderProps(), taskListItem.isDone());
 
-                        visitor.setSpansForNode(taskListItem, length);
+                    visitor.setSpansForNode(taskListItem, length);
 
-                        if (visitor.hasNext(taskListItem)) {
-                            visitor.ensureNewLine();
-                        }
+                    if (visitor.hasNext(taskListItem))
+                    {
+                        visitor.ensureNewLine();
                     }
-                });
-    }
-
-    private static int resolve(@NonNull Context context, @AttrRes int attr) {
-        final TypedValue typedValue = new TypedValue();
-        final int[] attrs = new int[]{attr};
-        final TypedArray typedArray = context.obtainStyledAttributes(typedValue.data, attrs);
-        try {
-            return typedArray.getColor(0, 0);
-        } finally {
-            typedArray.recycle();
-        }
+                }
+            });
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListPostProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListPostProcessor.java
@@ -2,6 +2,8 @@ package com.zeoflow.stylar.ext.tasklist;
 
 import android.text.TextUtils;
 
+import com.zeoflow.stylar.utils.ParserUtils;
+
 import org.commonmark.node.AbstractVisitor;
 import org.commonmark.node.ListItem;
 import org.commonmark.node.Node;
@@ -12,36 +14,41 @@ import org.commonmark.parser.PostProcessor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.zeoflow.stylar.utils.ParserUtils;
-
 // @since 4.6.0
 // Hint taken from commonmark-ext-task-list-items artifact
-class TaskListPostProcessor implements PostProcessor {
+class TaskListPostProcessor implements PostProcessor
+{
 
     @Override
-    public Node process(Node node) {
+    public Node process(Node node)
+    {
         final TaskListVisitor visitor = new TaskListVisitor();
         node.accept(visitor);
         return node;
     }
 
-    private static class TaskListVisitor extends AbstractVisitor {
+    private static class TaskListVisitor extends AbstractVisitor
+    {
 
         private static final Pattern REGEX_TASK_LIST_ITEM = Pattern.compile("^\\[([xX\\s])]\\s+(.*)");
 
         @Override
-        public void visit(ListItem listItem) {
+        public void visit(ListItem listItem)
+        {
             // Takes first child and checks if it is Text (we are looking for exact `[xX\s]` without any formatting)
             final Node child = listItem.getFirstChild();
             // check if it is paragraph (can contain text)
-            if (child instanceof Paragraph) {
+            if (child instanceof Paragraph)
+            {
                 final Node node = child.getFirstChild();
-                if (node instanceof Text) {
+                if (node instanceof Text)
+                {
 
                     final Text textNode = (Text) node;
                     final Matcher matcher = REGEX_TASK_LIST_ITEM.matcher(textNode.getLiteral());
 
-                    if (matcher.matches()) {
+                    if (matcher.matches())
+                    {
                         final String checked = matcher.group(1);
                         final boolean isChecked = "x".equals(checked) || "X".equals(checked);
 
@@ -54,7 +61,8 @@ class TaskListPostProcessor implements PostProcessor {
 
                         // append the rest of matched text (can be empty)
                         final String restMatchedText = matcher.group(2);
-                        if (!TextUtils.isEmpty(restMatchedText)) {
+                        if (!TextUtils.isEmpty(restMatchedText))
+                        {
                             paragraph.appendChild(new Text(restMatchedText));
                         }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListProps.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListProps.java
@@ -5,10 +5,12 @@ import com.zeoflow.stylar.Prop;
 /**
  * @since 3.0.0
  */
-public abstract class TaskListProps {
+public abstract class TaskListProps
+{
 
     public static final Prop<Boolean> DONE = Prop.of("task-list-done");
 
-    private TaskListProps() {
+    private TaskListProps()
+    {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListSpan.java
@@ -14,7 +14,8 @@ import com.zeoflow.stylar.utils.LeadingMarginUtils;
 /**
  * @since 1.0.1
  */
-public class TaskListSpan implements LeadingMarginSpan {
+public class TaskListSpan implements LeadingMarginSpan
+{
 
     private static final int[] STATE_CHECKED = new int[]{android.R.attr.state_checked};
 
@@ -26,7 +27,8 @@ public class TaskListSpan implements LeadingMarginSpan {
     // @since 2.0.1 field is NOT final (to allow mutation)
     private boolean isDone;
 
-    public TaskListSpan(@NonNull StylarTheme theme, @NonNull Drawable drawable, boolean isDone) {
+    public TaskListSpan(@NonNull StylarTheme theme, @NonNull Drawable drawable, boolean isDone)
+    {
         this.theme = theme;
         this.drawable = drawable;
         this.isDone = isDone;
@@ -35,7 +37,8 @@ public class TaskListSpan implements LeadingMarginSpan {
     /**
      * @since 2.0.1
      */
-    public boolean isDone() {
+    public boolean isDone()
+    {
         return isDone;
     }
 
@@ -45,20 +48,24 @@ public class TaskListSpan implements LeadingMarginSpan {
      *
      * @since 2.0.1
      */
-    public void setDone(boolean isDone) {
+    public void setDone(boolean isDone)
+    {
         this.isDone = isDone;
     }
 
     @Override
-    public int getLeadingMargin(boolean first) {
+    public int getLeadingMargin(boolean first)
+    {
         return theme.getBlockMargin();
     }
 
     @Override
-    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout) {
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline, int bottom, CharSequence text, int start, int end, boolean first, Layout layout)
+    {
 
         if (!first
-                || !LeadingMarginUtils.selfStart(start, text, this)) {
+            || !LeadingMarginUtils.selfStart(start, text, this))
+        {
             return;
         }
 
@@ -66,7 +73,8 @@ public class TaskListSpan implements LeadingMarginSpan {
         final float ascent = p.ascent();
 
         final int save = c.save();
-        try {
+        try
+        {
 
             final int width = theme.getBlockMargin();
             final int height = (int) (descent - ascent + 0.5F);
@@ -76,20 +84,25 @@ public class TaskListSpan implements LeadingMarginSpan {
 
             drawable.setBounds(0, 0, w, h);
 
-            if (drawable.isStateful()) {
+            if (drawable.isStateful())
+            {
                 final int[] state;
-                if (isDone) {
+                if (isDone)
+                {
                     state = STATE_CHECKED;
-                } else {
+                } else
+                {
                     state = STATE_NONE;
                 }
                 drawable.setState(state);
             }
 
             final int l;
-            if (dir > 0) {
+            if (dir > 0)
+            {
                 l = x + ((width - w) / 2);
-            } else {
+            } else
+            {
                 l = x - ((width - w) / 2) - w;
             }
 
@@ -98,7 +111,8 @@ public class TaskListSpan implements LeadingMarginSpan {
             c.translate(l, t);
             drawable.draw(c);
 
-        } finally {
+        } finally
+        {
             c.restoreToCount(save);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/ext/tasklist/TaskListSpanFactory.java
@@ -5,25 +5,28 @@ import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 
-public class TaskListSpanFactory implements SpanFactory {
+public class TaskListSpanFactory implements SpanFactory
+{
 
     private final Drawable drawable;
 
-    public TaskListSpanFactory(@NonNull Drawable drawable) {
+    public TaskListSpanFactory(@NonNull Drawable drawable)
+    {
         this.drawable = drawable;
     }
 
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new TaskListSpan(
-                configuration.theme(),
-                drawable,
-                TaskListProps.DONE.get(props, false)
+            configuration.theme(),
+            drawable,
+            TaskListProps.DONE.get(props, false)
         );
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/AppendableUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/AppendableUtils.java
@@ -4,32 +4,43 @@ import androidx.annotation.NonNull;
 
 import java.io.IOException;
 
-abstract class AppendableUtils {
+abstract class AppendableUtils
+{
 
-    static void appendQuietly(@NonNull Appendable appendable, char c) {
-        try {
+    private AppendableUtils()
+    {
+    }
+
+    static void appendQuietly(@NonNull Appendable appendable, char c)
+    {
+        try
+        {
             appendable.append(c);
-        } catch (IOException e) {
+        } catch (IOException e)
+        {
             throw new RuntimeException(e);
         }
     }
 
-    static void appendQuietly(@NonNull Appendable appendable, @NonNull CharSequence cs) {
-        try {
+    static void appendQuietly(@NonNull Appendable appendable, @NonNull CharSequence cs)
+    {
+        try
+        {
             appendable.append(cs);
-        } catch (IOException e) {
+        } catch (IOException e)
+        {
             throw new RuntimeException(e);
         }
     }
 
-    static void appendQuietly(@NonNull Appendable appendable, @NonNull CharSequence cs, int start, int end) {
-        try {
+    static void appendQuietly(@NonNull Appendable appendable, @NonNull CharSequence cs, int start, int end)
+    {
+        try
+        {
             appendable.append(cs, start, end);
-        } catch (IOException e) {
+        } catch (IOException e)
+        {
             throw new RuntimeException(e);
         }
-    }
-
-    private AppendableUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/CssInlineStyleParser.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/CssInlineStyleParser.java
@@ -8,39 +8,47 @@ import androidx.annotation.Nullable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-public abstract class CssInlineStyleParser {
+public abstract class CssInlineStyleParser
+{
+
+    @NonNull
+    public static CssInlineStyleParser create()
+    {
+        return new Impl();
+    }
 
     @NonNull
     public abstract Iterable<CssProperty> parse(@NonNull String inlineStyle);
 
-    @NonNull
-    public static CssInlineStyleParser create() {
-        return new Impl();
-    }
-
-    static class Impl extends CssInlineStyleParser {
+    static class Impl extends CssInlineStyleParser
+    {
 
         @NonNull
         @Override
-        public Iterable<CssProperty> parse(@NonNull String inlineStyle) {
+        public Iterable<CssProperty> parse(@NonNull String inlineStyle)
+        {
             return new CssIterable(inlineStyle);
         }
 
-        private static class CssIterable implements Iterable<CssProperty> {
+        private static class CssIterable implements Iterable<CssProperty>
+        {
 
             private final String input;
 
-            CssIterable(@NonNull String input) {
+            CssIterable(@NonNull String input)
+            {
                 this.input = input;
             }
 
             @NonNull
             @Override
-            public Iterator<CssProperty> iterator() {
+            public Iterator<CssProperty> iterator()
+            {
                 return new CssIterator();
             }
 
-            private class CssIterator implements Iterator<CssProperty> {
+            private class CssIterator implements Iterator<CssProperty>
+            {
 
                 private final CssProperty cssProperty = new CssProperty();
 
@@ -51,7 +59,8 @@ public abstract class CssInlineStyleParser {
                 private int index;
 
                 @Override
-                public boolean hasNext() {
+                public boolean hasNext()
+                {
 
                     prepareNext();
 
@@ -59,14 +68,17 @@ public abstract class CssInlineStyleParser {
                 }
 
                 @Override
-                public CssProperty next() {
-                    if (!hasNextPrepared()) {
+                public CssProperty next()
+                {
+                    if (!hasNextPrepared())
+                    {
                         throw new NoSuchElementException();
                     }
                     return cssProperty;
                 }
 
-                private void prepareNext() {
+                private void prepareNext()
+                {
 
                     // clear first
                     cssProperty.set("", "");
@@ -80,7 +92,8 @@ public abstract class CssInlineStyleParser {
 
                     boolean keyHasWhiteSpace = false;
 
-                    for (int i = index; i < length; i++) {
+                    for (int i = index; i < length; i++)
+                    {
 
                         c = input.charAt(i);
 
@@ -88,62 +101,79 @@ public abstract class CssInlineStyleParser {
                         // KEY and wait for the ':', if we do not find it and we find EOF or ';'
                         // we start creating KEY again after the ';'
 
-                        if (key == null) {
+                        if (key == null)
+                        {
 
-                            if (':' == c) {
+                            if (':' == c)
+                            {
 
                                 // we have no key yet, but we might have started creating it already
-                                if (builder.length() > 0) {
+                                if (builder.length() > 0)
+                                {
                                     key = builder.toString().trim();
                                 }
 
                                 builder.setLength(0);
 
-                            } else {
+                            } else
+                            {
                                 // if by any chance we have here the ';' -> reset key and try to match next
-                                if (';' == c) {
+                                if (';' == c)
+                                {
                                     builder.setLength(0);
-                                } else {
+                                } else
+                                {
 
                                     // key cannot have WS gaps (but leading and trailing are OK)
-                                    if (Character.isWhitespace(c)) {
-                                        if (builder.length() > 0) {
+                                    if (Character.isWhitespace(c))
+                                    {
+                                        if (builder.length() > 0)
+                                        {
                                             keyHasWhiteSpace = true;
                                         }
-                                    } else {
+                                    } else
+                                    {
                                         // if not a WS and we have found WS before, start a-new
                                         // else append
-                                        if (keyHasWhiteSpace) {
+                                        if (keyHasWhiteSpace)
+                                        {
                                             // start new filling
                                             builder.setLength(0);
                                             builder.append(c);
                                             // clear this flag
                                             keyHasWhiteSpace = false;
-                                        } else {
+                                        } else
+                                        {
                                             builder.append(c);
                                         }
                                     }
                                 }
                             }
-                        } else if (value == null) {
+                        } else if (value == null)
+                        {
 
-                            if (Character.isWhitespace(c)) {
-                                if (builder.length() > 0) {
+                            if (Character.isWhitespace(c))
+                            {
+                                if (builder.length() > 0)
+                                {
                                     builder.append(c);
                                 }
-                            } else if (';' == c) {
+                            } else if (';' == c)
+                            {
 
                                 value = builder.toString().trim();
                                 builder.setLength(0);
 
                                 // check if we have valid values -> if yes -> return it
-                                if (hasValues(key, value)) {
+                                if (hasValues(key, value))
+                                {
                                     index = i + 1;
                                     cssProperty.set(key, value);
                                     return;
                                 }
 
-                            } else {
+                            } else
+                            {
                                 builder.append(c);
                             }
                         }
@@ -151,20 +181,23 @@ public abstract class CssInlineStyleParser {
 
                     // here we must additionally check for EOF (we might be tracking value here)
                     if (key != null
-                            && builder.length() > 0) {
+                        && builder.length() > 0)
+                    {
                         value = builder.toString().trim();
                         cssProperty.set(key, value);
                         index = length;
                     }
                 }
 
-                private boolean hasNextPrepared() {
+                private boolean hasNextPrepared()
+                {
                     return hasValues(cssProperty.key(), cssProperty.value());
                 }
 
-                private boolean hasValues(@Nullable String key, @Nullable String value) {
+                private boolean hasValues(@Nullable String key, @Nullable String value)
+                {
                     return !TextUtils.isEmpty(key)
-                            && !TextUtils.isEmpty(value);
+                        && !TextUtils.isEmpty(value);
                 }
             }
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/CssProperty.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/CssProperty.java
@@ -2,41 +2,48 @@ package com.zeoflow.stylar.html;
 
 import androidx.annotation.NonNull;
 
-public class CssProperty {
+public class CssProperty
+{
 
     private String key;
     private String value;
 
-    CssProperty() {
+    CssProperty()
+    {
     }
 
-    void set(@NonNull String key, @NonNull String value) {
+    void set(@NonNull String key, @NonNull String value)
+    {
         this.key = key;
         this.value = value;
     }
 
     @NonNull
-    public String key() {
+    public String key()
+    {
         return key;
     }
 
     @NonNull
-    public String value() {
+    public String value()
+    {
         return value;
     }
 
     @NonNull
-    public CssProperty mutate() {
+    public CssProperty mutate()
+    {
         final CssProperty cssProperty = new CssProperty();
         cssProperty.set(this.key, this.value);
         return cssProperty;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "CssProperty{" +
-                "key='" + key + '\'' +
-                ", value='" + value + '\'' +
-                '}';
+            "key='" + key + '\'' +
+            ", value='" + value + '\'' +
+            '}';
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/HtmlEmptyTagReplacement.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/HtmlEmptyTagReplacement.java
@@ -13,42 +13,51 @@ import androidx.annotation.Nullable;
  *
  * @since 2.0.0
  */
-public class HtmlEmptyTagReplacement {
-
-    @NonNull
-    public static HtmlEmptyTagReplacement create() {
-        return new HtmlEmptyTagReplacement();
-    }
+public class HtmlEmptyTagReplacement
+{
 
     private static final String IMG_REPLACEMENT = "\uFFFC";
     private static final String IFRAME_REPLACEMENT = "\u00a0"; // non-breakable space
+
+    @NonNull
+    public static HtmlEmptyTagReplacement create()
+    {
+        return new HtmlEmptyTagReplacement();
+    }
 
     /**
      * @return replacement for supplied startTag or null if no replacement should occur (which will
      * lead to `Inline` tag have start &amp; end the same value, thus not applicable for applying a Span)
      */
     @Nullable
-    public String replace(@NonNull HtmlTag tag) {
+    public String replace(@NonNull HtmlTag tag)
+    {
 
         final String replacement;
 
         final String name = tag.name();
 
-        if ("br".equals(name)) {
+        if ("br".equals(name))
+        {
             replacement = "\n";
-        } else if ("img".equals(name)) {
+        } else if ("img".equals(name))
+        {
             final String alt = tag.attributes().get("alt");
             if (alt == null
-                    || alt.length() == 0) {
+                || alt.length() == 0)
+            {
                 // no alt is provided
                 replacement = IMG_REPLACEMENT;
-            } else {
+            } else
+            {
                 replacement = alt;
             }
-        } else if ("iframe".equals(name)) {
+        } else if ("iframe".equals(name))
+        {
             // @since 4.4.0 make iframe non-empty
             replacement = IFRAME_REPLACEMENT;
-        } else {
+        } else
+        {
             replacement = null;
         }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/html/HtmlPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/HtmlPlugin.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.zeoflow.stylar.AbstractStylarPlugin;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.StylarVisitor;
 import com.zeoflow.stylar.html.tag.BlockquoteHandler;
 import com.zeoflow.stylar.html.tag.EmphasisHandler;
@@ -21,24 +22,28 @@ import org.commonmark.node.HtmlBlock;
 import org.commonmark.node.HtmlInline;
 import org.commonmark.node.Node;
 
-import com.zeoflow.stylar.StylarConfiguration;
-
 /**
  * @since 3.0.0
  */
 public class HtmlPlugin extends AbstractStylarPlugin
 {
 
-    /**
-     * @see #create(HtmlConfigure)
-     * @since 4.0.0
-     */
-    public interface HtmlConfigure {
-        void configureHtml(@NonNull HtmlPlugin plugin);
+    public static final float SCRIPT_DEF_TEXT_SIZE_RATIO = .75F;
+    private final StylarHtmlRendererImpl.Builder builder;
+    private StylarHtmlParser htmlParser;
+    private StylarHtmlRenderer htmlRenderer;
+    // @since 4.4.0
+    private HtmlEmptyTagReplacement emptyTagReplacement = new HtmlEmptyTagReplacement();
+
+    @SuppressWarnings("WeakerAccess")
+    HtmlPlugin()
+    {
+        this.builder = new StylarHtmlRendererImpl.Builder();
     }
 
     @NonNull
-    public static HtmlPlugin create() {
+    public static HtmlPlugin create()
+    {
         return new HtmlPlugin();
     }
 
@@ -46,25 +51,11 @@ public class HtmlPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public static HtmlPlugin create(@NonNull HtmlConfigure configure) {
+    public static HtmlPlugin create(@NonNull HtmlConfigure configure)
+    {
         final HtmlPlugin plugin = create();
         configure.configureHtml(plugin);
         return plugin;
-    }
-
-    public static final float SCRIPT_DEF_TEXT_SIZE_RATIO = .75F;
-
-    private final StylarHtmlRendererImpl.Builder builder;
-
-    private StylarHtmlParser htmlParser;
-    private StylarHtmlRenderer htmlRenderer;
-
-    // @since 4.4.0
-    private HtmlEmptyTagReplacement emptyTagReplacement = new HtmlEmptyTagReplacement();
-
-    @SuppressWarnings("WeakerAccess")
-    HtmlPlugin() {
-        this.builder = new StylarHtmlRendererImpl.Builder();
     }
 
     /**
@@ -73,7 +64,8 @@ public class HtmlPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public HtmlPlugin allowNonClosedTags(boolean allowNonClosedTags) {
+    public HtmlPlugin allowNonClosedTags(boolean allowNonClosedTags)
+    {
         builder.allowNonClosedTags(allowNonClosedTags);
         return this;
     }
@@ -82,7 +74,8 @@ public class HtmlPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public HtmlPlugin addHandler(@NonNull TagHandler tagHandler) {
+    public HtmlPlugin addHandler(@NonNull TagHandler tagHandler)
+    {
         builder.addHandler(tagHandler);
         return this;
     }
@@ -91,7 +84,8 @@ public class HtmlPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @Nullable
-    public TagHandler getHandler(@NonNull String tagName) {
+    public TagHandler getHandler(@NonNull String tagName)
+    {
         return builder.getHandler(tagName);
     }
 
@@ -104,7 +98,8 @@ public class HtmlPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public HtmlPlugin excludeDefaults(boolean excludeDefaults) {
+    public HtmlPlugin excludeDefaults(boolean excludeDefaults)
+    {
         builder.excludeDefaults(excludeDefaults);
         return this;
     }
@@ -114,19 +109,22 @@ public class HtmlPlugin extends AbstractStylarPlugin
      * @since 4.4.0
      */
     @NonNull
-    public HtmlPlugin emptyTagReplacement(@NonNull HtmlEmptyTagReplacement emptyTagReplacement) {
+    public HtmlPlugin emptyTagReplacement(@NonNull HtmlEmptyTagReplacement emptyTagReplacement)
+    {
         this.emptyTagReplacement = emptyTagReplacement;
         return this;
     }
 
     @Override
-    public void configureConfiguration(@NonNull StylarConfiguration.Builder configurationBuilder) {
+    public void configureConfiguration(@NonNull StylarConfiguration.Builder configurationBuilder)
+    {
 
         // @since 4.0.0 we init internal html-renderer here (marks the end of configuration)
 
         final StylarHtmlRendererImpl.Builder builder = this.builder;
 
-        if (!builder.excludeDefaults()) {
+        if (!builder.excludeDefaults())
+        {
             // please note that it's better to not checkState for
             // this method call (minor optimization), final `build` method call
             // will check for the state and throw an exception if applicable
@@ -148,35 +146,54 @@ public class HtmlPlugin extends AbstractStylarPlugin
     }
 
     @Override
-    public void afterRender(@NonNull Node node, @NonNull StylarVisitor visitor) {
+    public void afterRender(@NonNull Node node, @NonNull StylarVisitor visitor)
+    {
         final StylarHtmlRenderer htmlRenderer = this.htmlRenderer;
-        if (htmlRenderer != null) {
+        if (htmlRenderer != null)
+        {
             htmlRenderer.render(visitor, htmlParser);
-        } else {
+        } else
+        {
             throw new IllegalStateException("Unexpected state, html-renderer is not defined");
         }
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
         builder
-                .on(HtmlBlock.class, new StylarVisitor.NodeVisitor<HtmlBlock>() {
-                    @Override
-                    public void visit(@NonNull StylarVisitor visitor, @NonNull HtmlBlock htmlBlock) {
-                        visitHtml(visitor, htmlBlock.getLiteral());
-                    }
-                })
-                .on(HtmlInline.class, new StylarVisitor.NodeVisitor<HtmlInline>() {
-                    @Override
-                    public void visit(@NonNull StylarVisitor visitor, @NonNull HtmlInline htmlInline) {
-                        visitHtml(visitor, htmlInline.getLiteral());
-                    }
-                });
+            .on(HtmlBlock.class, new StylarVisitor.NodeVisitor<HtmlBlock>()
+            {
+                @Override
+                public void visit(@NonNull StylarVisitor visitor, @NonNull HtmlBlock htmlBlock)
+                {
+                    visitHtml(visitor, htmlBlock.getLiteral());
+                }
+            })
+            .on(HtmlInline.class, new StylarVisitor.NodeVisitor<HtmlInline>()
+            {
+                @Override
+                public void visit(@NonNull StylarVisitor visitor, @NonNull HtmlInline htmlInline)
+                {
+                    visitHtml(visitor, htmlInline.getLiteral());
+                }
+            });
     }
 
-    private void visitHtml(@NonNull StylarVisitor visitor, @Nullable String html) {
-        if (html != null) {
+    private void visitHtml(@NonNull StylarVisitor visitor, @Nullable String html)
+    {
+        if (html != null)
+        {
             htmlParser.processFragment(visitor.builder(), html);
         }
+    }
+
+    /**
+     * @see #create(HtmlConfigure)
+     * @since 4.0.0
+     */
+    public interface HtmlConfigure
+    {
+        void configureHtml(@NonNull HtmlPlugin plugin);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/HtmlTag.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/HtmlTag.java
@@ -11,7 +11,8 @@ import java.util.Map;
  * @see Block
  * @since 2.0.0
  */
-public interface HtmlTag {
+public interface HtmlTag
+{
 
     int NO_END = -1;
 
@@ -64,14 +65,16 @@ public interface HtmlTag {
     /**
      * Represents <em>really</em> inline HTML tags (unlile commonmark definitions)
      */
-    interface Inline extends HtmlTag {
+    interface Inline extends HtmlTag
+    {
     }
 
     /**
      * Represents HTML block tags. Please note that all tags that are not inline should be
      * considered as block tags
      */
-    interface Block extends HtmlTag {
+    interface Block extends HtmlTag
+    {
 
         /**
          * @return parent {@link Block} or null if there is no parent (this block is at root level)

--- a/stylar/src/main/java/com/zeoflow/stylar/html/HtmlTagImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/HtmlTagImpl.java
@@ -7,14 +7,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-abstract class HtmlTagImpl implements HtmlTag {
+abstract class HtmlTagImpl implements HtmlTag
+{
 
     final String name;
     final int start;
     final Map<String, String> attributes;
     int end = NO_END;
 
-    protected HtmlTagImpl(@NonNull String name, int start, @NonNull Map<String, String> attributes) {
+    protected HtmlTagImpl(@NonNull String name, int start, @NonNull Map<String, String> attributes)
+    {
         this.name = name;
         this.start = start;
         this.attributes = attributes;
@@ -22,120 +24,143 @@ abstract class HtmlTagImpl implements HtmlTag {
 
     @NonNull
     @Override
-    public String name() {
+    public String name()
+    {
         return name;
     }
 
     @Override
-    public int start() {
+    public int start()
+    {
         return start;
     }
 
     @Override
-    public int end() {
+    public int end()
+    {
         return end;
     }
 
     @Override
-    public boolean isEmpty() {
+    public boolean isEmpty()
+    {
         return start == end;
     }
 
     @NonNull
     @Override
-    public Map<String, String> attributes() {
+    public Map<String, String> attributes()
+    {
         return attributes;
     }
 
     @Override
-    public boolean isClosed() {
+    public boolean isClosed()
+    {
         return end > NO_END;
     }
 
     abstract void closeAt(int end);
 
 
-    static class InlineImpl extends HtmlTagImpl implements Inline {
+    static class InlineImpl extends HtmlTagImpl implements Inline
+    {
 
-        InlineImpl(@NonNull String name, int start, @NonNull Map<String, String> attributes) {
+        InlineImpl(@NonNull String name, int start, @NonNull Map<String, String> attributes)
+        {
             super(name, start, attributes);
         }
 
         @Override
-        void closeAt(int end) {
-            if (!isClosed()) {
+        void closeAt(int end)
+        {
+            if (!isClosed())
+            {
                 super.end = end;
             }
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return "InlineImpl{" +
-                    "name='" + name + '\'' +
-                    ", start=" + start +
-                    ", end=" + end +
-                    ", attributes=" + attributes +
-                    '}';
+                "name='" + name + '\'' +
+                ", start=" + start +
+                ", end=" + end +
+                ", attributes=" + attributes +
+                '}';
         }
 
         @Override
-        public boolean isInline() {
+        public boolean isInline()
+        {
             return true;
         }
 
         @Override
-        public boolean isBlock() {
+        public boolean isBlock()
+        {
             return false;
         }
 
         @NonNull
         @Override
-        public Inline getAsInline() {
+        public Inline getAsInline()
+        {
             return this;
         }
 
         @NonNull
         @Override
-        public Block getAsBlock() {
+        public Block getAsBlock()
+        {
             throw new ClassCastException("Cannot cast Inline instance to Block");
         }
     }
 
-    static class BlockImpl extends HtmlTagImpl implements Block {
-
-        @NonNull
-        static BlockImpl root() {
-            return new BlockImpl("", 0, Collections.<String, String>emptyMap(), null);
-        }
-
-        @NonNull
-        static BlockImpl create(
-                @NonNull String name,
-                int start,
-                @NonNull Map<String, String> attributes,
-                @Nullable BlockImpl parent) {
-            return new BlockImpl(name, start, attributes, parent);
-        }
+    static class BlockImpl extends HtmlTagImpl implements Block
+    {
 
         final BlockImpl parent;
         List<BlockImpl> children;
 
         @SuppressWarnings("NullableProblems")
         BlockImpl(
-                @NonNull String name,
-                int start,
-                @NonNull Map<String, String> attributes,
-                @Nullable BlockImpl parent) {
+            @NonNull String name,
+            int start,
+            @NonNull Map<String, String> attributes,
+            @Nullable BlockImpl parent)
+        {
             super(name, start, attributes);
             this.parent = parent;
         }
 
+        @NonNull
+        static BlockImpl root()
+        {
+            return new BlockImpl("", 0, Collections.<String, String>emptyMap(), null);
+        }
+
+        @NonNull
+        static BlockImpl create(
+            @NonNull String name,
+            int start,
+            @NonNull Map<String, String> attributes,
+            @Nullable BlockImpl parent)
+        {
+            return new BlockImpl(name, start, attributes, parent);
+        }
+
         @Override
-        void closeAt(int end) {
-            if (!isClosed()) {
+        void closeAt(int end)
+        {
+            if (!isClosed())
+            {
                 super.end = end;
-                if (children != null) {
-                    for (BlockImpl child : children) {
+                if (children != null)
+                {
+                    for (BlockImpl child : children)
+                    {
                         child.closeAt(end);
                     }
                 }
@@ -143,23 +168,28 @@ abstract class HtmlTagImpl implements HtmlTag {
         }
 
         @Override
-        public boolean isRoot() {
+        public boolean isRoot()
+        {
             return parent == null;
         }
 
         @Nullable
         @Override
-        public Block parent() {
+        public Block parent()
+        {
             return parent;
         }
 
         @NonNull
         @Override
-        public List<Block> children() {
+        public List<Block> children()
+        {
             final List<Block> list;
-            if (children == null) {
+            if (children == null)
+            {
                 list = Collections.emptyList();
-            } else {
+            } else
+            {
                 list = Collections.unmodifiableList((List<? extends Block>) children);
             }
             return list;
@@ -167,42 +197,48 @@ abstract class HtmlTagImpl implements HtmlTag {
 
         @NonNull
         @Override
-        public Map<String, String> attributes() {
+        public Map<String, String> attributes()
+        {
             return attributes;
         }
 
         @Override
-        public boolean isInline() {
+        public boolean isInline()
+        {
             return false;
         }
 
         @Override
-        public boolean isBlock() {
+        public boolean isBlock()
+        {
             return true;
         }
 
         @NonNull
         @Override
-        public Inline getAsInline() {
+        public Inline getAsInline()
+        {
             throw new ClassCastException("Cannot cast Block instance to Inline");
         }
 
         @NonNull
         @Override
-        public Block getAsBlock() {
+        public Block getAsBlock()
+        {
             return this;
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return "BlockImpl{" +
-                    "name='" + name + '\'' +
-                    ", start=" + start +
-                    ", end=" + end +
-                    ", attributes=" + attributes +
-                    ", parent=" + (parent != null ? parent.name : null) +
-                    ", children=" + children +
-                    '}';
+                "name='" + name + '\'' +
+                ", start=" + start +
+                ", end=" + end +
+                ", attributes=" + attributes +
+                ", parent=" + (parent != null ? parent.name : null) +
+                ", children=" + children +
+                '}';
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlParser.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlParser.java
@@ -10,13 +10,9 @@ import java.util.List;
 public abstract class StylarHtmlParser
 {
 
-    public interface FlushAction<T> {
-        void apply(@NonNull List<T> tags);
-    }
-
     public abstract <T extends Appendable & CharSequence> void processFragment(
-            @NonNull T output,
-            @NonNull String htmlFragment);
+        @NonNull T output,
+        @NonNull String htmlFragment);
 
     /**
      * After this method exists a {@link StylarHtmlParser} will clear internal state for stored tags.
@@ -30,8 +26,8 @@ public abstract class StylarHtmlParser
      * @param action         {@link FlushAction} to be called with resulting tags ({@link HtmlTag.Inline})
      */
     public abstract void flushInlineTags(
-            int documentLength,
-            @NonNull FlushAction<HtmlTag.Inline> action);
+        int documentLength,
+        @NonNull FlushAction<HtmlTag.Inline> action);
 
     /**
      * After this method exists a {@link StylarHtmlParser} will clear internal state for stored tags.
@@ -45,9 +41,14 @@ public abstract class StylarHtmlParser
      * @param action         {@link FlushAction} to be called with resulting tags ({@link HtmlTag.Block})
      */
     public abstract void flushBlockTags(
-            int documentLength,
-            @NonNull FlushAction<HtmlTag.Block> action);
+        int documentLength,
+        @NonNull FlushAction<HtmlTag.Block> action);
 
     public abstract void reset();
+
+    public interface FlushAction<T>
+    {
+        void apply(@NonNull List<T> tags);
+    }
 
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlParserImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlParserImpl.java
@@ -29,151 +29,215 @@ import static com.zeoflow.stylar.html.AppendableUtils.appendQuietly;
 public class StylarHtmlParserImpl extends StylarHtmlParser
 {
 
-    @NonNull
-    public static StylarHtmlParserImpl create() {
-        return create(HtmlEmptyTagReplacement.create());
-    }
-
-    @NonNull
-    public static StylarHtmlParserImpl create(@NonNull HtmlEmptyTagReplacement inlineTagReplacement) {
-        return new StylarHtmlParserImpl(inlineTagReplacement, TrimmingAppender.create());
-    }
-
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
     @VisibleForTesting
     static final Set<String> INLINE_TAGS;
-
     private static final Set<String> VOID_TAGS;
-
     // these are the tags that are considered _block_ ones
     // this parser will ensure that these blocks are started on a new line
     // other tags that are NOT inline are considered as block tags, but won't have new line
     // inserted before them
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements
     private static final Set<String> BLOCK_TAGS;
-
     private static final String TAG_PARAGRAPH = "p";
     private static final String TAG_LIST_ITEM = "li";
 
-    static {
+    static
+    {
         INLINE_TAGS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-                "a", "abbr", "acronym",
-                "b", "bdo", "big", "br", "button",
-                "cite", "code",
-                "dfn",
-                "em",
-                "i", "img", "input",
-                "kbd",
-                "label",
-                "map",
-                "object",
-                "q",
-                "samp", "script", "select", "small", "span", "strong", "sub", "sup",
-                "textarea", "time", "tt",
-                "var"
+            "a", "abbr", "acronym",
+            "b", "bdo", "big", "br", "button",
+            "cite", "code",
+            "dfn",
+            "em",
+            "i", "img", "input",
+            "kbd",
+            "label",
+            "map",
+            "object",
+            "q",
+            "samp", "script", "select", "small", "span", "strong", "sub", "sup",
+            "textarea", "time", "tt",
+            "var"
         )));
         VOID_TAGS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-                "area",
-                "base", "br",
-                "col",
-                "embed",
-                "hr",
-                "img", "input",
-                "keygen",
-                "link",
-                "meta",
-                "param",
-                "source",
-                "track",
-                "wbr"
+            "area",
+            "base", "br",
+            "col",
+            "embed",
+            "hr",
+            "img", "input",
+            "keygen",
+            "link",
+            "meta",
+            "param",
+            "source",
+            "track",
+            "wbr"
         )));
         BLOCK_TAGS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-                "address", "article", "aside",
-                "blockquote",
-                "canvas",
-                "dd", "div", "dl", "dt",
-                "fieldset", "figcaption", "figure", "footer", "form",
-                "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr",
-                "li",
-                "main",
-                "nav", "noscript",
-                "ol", "output",
-                "p", "pre",
-                "section",
-                "table", "tfoot",
-                "ul",
-                "video"
+            "address", "article", "aside",
+            "blockquote",
+            "canvas",
+            "dd", "div", "dl", "dt",
+            "fieldset", "figcaption", "figure", "footer", "form",
+            "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr",
+            "li",
+            "main",
+            "nav", "noscript",
+            "ol", "output",
+            "p", "pre",
+            "section",
+            "table", "tfoot",
+            "ul",
+            "video"
         )));
     }
 
     private final HtmlEmptyTagReplacement emptyTagReplacement;
-
     private final TrimmingAppender trimmingAppender;
-
     private final List<HtmlTagImpl.InlineImpl> inlineTags = new ArrayList<>(0);
-
     private HtmlTagImpl.BlockImpl currentBlock = HtmlTagImpl.BlockImpl.root();
-
     private boolean isInsidePreTag;
-
     // the thing is: we ensure a new line BEFORE block tag
     // but not after, so another tag will be placed on the same line (which is wrong)
     private boolean previousIsBlock;
 
-
     StylarHtmlParserImpl(
-            @NonNull HtmlEmptyTagReplacement replacement,
-            @NonNull TrimmingAppender trimmingAppender) {
+        @NonNull HtmlEmptyTagReplacement replacement,
+        @NonNull TrimmingAppender trimmingAppender)
+    {
         this.emptyTagReplacement = replacement;
         this.trimmingAppender = trimmingAppender;
     }
 
+    @NonNull
+    public static StylarHtmlParserImpl create()
+    {
+        return create(HtmlEmptyTagReplacement.create());
+    }
+
+    @NonNull
+    public static StylarHtmlParserImpl create(@NonNull HtmlEmptyTagReplacement inlineTagReplacement)
+    {
+        return new StylarHtmlParserImpl(inlineTagReplacement, TrimmingAppender.create());
+    }
+
+    // name here must lower case
+    protected static boolean isInlineTag(@NonNull String name)
+    {
+        return INLINE_TAGS.contains(name);
+    }
+
+    protected static boolean isVoidTag(@NonNull String name)
+    {
+        return VOID_TAGS.contains(name);
+    }
+
+    protected static boolean isBlockTag(@NonNull String name)
+    {
+        return BLOCK_TAGS.contains(name);
+    }
+
+    protected static <T extends Appendable & CharSequence> void ensureNewLine(@NonNull T output)
+    {
+        final int length = output.length();
+        if (length > 0
+            && '\n' != output.charAt(length - 1))
+        {
+            appendQuietly(output, '\n');
+        }
+    }
+
+    @NonNull
+    protected static Map<String, String> extractAttributes(@NonNull Token.StartTag startTag)
+    {
+
+        Map<String, String> map;
+
+        final Attributes attributes = startTag.attributes;
+        final int size = attributes.size();
+
+        if (size > 0)
+        {
+            map = new HashMap<>(size);
+            for (Attribute attribute : attributes)
+            {
+                map.put(attribute.getKey().toLowerCase(Locale.US), attribute.getValue());
+            }
+            map = Collections.unmodifiableMap(map);
+        } else
+        {
+            map = Collections.emptyMap();
+        }
+
+        return map;
+    }
+
+    protected static <T extends Appendable & CharSequence> boolean isEmpty(
+        @NonNull T output,
+        @NonNull HtmlTagImpl tag)
+    {
+        return tag.start == output.length();
+    }
+
     @Override
     public <T extends Appendable & CharSequence> void processFragment(
-            @NonNull T output,
-            @NonNull String htmlFragment) {
+        @NonNull T output,
+        @NonNull String htmlFragment)
+    {
 
         // we might want to reuse tokeniser (at least when the same output is involved)
         // as CharacterReader does a bit of initialization (cache etc) as it's
         // primary usage is parsing a document in one run (not parsing _fragments_)
         final Tokeniser tokeniser = new Tokeniser(new CharacterReader(htmlFragment), ParseErrorList.noTracking());
 
-        while (true) {
+        while (true)
+        {
 
             final Token token = tokeniser.read();
             final Token.TokenType tokenType = token.type;
 
-            if (Token.TokenType.EOF == tokenType) {
+            if (Token.TokenType.EOF == tokenType)
+            {
                 break;
             }
 
-            switch (tokenType) {
+            switch (tokenType)
+            {
 
-                case StartTag: {
+                case StartTag:
+                {
 
                     final Token.StartTag startTag = (Token.StartTag) token;
 
-                    if (isInlineTag(startTag.normalName)) {
+                    if (isInlineTag(startTag.normalName))
+                    {
                         processInlineTagStart(output, startTag);
-                    } else {
+                    } else
+                    {
                         processBlockTagStart(output, startTag);
                     }
                 }
                 break;
 
-                case EndTag: {
+                case EndTag:
+                {
 
                     final Token.EndTag endTag = (Token.EndTag) token;
 
-                    if (isInlineTag(endTag.normalName)) {
+                    if (isInlineTag(endTag.normalName))
+                    {
                         processInlineTagEnd(output, endTag);
-                    } else {
+                    } else
+                    {
                         processBlockTagEnd(output, endTag);
                     }
                 }
                 break;
 
-                case Character: {
+                case Character:
+                {
                     processCharacter(output, ((Token.Character) token));
                 }
                 break;
@@ -185,38 +249,48 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
     }
 
     @Override
-    public void flushInlineTags(int documentLength, @NonNull FlushAction<HtmlTag.Inline> action) {
-        if (inlineTags.size() > 0) {
+    public void flushInlineTags(int documentLength, @NonNull FlushAction<HtmlTag.Inline> action)
+    {
+        if (inlineTags.size() > 0)
+        {
 
-            if (documentLength > HtmlTag.NO_END) {
-                for (HtmlTagImpl.InlineImpl inline : inlineTags) {
+            if (documentLength > HtmlTag.NO_END)
+            {
+                for (HtmlTagImpl.InlineImpl inline : inlineTags)
+                {
                     inline.closeAt(documentLength);
                 }
             }
 
             action.apply(Collections.unmodifiableList((List<? extends HtmlTag.Inline>) inlineTags));
             inlineTags.clear();
-        } else {
+        } else
+        {
             action.apply(Collections.<HtmlTag.Inline>emptyList());
         }
     }
 
     @Override
-    public void flushBlockTags(int documentLength, @NonNull FlushAction<HtmlTag.Block> action) {
+    public void flushBlockTags(int documentLength, @NonNull FlushAction<HtmlTag.Block> action)
+    {
 
         HtmlTagImpl.BlockImpl block = currentBlock;
-        while (block.parent != null) {
+        while (block.parent != null)
+        {
             block = block.parent;
         }
 
-        if (documentLength > HtmlTag.NO_END) {
+        if (documentLength > HtmlTag.NO_END)
+        {
             block.closeAt(documentLength);
         }
 
         final List<HtmlTag.Block> children = block.children();
-        if (children.size() > 0) {
+        if (children.size() > 0)
+        {
             action.apply(children);
-        } else {
+        } else
+        {
             action.apply(Collections.<HtmlTag.Block>emptyList());
         }
 
@@ -224,15 +298,16 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
     }
 
     @Override
-    public void reset() {
+    public void reset()
+    {
         inlineTags.clear();
         currentBlock = HtmlTagImpl.BlockImpl.root();
     }
 
-
     protected <T extends Appendable & CharSequence> void processInlineTagStart(
-            @NonNull T output,
-            @NonNull Token.StartTag startTag) {
+        @NonNull T output,
+        @NonNull Token.StartTag startTag)
+    {
 
         final String name = startTag.normalName;
 
@@ -241,11 +316,13 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
         ensureNewLineIfPreviousWasBlock(output);
 
         if (isVoidTag(name)
-                || startTag.selfClosing) {
+            || startTag.selfClosing)
+        {
 
             final String replacement = emptyTagReplacement.replace(inline);
             if (replacement != null
-                    && replacement.length() > 0) {
+                && replacement.length() > 0)
+            {
                 appendQuietly(output, replacement);
             }
 
@@ -259,15 +336,18 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
     }
 
     protected <T extends Appendable & CharSequence> void processInlineTagEnd(
-            @NonNull T output,
-            @NonNull Token.EndTag endTag) {
+        @NonNull T output,
+        @NonNull Token.EndTag endTag)
+    {
 
         // try to find it, if none found -> ignore
         final HtmlTagImpl.InlineImpl openInline = findOpenInlineTag(endTag.normalName);
-        if (openInline != null) {
+        if (openInline != null)
+        {
 
             // okay, if this tag is empty -> call replacement
-            if (isEmpty(output, openInline)) {
+            if (isEmpty(output, openInline))
+            {
                 appendEmptyTagReplacement(output, openInline);
             }
 
@@ -276,10 +356,10 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
         }
     }
 
-
     protected <T extends Appendable & CharSequence> void processBlockTagStart(
-            @NonNull T output,
-            @NonNull Token.StartTag startTag) {
+        @NonNull T output,
+        @NonNull Token.StartTag startTag)
+    {
 
         final String name = startTag.normalName;
 
@@ -287,23 +367,27 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
         // there is only one strong rule -> paragraph cannot contain anything
         // except inline tags
 
-        if (TAG_PARAGRAPH.equals(currentBlock.name)) {
+        if (TAG_PARAGRAPH.equals(currentBlock.name))
+        {
             // it must be closed here not matter what we are as here we _assume_
             // that it's a block tag
             currentBlock.closeAt(output.length());
             appendQuietly(output, '\n');
             currentBlock = currentBlock.parent;
         } else if (TAG_LIST_ITEM.equals(name)
-                && TAG_LIST_ITEM.equals(currentBlock.name)) {
+            && TAG_LIST_ITEM.equals(currentBlock.name))
+        {
             // close previous list item if in the same parent
             currentBlock.closeAt(output.length());
             currentBlock = currentBlock.parent;
         }
 
-        if (isBlockTag(name)) {
+        if (isBlockTag(name))
+        {
             isInsidePreTag = "pre".equals(name);
             ensureNewLine(output);
-        } else {
+        } else
+        {
             ensureNewLineIfPreviousWasBlock(output);
         }
 
@@ -312,10 +396,12 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
         final HtmlTagImpl.BlockImpl block = HtmlTagImpl.BlockImpl.create(name, start, extractAttributes(startTag), currentBlock);
 
         final boolean isVoid = isVoidTag(name) || startTag.selfClosing;
-        if (isVoid) {
+        if (isVoid)
+        {
             final String replacement = emptyTagReplacement.replace(block);
             if (replacement != null
-                    && replacement.length() > 0) {
+                && replacement.length() > 0)
+            {
                 appendQuietly(output, replacement);
             }
             block.closeAt(output.length());
@@ -325,37 +411,44 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
         appendBlockChild(block.parent, block);
 
         // if not void start filling-in children
-        if (!isVoid) {
+        if (!isVoid)
+        {
             this.currentBlock = block;
         }
     }
 
     protected <T extends Appendable & CharSequence> void processBlockTagEnd(
-            @NonNull T output,
-            @NonNull Token.EndTag endTag) {
+        @NonNull T output,
+        @NonNull Token.EndTag endTag)
+    {
 
         final String name = endTag.normalName;
 
         final HtmlTagImpl.BlockImpl block = findOpenBlockTag(endTag.normalName);
-        if (block != null) {
+        if (block != null)
+        {
 
-            if ("pre".equals(name)) {
+            if ("pre".equals(name))
+            {
                 isInsidePreTag = false;
             }
 
             // okay, if this tag is empty -> call replacement
-            if (isEmpty(output, block)) {
+            if (isEmpty(output, block))
+            {
                 appendEmptyTagReplacement(output, block);
             }
 
             block.closeAt(output.length());
 
             // if it's empty -> we do no care about if it's block or not
-            if (!block.isEmpty()) {
+            if (!block.isEmpty())
+            {
                 previousIsBlock = isBlockTag(block.name);
             }
 
-            if (TAG_PARAGRAPH.equals(name)) {
+            if (TAG_PARAGRAPH.equals(name))
+            {
                 appendQuietly(output, '\n');
             }
 
@@ -364,23 +457,28 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
     }
 
     protected <T extends Appendable & CharSequence> void processCharacter(
-            @NonNull T output,
-            @NonNull Token.Character character) {
+        @NonNull T output,
+        @NonNull Token.Character character)
+    {
 
         // there are tags: BUTTON, INPUT, SELECT, SCRIPT, TEXTAREA, STYLE
         // that might have character data that we do not want to display
 
-        if (isInsidePreTag) {
+        if (isInsidePreTag)
+        {
             appendQuietly(output, character.getData());
-        } else {
+        } else
+        {
             ensureNewLineIfPreviousWasBlock(output);
             trimmingAppender.append(output, character.getData());
         }
     }
 
-    protected void appendBlockChild(@NonNull HtmlTagImpl.BlockImpl parent, @NonNull HtmlTagImpl.BlockImpl child) {
+    protected void appendBlockChild(@NonNull HtmlTagImpl.BlockImpl parent, @NonNull HtmlTagImpl.BlockImpl child)
+    {
         List<HtmlTagImpl.BlockImpl> children = parent.children;
-        if (children == null) {
+        if (children == null)
+        {
             children = new ArrayList<>(2);
             parent.children = children;
         }
@@ -388,14 +486,17 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
     }
 
     @Nullable
-    protected HtmlTagImpl.InlineImpl findOpenInlineTag(@NonNull String name) {
+    protected HtmlTagImpl.InlineImpl findOpenInlineTag(@NonNull String name)
+    {
 
         HtmlTagImpl.InlineImpl inline;
 
-        for (int i = inlineTags.size() - 1; i > -1; i--) {
+        for (int i = inlineTags.size() - 1; i > -1; i--)
+        {
             inline = inlineTags.get(i);
             if (name.equals(inline.name)
-                    && inline.end < 0) {
+                && inline.end < 0)
+            {
                 return inline;
             }
         }
@@ -404,78 +505,36 @@ public class StylarHtmlParserImpl extends StylarHtmlParser
     }
 
     @Nullable
-    protected HtmlTagImpl.BlockImpl findOpenBlockTag(@NonNull String name) {
+    protected HtmlTagImpl.BlockImpl findOpenBlockTag(@NonNull String name)
+    {
 
         HtmlTagImpl.BlockImpl blockTag = currentBlock;
 
         while (blockTag != null
-                && !name.equals(blockTag.name) && !blockTag.isClosed()) {
+            && !name.equals(blockTag.name) && !blockTag.isClosed())
+        {
             blockTag = blockTag.parent;
         }
 
         return blockTag;
     }
 
-    protected <T extends Appendable & CharSequence> void ensureNewLineIfPreviousWasBlock(@NonNull T output) {
-        if (previousIsBlock) {
+    protected <T extends Appendable & CharSequence> void ensureNewLineIfPreviousWasBlock(@NonNull T output)
+    {
+        if (previousIsBlock)
+        {
             ensureNewLine(output);
             previousIsBlock = false;
         }
     }
 
-    // name here must lower case
-    protected static boolean isInlineTag(@NonNull String name) {
-        return INLINE_TAGS.contains(name);
-    }
-
-    protected static boolean isVoidTag(@NonNull String name) {
-        return VOID_TAGS.contains(name);
-    }
-
-    protected static boolean isBlockTag(@NonNull String name) {
-        return BLOCK_TAGS.contains(name);
-    }
-
-    protected static <T extends Appendable & CharSequence> void ensureNewLine(@NonNull T output) {
-        final int length = output.length();
-        if (length > 0
-                && '\n' != output.charAt(length - 1)) {
-            appendQuietly(output, '\n');
-        }
-    }
-
-    @NonNull
-    protected static Map<String, String> extractAttributes(@NonNull Token.StartTag startTag) {
-
-        Map<String, String> map;
-
-        final Attributes attributes = startTag.attributes;
-        final int size = attributes.size();
-
-        if (size > 0) {
-            map = new HashMap<>(size);
-            for (Attribute attribute : attributes) {
-                map.put(attribute.getKey().toLowerCase(Locale.US), attribute.getValue());
-            }
-            map = Collections.unmodifiableMap(map);
-        } else {
-            map = Collections.emptyMap();
-        }
-
-        return map;
-    }
-
-    protected static <T extends Appendable & CharSequence> boolean isEmpty(
-            @NonNull T output,
-            @NonNull HtmlTagImpl tag) {
-        return tag.start == output.length();
-    }
-
     protected <T extends Appendable & CharSequence> void appendEmptyTagReplacement(
-            @NonNull T output,
-            @NonNull HtmlTagImpl tag) {
+        @NonNull T output,
+        @NonNull HtmlTagImpl tag)
+    {
         final String replacement = emptyTagReplacement.replace(tag);
-        if (replacement != null) {
+        if (replacement != null)
+        {
             appendQuietly(output, replacement);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlRenderer.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlRenderer.java
@@ -12,8 +12,8 @@ public abstract class StylarHtmlRenderer
 {
 
     public abstract void render(
-            @NonNull StylarVisitor visitor,
-            @NonNull StylarHtmlParser parser
+        @NonNull StylarVisitor visitor,
+        @NonNull StylarHtmlParser parser
     );
 
     @Nullable

--- a/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlRendererImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlRendererImpl.java
@@ -17,60 +17,75 @@ class StylarHtmlRendererImpl extends StylarHtmlRenderer
     private final Map<String, TagHandler> tagHandlers;
 
     @SuppressWarnings("WeakerAccess")
-    StylarHtmlRendererImpl(boolean allowNonClosedTags, @NonNull Map<String, TagHandler> tagHandlers) {
+    StylarHtmlRendererImpl(boolean allowNonClosedTags, @NonNull Map<String, TagHandler> tagHandlers)
+    {
         this.allowNonClosedTags = allowNonClosedTags;
         this.tagHandlers = tagHandlers;
     }
 
     @Override
     public void render(
-            @NonNull final StylarVisitor visitor,
-            @NonNull StylarHtmlParser parser) {
+        @NonNull final StylarVisitor visitor,
+        @NonNull StylarHtmlParser parser)
+    {
 
         final int end;
-        if (!allowNonClosedTags) {
+        if (!allowNonClosedTags)
+        {
             end = HtmlTag.NO_END;
-        } else {
+        } else
+        {
             end = visitor.length();
         }
 
-        parser.flushInlineTags(end, new StylarHtmlParser.FlushAction<HtmlTag.Inline>() {
+        parser.flushInlineTags(end, new StylarHtmlParser.FlushAction<HtmlTag.Inline>()
+        {
             @Override
-            public void apply(@NonNull List<HtmlTag.Inline> tags) {
+            public void apply(@NonNull List<HtmlTag.Inline> tags)
+            {
 
                 TagHandler handler;
 
-                for (HtmlTag.Inline inline : tags) {
+                for (HtmlTag.Inline inline : tags)
+                {
 
                     // if tag is not closed -> do not render
-                    if (!inline.isClosed()) {
+                    if (!inline.isClosed())
+                    {
                         continue;
                     }
 
                     handler = tagHandler(inline.name());
-                    if (handler != null) {
+                    if (handler != null)
+                    {
                         handler.handle(visitor, StylarHtmlRendererImpl.this, inline);
                     }
                 }
             }
         });
 
-        parser.flushBlockTags(end, new StylarHtmlParser.FlushAction<HtmlTag.Block>() {
+        parser.flushBlockTags(end, new StylarHtmlParser.FlushAction<HtmlTag.Block>()
+        {
             @Override
-            public void apply(@NonNull List<HtmlTag.Block> tags) {
+            public void apply(@NonNull List<HtmlTag.Block> tags)
+            {
 
                 TagHandler handler;
 
-                for (HtmlTag.Block block : tags) {
+                for (HtmlTag.Block block : tags)
+                {
 
-                    if (!block.isClosed()) {
+                    if (!block.isClosed())
+                    {
                         continue;
                     }
 
                     handler = tagHandler(block.name());
-                    if (handler != null) {
+                    if (handler != null)
+                    {
                         handler.handle(visitor, StylarHtmlRendererImpl.this, block);
-                    } else {
+                    } else
+                    {
                         // see if any of children can be handled
                         apply(block.children());
                     }
@@ -83,11 +98,13 @@ class StylarHtmlRendererImpl extends StylarHtmlRenderer
 
     @Nullable
     @Override
-    public TagHandler tagHandler(@NonNull String tagName) {
+    public TagHandler tagHandler(@NonNull String tagName)
+    {
         return tagHandlers.get(tagName);
     }
 
-    static class Builder {
+    static class Builder
+    {
 
         private final Map<String, TagHandler> tagHandlers = new HashMap<>(2);
         private boolean allowNonClosedTags;
@@ -95,35 +112,42 @@ class StylarHtmlRendererImpl extends StylarHtmlRenderer
 
         private boolean isBuilt;
 
-        void allowNonClosedTags(boolean allowNonClosedTags) {
+        void allowNonClosedTags(boolean allowNonClosedTags)
+        {
             checkState();
             this.allowNonClosedTags = allowNonClosedTags;
         }
 
-        void addHandler(@NonNull TagHandler tagHandler) {
+        void addHandler(@NonNull TagHandler tagHandler)
+        {
             checkState();
-            for (String tag : tagHandler.supportedTags()) {
+            for (String tag : tagHandler.supportedTags())
+            {
                 tagHandlers.put(tag, tagHandler);
             }
         }
 
         @Nullable
-        TagHandler getHandler(@NonNull String tagName) {
+        TagHandler getHandler(@NonNull String tagName)
+        {
             checkState();
             return tagHandlers.get(tagName);
         }
 
-        public void excludeDefaults(boolean excludeDefaults) {
+        public void excludeDefaults(boolean excludeDefaults)
+        {
             checkState();
             this.excludeDefaults = excludeDefaults;
         }
 
-        boolean excludeDefaults() {
+        boolean excludeDefaults()
+        {
             return excludeDefaults;
         }
 
         @NonNull
-        public StylarHtmlRenderer build() {
+        public StylarHtmlRenderer build()
+        {
 
             checkState();
 
@@ -132,19 +156,24 @@ class StylarHtmlRendererImpl extends StylarHtmlRenderer
             // okay, let's validate that we have at least one tagHandler registered
             // if we have none -> return no-op implementation
             return tagHandlers.size() > 0
-                    ? new StylarHtmlRendererImpl(allowNonClosedTags, Collections.unmodifiableMap(tagHandlers))
-                    : new StylarHtmlRendererNoOp();
+                ? new StylarHtmlRendererImpl(allowNonClosedTags, Collections.unmodifiableMap(tagHandlers))
+                : new StylarHtmlRendererNoOp();
         }
 
-        private void checkState() {
-            if (isBuilt) {
+        private void checkState()
+        {
+            if (isBuilt)
+            {
                 throw new IllegalStateException("Builder has been already built");
             }
         }
 
-        void addDefaultTagHandler(@NonNull TagHandler tagHandler) {
-            for (String tag : tagHandler.supportedTags()) {
-                if (!tagHandlers.containsKey(tag)) {
+        void addDefaultTagHandler(@NonNull TagHandler tagHandler)
+        {
+            for (String tag : tagHandler.supportedTags())
+            {
+                if (!tagHandlers.containsKey(tag))
+                {
                     tagHandlers.put(tag, tagHandler);
                 }
             }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlRendererNoOp.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/StylarHtmlRendererNoOp.java
@@ -9,13 +9,15 @@ class StylarHtmlRendererNoOp extends StylarHtmlRenderer
 {
 
     @Override
-    public void render(@NonNull StylarVisitor visitor, @NonNull StylarHtmlParser parser) {
+    public void render(@NonNull StylarVisitor visitor, @NonNull StylarHtmlParser parser)
+    {
         parser.reset();
     }
 
     @Nullable
     @Override
-    public TagHandler tagHandler(@NonNull String tagName) {
+    public TagHandler tagHandler(@NonNull String tagName)
+    {
         return null;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/TagHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/TagHandler.java
@@ -6,12 +6,40 @@ import com.zeoflow.stylar.StylarVisitor;
 
 import java.util.Collection;
 
-public abstract class TagHandler {
+public abstract class TagHandler
+{
+
+    protected static void visitChildren(
+        @NonNull StylarVisitor visitor,
+        @NonNull StylarHtmlRenderer renderer,
+        @NonNull HtmlTag.Block block)
+    {
+
+        TagHandler handler;
+
+        for (HtmlTag.Block child : block.children())
+        {
+
+            if (!child.isClosed())
+            {
+                continue;
+            }
+
+            handler = renderer.tagHandler(child.name());
+            if (handler != null)
+            {
+                handler.handle(visitor, renderer, child);
+            } else
+            {
+                visitChildren(visitor, renderer, child);
+            }
+        }
+    }
 
     public abstract void handle(
-            @NonNull StylarVisitor visitor,
-            @NonNull StylarHtmlRenderer renderer,
-            @NonNull HtmlTag tag
+        @NonNull StylarVisitor visitor,
+        @NonNull StylarHtmlRenderer renderer,
+        @NonNull HtmlTag tag
     );
 
     /**
@@ -19,27 +47,4 @@ public abstract class TagHandler {
      */
     @NonNull
     public abstract Collection<String> supportedTags();
-
-
-    protected static void visitChildren(
-            @NonNull StylarVisitor visitor,
-            @NonNull StylarHtmlRenderer renderer,
-            @NonNull HtmlTag.Block block) {
-
-        TagHandler handler;
-
-        for (HtmlTag.Block child : block.children()) {
-
-            if (!child.isClosed()) {
-                continue;
-            }
-
-            handler = renderer.tagHandler(child.name());
-            if (handler != null) {
-                handler.handle(visitor, renderer, child);
-            } else {
-                visitChildren(visitor, renderer, child);
-            }
-        }
-    }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/TagHandlerNoOp.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/TagHandlerNoOp.java
@@ -11,33 +11,39 @@ import java.util.Collections;
 /**
  * @since 4.0.0
  */
-public class TagHandlerNoOp extends TagHandler {
-
-    @NonNull
-    public static TagHandlerNoOp create(@NonNull String tag) {
-        return new TagHandlerNoOp(Collections.singleton(tag));
-    }
-
-    @NonNull
-    public static TagHandlerNoOp create(@NonNull String... tags) {
-        return new TagHandlerNoOp(Arrays.asList(tags));
-    }
+public class TagHandlerNoOp extends TagHandler
+{
 
     private final Collection<String> tags;
 
     @SuppressWarnings("WeakerAccess")
-    TagHandlerNoOp(Collection<String> tags) {
+    TagHandlerNoOp(Collection<String> tags)
+    {
         this.tags = tags;
     }
 
+    @NonNull
+    public static TagHandlerNoOp create(@NonNull String tag)
+    {
+        return new TagHandlerNoOp(Collections.singleton(tag));
+    }
+
+    @NonNull
+    public static TagHandlerNoOp create(@NonNull String... tags)
+    {
+        return new TagHandlerNoOp(Arrays.asList(tags));
+    }
+
     @Override
-    public void handle(@NonNull StylarVisitor visitor, @NonNull StylarHtmlRenderer renderer, @NonNull HtmlTag tag) {
+    public void handle(@NonNull StylarVisitor visitor, @NonNull StylarHtmlRenderer renderer, @NonNull HtmlTag tag)
+    {
         // no op
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return tags;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/TrimmingAppender.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/TrimmingAppender.java
@@ -2,21 +2,22 @@ package com.zeoflow.stylar.html;
 
 import androidx.annotation.NonNull;
 
-import static com.zeoflow.stylar.html.AppendableUtils.appendQuietly;
-
-abstract class TrimmingAppender {
-
-    abstract <T extends Appendable & CharSequence> void append(
-            @NonNull T output,
-            @NonNull String data
-    );
+abstract class TrimmingAppender
+{
 
     @NonNull
-    static TrimmingAppender create() {
+    static TrimmingAppender create()
+    {
         return new Impl();
     }
 
-    static class Impl extends TrimmingAppender {
+    abstract <T extends Appendable & CharSequence> void append(
+        @NonNull T output,
+        @NonNull String data
+    );
+
+    static class Impl extends TrimmingAppender
+    {
 
         // if data is fully empty (consists of white spaces) -> do not add anything
         // leading ws:
@@ -26,9 +27,10 @@ abstract class TrimmingAppender {
 
         @Override
         <T extends Appendable & CharSequence> void append(
-                @NonNull T output,
-                @NonNull String data
-        ) {
+            @NonNull T output,
+            @NonNull String data
+        )
+        {
 
             final int startLength = output.length();
 
@@ -36,20 +38,24 @@ abstract class TrimmingAppender {
 
             boolean previousIsWhiteSpace = false;
 
-            for (int i = 0, length = data.length(); i < length; i++) {
+            for (int i = 0, length = data.length(); i < length; i++)
+            {
 
                 c = data.charAt(i);
 
-                if (Character.isWhitespace(c)) {
+                if (Character.isWhitespace(c))
+                {
                     previousIsWhiteSpace = true;
                     continue;
                 }
 
-                if (previousIsWhiteSpace) {
+                if (previousIsWhiteSpace)
+                {
                     // validate that output has ws as last char
                     final int outputLength = output.length();
                     if (outputLength > 0
-                            && !Character.isWhitespace(output.charAt(outputLength - 1))) {
+                        && !Character.isWhitespace(output.charAt(outputLength - 1)))
+                    {
                         AppendableUtils.appendQuietly(output, ' ');
                     }
                 }
@@ -60,7 +66,8 @@ abstract class TrimmingAppender {
 
             // additionally check if previousIsWhiteSpace is true (if data ended with ws)
             // BUT only if we have added something (otherwise the whole data is empty (white))
-            if (previousIsWhiteSpace && (startLength < output.length())) {
+            if (previousIsWhiteSpace && (startLength < output.length()))
+            {
                 AppendableUtils.appendQuietly(output, ' ');
             }
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/UncheckedIOException.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/UncheckedIOException.java
@@ -2,12 +2,15 @@ package com.zeoflow.stylar.html.jsoup;
 
 import java.io.IOException;
 
-public class UncheckedIOException extends RuntimeException {
-    public UncheckedIOException(IOException cause) {
+public class UncheckedIOException extends RuntimeException
+{
+    public UncheckedIOException(IOException cause)
+    {
         super(cause);
     }
 
-    public IOException ioException() {
+    public IOException ioException()
+    {
         return (IOException) getCause();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/helper/Normalizer.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/helper/Normalizer.java
@@ -5,13 +5,16 @@ import java.util.Locale;
 /**
  * Util methods for normalizing strings. Jsoup internal use only, please don't depend on this API.
  */
-public final class Normalizer {
+public final class Normalizer
+{
 
-    public static String lowerCase(final String input) {
+    public static String lowerCase(final String input)
+    {
         return input != null ? input.toLowerCase(Locale.ENGLISH) : "";
     }
 
-    public static String normalize(final String input) {
+    public static String normalize(final String input)
+    {
         return lowerCase(input).trim();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/helper/Validate.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/helper/Validate.java
@@ -3,81 +3,100 @@ package com.zeoflow.stylar.html.jsoup.helper;
 /**
  * Simple validation methods. Designed for jsoup internal use
  */
-public final class Validate {
+public final class Validate
+{
 
-    private Validate() {}
+    private Validate()
+    {
+    }
 
     /**
      * Validates that the object is not null
+     *
      * @param obj object to test
      */
-    public static void notNull(Object obj) {
+    public static void notNull(Object obj)
+    {
         if (obj == null)
             throw new IllegalArgumentException("Object must not be null");
     }
 
     /**
      * Validates that the object is not null
+     *
      * @param obj object to test
      * @param msg message to output if validation fails
      */
-    public static void notNull(Object obj, String msg) {
+    public static void notNull(Object obj, String msg)
+    {
         if (obj == null)
             throw new IllegalArgumentException(msg);
     }
 
     /**
      * Validates that the value is true
+     *
      * @param val object to test
      */
-    public static void isTrue(boolean val) {
+    public static void isTrue(boolean val)
+    {
         if (!val)
             throw new IllegalArgumentException("Must be true");
     }
 
     /**
      * Validates that the value is true
+     *
      * @param val object to test
      * @param msg message to output if validation fails
      */
-    public static void isTrue(boolean val, String msg) {
+    public static void isTrue(boolean val, String msg)
+    {
         if (!val)
             throw new IllegalArgumentException(msg);
     }
 
     /**
      * Validates that the value is false
+     *
      * @param val object to test
      */
-    public static void isFalse(boolean val) {
+    public static void isFalse(boolean val)
+    {
         if (val)
             throw new IllegalArgumentException("Must be false");
     }
 
     /**
      * Validates that the value is false
+     *
      * @param val object to test
      * @param msg message to output if validation fails
      */
-    public static void isFalse(boolean val, String msg) {
+    public static void isFalse(boolean val, String msg)
+    {
         if (val)
             throw new IllegalArgumentException(msg);
     }
 
     /**
      * Validates that the array contains no null elements
+     *
      * @param objects the array to test
      */
-    public static void noNullElements(Object[] objects) {
+    public static void noNullElements(Object[] objects)
+    {
         noNullElements(objects, "Array must not contain any null objects");
     }
 
     /**
      * Validates that the array contains no null elements
+     *
      * @param objects the array to test
-     * @param msg message to output if validation fails
+     * @param msg     message to output if validation fails
      */
-    public static void noNullElements(Object[] objects, String msg) {
+    public static void noNullElements(Object[] objects, String msg)
+    {
         for (Object obj : objects)
             if (obj == null)
                 throw new IllegalArgumentException(msg);
@@ -85,28 +104,34 @@ public final class Validate {
 
     /**
      * Validates that the string is not empty
+     *
      * @param string the string to test
      */
-    public static void notEmpty(String string) {
+    public static void notEmpty(String string)
+    {
         if (string == null || string.length() == 0)
             throw new IllegalArgumentException("String must not be empty");
     }
 
     /**
      * Validates that the string is not empty
+     *
      * @param string the string to test
-     * @param msg message to output if validation fails
+     * @param msg    message to output if validation fails
      */
-    public static void notEmpty(String string, String msg) {
+    public static void notEmpty(String string, String msg)
+    {
         if (string == null || string.length() == 0)
             throw new IllegalArgumentException(msg);
     }
 
     /**
-     Cause a failure.
-     @param msg message to output.
+     * Cause a failure.
+     *
+     * @param msg message to output.
      */
-    public static void fail(String msg) {
+    public static void fail(String msg)
+    {
         throw new IllegalArgumentException(msg);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/nodes/Attribute.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/nodes/Attribute.java
@@ -5,9 +5,10 @@ import com.zeoflow.stylar.html.jsoup.helper.Validate;
 import java.util.Map;
 
 /**
- A single key + value attribute. (Only used for presentation.)
+ * A single key + value attribute. (Only used for presentation.)
  */
-public class Attribute implements Map.Entry<String, String>, Cloneable  {
+public class Attribute implements Map.Entry<String, String>, Cloneable
+{
 //    private static final String[] booleanAttributes = {
 //            "allowfullscreen", "async", "autofocus", "checked", "compact", "declare", "default", "defer", "disabled",
 //            "formnovalidate", "hidden", "inert", "ismap", "itemscope", "multiple", "muted", "nohref", "noresize",
@@ -15,26 +16,30 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
 //            "sortable", "truespeed", "typemustmatch"
 //    };
 
+    Attributes parent; // used to update the holding Attributes when the key / value is changed via this interface
     private String key;
     private String val;
-    Attributes parent; // used to update the holding Attributes when the key / value is changed via this interface
 
     /**
      * Create a new attribute from unencoded (raw) key and value.
-     * @param key attribute key; case is preserved.
+     *
+     * @param key   attribute key; case is preserved.
      * @param value attribute value
      */
-    public Attribute(String key, String value) {
+    public Attribute(String key, String value)
+    {
         this(key, value, null);
     }
 
     /**
      * Create a new attribute from unencoded (raw) key and value.
-     * @param key attribute key; case is preserved.
-     * @param val attribute value
+     *
+     * @param key    attribute key; case is preserved.
+     * @param val    attribute value
      * @param parent the containing Attributes (this Attribute is not automatically added to said Attributes)
      */
-    public Attribute(String key, String val, Attributes parent) {
+    public Attribute(String key, String val, Attributes parent)
+    {
         Validate.notNull(key);
         this.key = key.trim();
         Validate.notEmpty(key); // trimming could potentially make empty, so validate here
@@ -43,22 +48,27 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     }
 
     /**
-     Get the attribute key.
-     @return the attribute key
+     * Get the attribute key.
+     *
+     * @return the attribute key
      */
-    public String getKey() {
+    public String getKey()
+    {
         return key;
     }
 
     /**
-     Set the attribute key; case is preserved.
-     @param key the new key; must not be null
+     * Set the attribute key; case is preserved.
+     *
+     * @param key the new key; must not be null
      */
-    public void setKey(String key) {
+    public void setKey(String key)
+    {
         Validate.notNull(key);
         key = key.trim();
         Validate.notEmpty(key); // trimming could potentially make empty, so validate here
-        if (parent != null) {
+        if (parent != null)
+        {
             int i = parent.indexOfKey(this.key);
             if (i != Attributes.NotFound)
                 parent.keys[i] = key;
@@ -67,20 +77,25 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     }
 
     /**
-     Get the attribute value.
-     @return the attribute value
+     * Get the attribute value.
+     *
+     * @return the attribute value
      */
-    public String getValue() {
+    public String getValue()
+    {
         return val;
     }
 
     /**
-     Set the attribute value.
-     @param val the new attribute value; must not be null
+     * Set the attribute value.
+     *
+     * @param val the new attribute value; must not be null
      */
-    public String setValue(String val) {
+    public String setValue(String val)
+    {
         String oldVal = parent.get(this.key);
-        if (parent != null) {
+        if (parent != null)
+        {
             int i = parent.indexOfKey(this.key);
             if (i != Attributes.NotFound)
                 parent.vals[i] = val;
@@ -176,7 +191,8 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
 //    }
 
     @Override
-    public boolean equals(Object o) { // note parent not considered
+    public boolean equals(Object o)
+    { // note parent not considered
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Attribute attribute = (Attribute) o;
@@ -185,17 +201,21 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     }
 
     @Override
-    public int hashCode() { // note parent not considered
+    public int hashCode()
+    { // note parent not considered
         int result = key != null ? key.hashCode() : 0;
         result = 31 * result + (val != null ? val.hashCode() : 0);
         return result;
     }
 
     @Override
-    public Attribute clone() {
-        try {
+    public Attribute clone()
+    {
+        try
+        {
             return (Attribute) super.clone();
-        } catch (CloneNotSupportedException e) {
+        } catch (CloneNotSupportedException e)
+        {
             throw new RuntimeException(e);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/nodes/CommonMarkEntities.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/nodes/CommonMarkEntities.java
@@ -8,43 +8,53 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Map;
 
-public abstract class CommonMarkEntities {
-
-    public static boolean isNamedEntity(@NonNull String name) {
-        return COMMONMARK_NAMED_ENTITIES.containsKey(name);
-    }
-
-    public static int codepointsForName(@NonNull String name, @NonNull int[] codepoints) {
-        final String value = COMMONMARK_NAMED_ENTITIES.get(name);
-        if (value != null) {
-            final int length = value.length();
-            if (length == 1) {
-                codepoints[0] = value.charAt(0);
-            } else {
-                codepoints[0] = value.charAt(0);
-                codepoints[1] = value.charAt(1);
-            }
-            return length;
-        }
-        return 0;
-    }
+public abstract class CommonMarkEntities
+{
 
     private static final Map<String, String> COMMONMARK_NAMED_ENTITIES;
 
-    static {
+    static
+    {
         Map<String, String> map;
-        try {
+        try
+        {
             final Field field = Html5Entities.class.getDeclaredField("NAMED_CHARACTER_REFERENCES");
             field.setAccessible(true);
             //noinspection unchecked
             map = (Map<String, String>) field.get(null);
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             map = Collections.emptyMap();
             t.printStackTrace();
         }
         COMMONMARK_NAMED_ENTITIES = map;
     }
 
-    private CommonMarkEntities() {
+    private CommonMarkEntities()
+    {
+    }
+
+    public static boolean isNamedEntity(@NonNull String name)
+    {
+        return COMMONMARK_NAMED_ENTITIES.containsKey(name);
+    }
+
+    public static int codepointsForName(@NonNull String name, @NonNull int[] codepoints)
+    {
+        final String value = COMMONMARK_NAMED_ENTITIES.get(name);
+        if (value != null)
+        {
+            final int length = value.length();
+            if (length == 1)
+            {
+                codepoints[0] = value.charAt(0);
+            } else
+            {
+                codepoints[0] = value.charAt(0);
+                codepoints[1] = value.charAt(1);
+            }
+            return length;
+        }
+        return 0;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/nodes/DocumentType.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/nodes/DocumentType.java
@@ -3,7 +3,8 @@ package com.zeoflow.stylar.html.jsoup.nodes;
 /**
  * A {@code <!DOCTYPE>} node.
  */
-public class DocumentType /*extends LeafNode*/ {
+public class DocumentType /*extends LeafNode*/
+{
     // todo needs a bit of a chunky cleanup. this level of detail isn't needed
     public static final String PUBLIC_KEY = "PUBLIC";
     public static final String SYSTEM_KEY = "SYSTEM";

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/ParseError.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/ParseError.java
@@ -3,38 +3,46 @@ package com.zeoflow.stylar.html.jsoup.parser;
 /**
  * A Parse Error records an error in the input HTML that occurs in either the tokenisation or the tree building phase.
  */
-public class ParseError {
+public class ParseError
+{
     private int pos;
     private String errorMsg;
 
-    ParseError(int pos, String errorMsg) {
+    ParseError(int pos, String errorMsg)
+    {
         this.pos = pos;
         this.errorMsg = errorMsg;
     }
 
-    ParseError(int pos, String errorFormat, Object... args) {
+    ParseError(int pos, String errorFormat, Object... args)
+    {
         this.errorMsg = String.format(errorFormat, args);
         this.pos = pos;
     }
 
     /**
      * Retrieve the error message.
+     *
      * @return the error message.
      */
-    public String getErrorMessage() {
+    public String getErrorMessage()
+    {
         return errorMsg;
     }
 
     /**
      * Retrieves the offset of the error.
+     *
      * @return error offset within input
      */
-    public int getPosition() {
+    public int getPosition()
+    {
         return pos;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return pos + ": " + errorMsg;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/ParseErrorList.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/ParseErrorList.java
@@ -7,28 +7,34 @@ import java.util.ArrayList;
  *
  * @author Jonathan Hedley
  */
-public class ParseErrorList extends ArrayList<ParseError>{
+public class ParseErrorList extends ArrayList<ParseError>
+{
     private static final int INITIAL_CAPACITY = 16;
     private final int maxSize;
 
-    ParseErrorList(int initialCapacity, int maxSize) {
+    ParseErrorList(int initialCapacity, int maxSize)
+    {
         super(initialCapacity);
         this.maxSize = maxSize;
     }
 
-    boolean canAddError() {
-        return size() < maxSize;
-    }
-
-    int getMaxSize() {
-        return maxSize;
-    }
-
-    public static ParseErrorList noTracking() {
+    public static ParseErrorList noTracking()
+    {
         return new ParseErrorList(0, 0);
     }
 
-    public static ParseErrorList tracking(int maxSize) {
+    public static ParseErrorList tracking(int maxSize)
+    {
         return new ParseErrorList(INITIAL_CAPACITY, maxSize);
+    }
+
+    boolean canAddError()
+    {
+        return size() < maxSize;
+    }
+
+    int getMaxSize()
+    {
+        return maxSize;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/Token.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/Token.java
@@ -10,11 +10,13 @@ import static com.zeoflow.stylar.html.jsoup.helper.Normalizer.lowerCase;
 /**
  * Parse tokens for the Tokeniser.
  */
-public abstract class Token {
+public abstract class Token
+{
 
     public final TokenType type;
 
-    protected Token(@NonNull TokenType tokenType) {
+    protected Token(@NonNull TokenType tokenType)
+    {
         this.type = tokenType;
     }
 
@@ -22,31 +24,46 @@ public abstract class Token {
 //        return this.getClass().getSimpleName();
 //    }
 
+    static void reset(StringBuilder sb)
+    {
+        if (sb != null)
+        {
+            sb.delete(0, sb.length());
+        }
+    }
+
     /**
      * Reset the data represent by this token, for reuse. Prevents the need to create transfer objects for every
      * piece of data, which immediately get GCed.
      */
     public abstract Token reset();
 
-    static void reset(StringBuilder sb) {
-        if (sb != null) {
-            sb.delete(0, sb.length());
-        }
+    public enum TokenType
+    {
+        Doctype,
+        StartTag,
+        EndTag,
+        Comment,
+        Character, // note no CData - treated in builder as an extension of Character
+        EOF
     }
 
-    public static final class Doctype extends Token {
+    public static final class Doctype extends Token
+    {
         final StringBuilder name = new StringBuilder();
-        String pubSysKey = null;
         final StringBuilder publicIdentifier = new StringBuilder();
         final StringBuilder systemIdentifier = new StringBuilder();
+        String pubSysKey = null;
         boolean forceQuirks = false;
 
-        Doctype() {
+        Doctype()
+        {
             super(TokenType.Doctype);
         }
 
         @Override
-        public Token reset() {
+        public Token reset()
+        {
             reset(name);
             pubSysKey = null;
             reset(publicIdentifier);
@@ -55,45 +72,53 @@ public abstract class Token {
             return this;
         }
 
-        String getName() {
+        String getName()
+        {
             return name.toString();
         }
 
-        String getPubSysKey() {
+        String getPubSysKey()
+        {
             return pubSysKey;
         }
 
-        String getPublicIdentifier() {
+        String getPublicIdentifier()
+        {
             return publicIdentifier.toString();
         }
 
-        public String getSystemIdentifier() {
+        public String getSystemIdentifier()
+        {
             return systemIdentifier.toString();
         }
 
-        public boolean isForceQuirks() {
+        public boolean isForceQuirks()
+        {
             return forceQuirks;
         }
     }
 
-    public static abstract class Tag extends Token {
+    public static abstract class Tag extends Token
+    {
 
         public String tagName;
         public String normalName; // lc version of tag name, for case insensitive tree build
+        public boolean selfClosing = false;
+        public Attributes attributes; // start tags get attributes on construction. End tags get attributes on first new attribute (but only for parser convenience, not used).
         private String pendingAttributeName; // attribute names are generally caught in one hop, not accumulated
         private StringBuilder pendingAttributeValue = new StringBuilder(); // but values are accumulated, from e.g. & in hrefs
         private String pendingAttributeValueS; // try to get attr vals in one shot, vs Builder
         private boolean hasEmptyAttributeValue = false; // distinguish boolean attribute from empty string value
         private boolean hasPendingAttributeValue = false;
-        public boolean selfClosing = false;
-        public Attributes attributes; // start tags get attributes on construction. End tags get attributes on first new attribute (but only for parser convenience, not used).
 
-        protected Tag(@NonNull TokenType tokenType) {
+        protected Tag(@NonNull TokenType tokenType)
+        {
             super(tokenType);
         }
 
         @Override
-        public Tag reset() {
+        public Tag reset()
+        {
             tagName = null;
             normalName = null;
             pendingAttributeName = null;
@@ -106,14 +131,17 @@ public abstract class Token {
             return this;
         }
 
-        final void newAttribute() {
+        final void newAttribute()
+        {
             if (attributes == null)
                 attributes = new Attributes();
 
-            if (pendingAttributeName != null) {
+            if (pendingAttributeName != null)
+            {
                 // the tokeniser has skipped whitespace control chars, but trimming could collapse to empty for other control codes, so verify here
                 pendingAttributeName = pendingAttributeName.trim();
-                if (pendingAttributeName.length() > 0) {
+                if (pendingAttributeName.length() > 0)
+                {
                     String value;
                     if (hasPendingAttributeValue)
                         value = pendingAttributeValue.length() > 0 ? pendingAttributeValue.toString() : pendingAttributeValueS;
@@ -131,111 +159,136 @@ public abstract class Token {
             pendingAttributeValueS = null;
         }
 
-        final void finaliseTag() {
+        final void finaliseTag()
+        {
             // finalises for emit
-            if (pendingAttributeName != null) {
+            if (pendingAttributeName != null)
+            {
                 // todo: check if attribute name exists; if so, drop and error
                 newAttribute();
             }
         }
 
-        final String name() { // preserves case, for input into Tag.valueOf (which may drop case)
+        final String name()
+        { // preserves case, for input into Tag.valueOf (which may drop case)
             Validate.isFalse(tagName == null || tagName.length() == 0);
             return tagName;
         }
 
-        final String normalName() { // loses case, used in tree building for working out where in tree it should go
+        final String normalName()
+        { // loses case, used in tree building for working out where in tree it should go
             return normalName;
         }
 
-        final Tag name(String name) {
+        final Tag name(String name)
+        {
             tagName = name;
             normalName = lowerCase(name);
             return this;
         }
 
-        final boolean isSelfClosing() {
+        final boolean isSelfClosing()
+        {
             return selfClosing;
         }
 
         @SuppressWarnings({"TypeMayBeWeakened"})
-        final Attributes getAttributes() {
+        final Attributes getAttributes()
+        {
             return attributes;
         }
 
         // these appenders are rarely hit in not null state-- caused by null chars.
-        final void appendTagName(String append) {
+        final void appendTagName(String append)
+        {
             tagName = tagName == null ? append : tagName.concat(append);
             normalName = lowerCase(tagName);
         }
 
-        final void appendTagName(char append) {
+        final void appendTagName(char append)
+        {
             appendTagName(String.valueOf(append));
         }
 
-        final void appendAttributeName(String append) {
+        final void appendAttributeName(String append)
+        {
             pendingAttributeName = pendingAttributeName == null ? append : pendingAttributeName.concat(append);
         }
 
-        final void appendAttributeName(char append) {
+        final void appendAttributeName(char append)
+        {
             appendAttributeName(String.valueOf(append));
         }
 
-        final void appendAttributeValue(String append) {
+        final void appendAttributeValue(String append)
+        {
             ensureAttributeValue();
-            if (pendingAttributeValue.length() == 0) {
+            if (pendingAttributeValue.length() == 0)
+            {
                 pendingAttributeValueS = append;
-            } else {
+            } else
+            {
                 pendingAttributeValue.append(append);
             }
         }
 
-        final void appendAttributeValue(char append) {
+        final void appendAttributeValue(char append)
+        {
             ensureAttributeValue();
             pendingAttributeValue.append(append);
         }
 
-        final void appendAttributeValue(char[] append) {
+        final void appendAttributeValue(char[] append)
+        {
             ensureAttributeValue();
             pendingAttributeValue.append(append);
         }
 
-        final void appendAttributeValue(int[] appendCodepoints) {
+        final void appendAttributeValue(int[] appendCodepoints)
+        {
             ensureAttributeValue();
-            for (int codepoint : appendCodepoints) {
+            for (int codepoint : appendCodepoints)
+            {
                 pendingAttributeValue.appendCodePoint(codepoint);
             }
         }
 
-        final void setEmptyAttributeValue() {
+        final void setEmptyAttributeValue()
+        {
             hasEmptyAttributeValue = true;
         }
 
-        private void ensureAttributeValue() {
+        private void ensureAttributeValue()
+        {
             hasPendingAttributeValue = true;
             // if on second hit, we'll need to move to the builder
-            if (pendingAttributeValueS != null) {
+            if (pendingAttributeValueS != null)
+            {
                 pendingAttributeValue.append(pendingAttributeValueS);
                 pendingAttributeValueS = null;
             }
         }
     }
 
-    public final static class StartTag extends Tag {
-        public StartTag() {
+    public final static class StartTag extends Tag
+    {
+        public StartTag()
+        {
             super(TokenType.StartTag);
             attributes = new Attributes();
         }
 
         @Override
-        public Tag reset() {
+        public Tag reset()
+        {
             super.reset();
             attributes = new Attributes();
             // todo - would prefer these to be null, but need to check Element assertions
             return this;
         }
 
-        StartTag nameAttr(String name, Attributes attributes) {
+        StartTag nameAttr(String name, Attributes attributes)
+        {
             this.tagName = name;
             this.attributes = attributes;
             normalName = lowerCase(tagName);
@@ -243,7 +296,8 @@ public abstract class Token {
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             if (attributes != null && attributes.size() > 0)
                 return "<" + name() + " " + attributes.toString() + ">";
             else
@@ -251,92 +305,98 @@ public abstract class Token {
         }
     }
 
-    public final static class EndTag extends Tag {
-        EndTag() {
+    public final static class EndTag extends Tag
+    {
+        EndTag()
+        {
             super(TokenType.EndTag);
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return "</" + name() + ">";
         }
     }
 
-    public final static class Comment extends Token {
+    public final static class Comment extends Token
+    {
         final StringBuilder data = new StringBuilder();
         boolean bogus = false;
 
+        Comment()
+        {
+            super(TokenType.Comment);
+        }
+
         @Override
-        public Token reset() {
+        public Token reset()
+        {
             reset(data);
             bogus = false;
             return this;
         }
 
-        Comment() {
-            super(TokenType.Comment);
-        }
-
-        String getData() {
+        String getData()
+        {
             return data.toString();
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return "<!--" + getData() + "-->";
         }
     }
 
-    public static class Character extends Token {
+    public static class Character extends Token
+    {
         private String data;
 
-        Character() {
+        Character()
+        {
             super(TokenType.Character);
         }
 
         @Override
-        public Token reset() {
+        public Token reset()
+        {
             data = null;
             return this;
         }
 
-        Character data(String data) {
+        Character data(String data)
+        {
             this.data = data;
             return this;
         }
 
-        public String getData() {
+        public String getData()
+        {
             return data;
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return getData();
         }
     }
 
-    public final static class CData extends Character {
-        CData(String data) {
+    public final static class CData extends Character
+    {
+        CData(String data)
+        {
             super();
             this.data(data);
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return "<![CDATA[" + getData() + "]]>";
         }
 
-    }
-
-    public final static class EOF extends Token {
-        EOF() {
-            super(Token.TokenType.EOF);
-        }
-
-        @Override
-        public Token reset() {
-            return this;
-        }
     }
 
 //    final boolean isDoctype() {
@@ -387,12 +447,17 @@ public abstract class Token {
 //        return type == TokenType.EOF;
 //    }
 
-    public enum TokenType {
-        Doctype,
-        StartTag,
-        EndTag,
-        Comment,
-        Character, // note no CData - treated in builder as an extension of Character
-        EOF
+    public final static class EOF extends Token
+    {
+        EOF()
+        {
+            super(Token.TokenType.EOF);
+        }
+
+        @Override
+        public Token reset()
+        {
+            return this;
+        }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/Tokeniser.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/Tokeniser.java
@@ -1,135 +1,151 @@
 package com.zeoflow.stylar.html.jsoup.parser;
 
 import com.zeoflow.stylar.html.jsoup.helper.Validate;
+import com.zeoflow.stylar.html.jsoup.nodes.CommonMarkEntities;
 
 import java.util.Arrays;
-
-import com.zeoflow.stylar.html.jsoup.nodes.CommonMarkEntities;
 
 /**
  * Readers the input stream into tokens.
  */
-public final class Tokeniser {
+public final class Tokeniser
+{
     static final char replacementChar = '\uFFFD'; // replaces null character
-    private static final char[] notCharRefCharsSorted = new char[]{'\t', '\n', '\r', '\f', ' ', '<', '&'};
-
     // Some illegal character escapes are parsed by browsers as windows-1252 instead. See issue #1034
     // https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
     static final int win1252ExtensionsStart = 0x80;
-    static final int[] win1252Extensions = new int[] {
-            // we could build this manually, but Windows-1252 is not a standard java charset so that could break on
-            // some platforms - this table is verified with a test
-            0x20AC, 0x0081, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021,
-            0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008D, 0x017D, 0x008F,
-            0x0090, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014,
-            0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0x009D, 0x017E, 0x0178,
+    static final int[] win1252Extensions = new int[]{
+        // we could build this manually, but Windows-1252 is not a standard java charset so that could break on
+        // some platforms - this table is verified with a test
+        0x20AC, 0x0081, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021,
+        0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008D, 0x017D, 0x008F,
+        0x0090, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014,
+        0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0x009D, 0x017E, 0x0178,
     };
+    private static final char[] notCharRefCharsSorted = new char[]{'\t', '\n', '\r', '\f', ' ', '<', '&'};
 
-    static {
+    static
+    {
         Arrays.sort(notCharRefCharsSorted);
     }
 
     private final CharacterReader reader; // html input
     private final ParseErrorList errors; // errors found while tokenising
-
-    private TokeniserState state = TokeniserState.Data; // current tokenisation state
-    private Token emitPending; // the token we are about to emit on next read
-    private boolean isEmitPending = false;
-    private String charsString = null; // characters pending an emit. Will fall to charsBuilder if more than one
-    private StringBuilder charsBuilder = new StringBuilder(1024); // buffers characters to output as one token, if more than one emit per read
+    final private int[] codepointHolder = new int[1]; // holder to not have to keep creating arrays
+    final private int[] multipointHolder = new int[2];
     StringBuilder dataBuffer = new StringBuilder(1024); // buffers data looking for </script>
-
     Token.Tag tagPending; // tag we are building up
     Token.StartTag startPending = new Token.StartTag();
     Token.EndTag endPending = new Token.EndTag();
     Token.Character charPending = new Token.Character();
     Token.Doctype doctypePending = new Token.Doctype(); // doctype building up
     Token.Comment commentPending = new Token.Comment(); // comment building up
+    private TokeniserState state = TokeniserState.Data; // current tokenisation state
+    private Token emitPending; // the token we are about to emit on next read
+    private boolean isEmitPending = false;
+    private String charsString = null; // characters pending an emit. Will fall to charsBuilder if more than one
+    private StringBuilder charsBuilder = new StringBuilder(1024); // buffers characters to output as one token, if more than one emit per read
     private String lastStartTag; // the last start tag emitted, to test appropriate end tag
 
-    public Tokeniser(CharacterReader reader, ParseErrorList errors) {
+    public Tokeniser(CharacterReader reader, ParseErrorList errors)
+    {
         this.reader = reader;
         this.errors = errors;
     }
 
-    public Token read() {
+    public Token read()
+    {
         while (!isEmitPending)
             state.read(this, reader);
 
         // if emit is pending, a non-character token was found: return any chars in buffer, and leave token for next read:
-        if (charsBuilder.length() > 0) {
+        if (charsBuilder.length() > 0)
+        {
             String str = charsBuilder.toString();
             charsBuilder.delete(0, charsBuilder.length());
             charsString = null;
             return charPending.data(str);
-        } else if (charsString != null) {
+        } else if (charsString != null)
+        {
             Token token = charPending.data(charsString);
             charsString = null;
             return token;
-        } else {
+        } else
+        {
             isEmitPending = false;
             return emitPending;
         }
     }
 
-    void emit(Token token) {
+    void emit(Token token)
+    {
         Validate.isFalse(isEmitPending, "There is an unread token pending!");
 
         emitPending = token;
         isEmitPending = true;
 
-        if (token.type == Token.TokenType.StartTag) {
+        if (token.type == Token.TokenType.StartTag)
+        {
             Token.StartTag startTag = (Token.StartTag) token;
             lastStartTag = startTag.tagName;
-        } else if (token.type == Token.TokenType.EndTag) {
+        } else if (token.type == Token.TokenType.EndTag)
+        {
             Token.EndTag endTag = (Token.EndTag) token;
             if (endTag.attributes != null)
                 error("Attributes incorrectly present on end tag");
         }
     }
 
-    void emit(final String str) {
+    void emit(final String str)
+    {
         // buffer strings up until last string token found, to emit only one token for a run of character refs etc.
         // does not set isEmitPending; read checks that
-        if (charsString == null) {
+        if (charsString == null)
+        {
             charsString = str;
-        }
-        else {
-            if (charsBuilder.length() == 0) { // switching to string builder as more than one emit before read
+        } else
+        {
+            if (charsBuilder.length() == 0)
+            { // switching to string builder as more than one emit before read
                 charsBuilder.append(charsString);
             }
             charsBuilder.append(str);
         }
     }
 
-    void emit(char[] chars) {
+    void emit(char[] chars)
+    {
         emit(String.valueOf(chars));
     }
 
-    void emit(int[] codepoints) {
+    void emit(int[] codepoints)
+    {
         emit(new String(codepoints, 0, codepoints.length));
     }
 
-    void emit(char c) {
+    void emit(char c)
+    {
         emit(String.valueOf(c));
     }
 
-    TokeniserState getState() {
+    TokeniserState getState()
+    {
         return state;
     }
 
-    void transition(TokeniserState state) {
+    void transition(TokeniserState state)
+    {
         this.state = state;
     }
 
-    void advanceTransition(TokeniserState state) {
+    void advanceTransition(TokeniserState state)
+    {
         reader.advance();
         this.state = state;
     }
 
-    final private int[] codepointHolder = new int[1]; // holder to not have to keep creating arrays
-    final private int[] multipointHolder = new int[2];
-    int[] consumeCharacterReference(Character additionalAllowedCharacter, boolean inAttribute) {
+    int[] consumeCharacterReference(Character additionalAllowedCharacter, boolean inAttribute)
+    {
         if (reader.isEmpty())
             return null;
         if (additionalAllowedCharacter != null && additionalAllowedCharacter == reader.current())
@@ -139,10 +155,12 @@ public final class Tokeniser {
 
         final int[] codeRef = codepointHolder;
         reader.mark();
-        if (reader.matchConsume("#")) { // numbered
+        if (reader.matchConsume("#"))
+        { // numbered
             boolean isHexMode = reader.matchConsumeIgnoreCase("X");
             String numRef = isHexMode ? reader.consumeHexSequence() : reader.consumeDigitSequence();
-            if (numRef.length() == 0) { // didn't match anything
+            if (numRef.length() == 0)
+            { // didn't match anything
                 characterReferenceError("numeric reference with no numerals");
                 reader.rewindToMark();
                 return null;
@@ -150,18 +168,23 @@ public final class Tokeniser {
             if (!reader.matchConsume(";"))
                 characterReferenceError("missing semicolon"); // missing semi
             int charval = -1;
-            try {
+            try
+            {
                 int base = isHexMode ? 16 : 10;
                 charval = Integer.valueOf(numRef, base);
-            } catch (NumberFormatException ignored) {
+            } catch (NumberFormatException ignored)
+            {
             } // skip
-            if (charval == -1 || (charval >= 0xD800 && charval <= 0xDFFF) || charval > 0x10FFFF) {
+            if (charval == -1 || (charval >= 0xD800 && charval <= 0xDFFF) || charval > 0x10FFFF)
+            {
                 characterReferenceError("character outside of valid range");
                 codeRef[0] = replacementChar;
                 return codeRef;
-            } else {
+            } else
+            {
                 // fix illegal unicode characters to match browser behavior
-                if (charval >= win1252ExtensionsStart && charval < win1252ExtensionsStart + win1252Extensions.length) {
+                if (charval >= win1252ExtensionsStart && charval < win1252ExtensionsStart + win1252Extensions.length)
+                {
                     characterReferenceError("character is not a valid unicode code point");
                     charval = win1252Extensions[charval - win1252ExtensionsStart];
                 }
@@ -171,20 +194,23 @@ public final class Tokeniser {
                 codeRef[0] = charval;
                 return codeRef;
             }
-        } else { // named
+        } else
+        { // named
             // get as many letters as possible, and look for matching entities.
             String nameRef = reader.consumeLetterThenDigitSequence();
             boolean looksLegit = reader.matches(';');
             // found if a base named entity without a ;, or an extended entity with the ;.
             boolean found = (CommonMarkEntities.isNamedEntity(nameRef) && looksLegit);
 
-            if (!found) {
+            if (!found)
+            {
                 reader.rewindToMark();
                 if (looksLegit) // named with semicolon
                     characterReferenceError(String.format("invalid named referenece '%s'", nameRef));
                 return null;
             }
-            if (inAttribute && (reader.matchesLetter() || reader.matchesDigit() || reader.matchesAny('=', '-', '_'))) {
+            if (inAttribute && (reader.matchesLetter() || reader.matchesDigit() || reader.matchesAny('=', '-', '_')))
+            {
                 // don't want that to match
                 reader.rewindToMark();
                 return null;
@@ -192,77 +218,94 @@ public final class Tokeniser {
             if (!reader.matchConsume(";"))
                 characterReferenceError("missing semicolon"); // missing semi
             int numChars = CommonMarkEntities.codepointsForName(nameRef, multipointHolder);
-            if (numChars == 1) {
+            if (numChars == 1)
+            {
                 codeRef[0] = multipointHolder[0];
                 return codeRef;
-            } else if (numChars ==2) {
+            } else if (numChars == 2)
+            {
                 return multipointHolder;
-            } else {
+            } else
+            {
                 Validate.fail("Unexpected characters returned for " + nameRef);
                 return multipointHolder;
             }
         }
     }
 
-    Token.Tag createTagPending(boolean start) {
+    Token.Tag createTagPending(boolean start)
+    {
         tagPending = start ? startPending.reset() : endPending.reset();
         return tagPending;
     }
 
-    void emitTagPending() {
+    void emitTagPending()
+    {
         tagPending.finaliseTag();
         emit(tagPending);
     }
 
-    void createCommentPending() {
+    void createCommentPending()
+    {
         commentPending.reset();
     }
 
-    void emitCommentPending() {
+    void emitCommentPending()
+    {
         emit(commentPending);
     }
 
-    void createDoctypePending() {
+    void createDoctypePending()
+    {
         doctypePending.reset();
     }
 
-    void emitDoctypePending() {
+    void emitDoctypePending()
+    {
         emit(doctypePending);
     }
 
-    void createTempBuffer() {
+    void createTempBuffer()
+    {
         Token.reset(dataBuffer);
     }
 
-    boolean isAppropriateEndTagToken() {
+    boolean isAppropriateEndTagToken()
+    {
         return lastStartTag != null && tagPending.name().equalsIgnoreCase(lastStartTag);
     }
 
-    String appropriateEndTagName() {
+    String appropriateEndTagName()
+    {
         return lastStartTag; // could be null
     }
 
-    void error(TokeniserState state) {
+    void error(TokeniserState state)
+    {
         if (errors.canAddError())
             errors.add(new ParseError(reader.pos(), "Unexpected character '%s' in input state [%s]", reader.current(), state));
     }
 
-    void eofError(TokeniserState state) {
+    void eofError(TokeniserState state)
+    {
         if (errors.canAddError())
             errors.add(new ParseError(reader.pos(), "Unexpectedly reached end of file (EOF) in input state [%s]", state));
     }
 
-    private void characterReferenceError(String message) {
+    private void characterReferenceError(String message)
+    {
         if (errors.canAddError())
             errors.add(new ParseError(reader.pos(), "Invalid character reference: %s", message));
     }
 
-    void error(String errorMsg) {
+    void error(String errorMsg)
+    {
         if (errors.canAddError())
             errors.add(new ParseError(reader.pos(), errorMsg));
     }
 
-    boolean currentNodeInHtmlNS() {
+    boolean currentNodeInHtmlNS()
+    {
         // todo: implement namespaces correctly
         return true;
         // Element currentNode = currentNode();

--- a/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/TokeniserState.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/jsoup/parser/TokeniserState.java
@@ -5,1612 +5,1829 @@ import com.zeoflow.stylar.html.jsoup.nodes.DocumentType;
 /**
  * States and transition activations for the Tokeniser.
  */
-enum TokeniserState {
-    Data {
-        // in data state, gather characters until a character reference or tag is found
-        void read(Tokeniser t, CharacterReader r) {
-            switch (r.current()) {
-                case '&':
-                    t.advanceTransition(CharacterReferenceInData);
-                    break;
-                case '<':
-                    t.advanceTransition(TagOpen);
-                    break;
-                case nullChar:
-                    t.error(this); // NOT replacement character (oddly?)
-                    t.emit(r.consume());
-                    break;
-                case eof:
-                    t.emit(new Token.EOF());
-                    break;
-                default:
-                    String data = r.consumeData();
-                    t.emit(data);
-                    break;
+enum TokeniserState
+{
+    Data
+        {
+            // in data state, gather characters until a character reference or tag is found
+            void read(Tokeniser t, CharacterReader r)
+            {
+                switch (r.current())
+                {
+                    case '&':
+                        t.advanceTransition(CharacterReferenceInData);
+                        break;
+                    case '<':
+                        t.advanceTransition(TagOpen);
+                        break;
+                    case nullChar:
+                        t.error(this); // NOT replacement character (oddly?)
+                        t.emit(r.consume());
+                        break;
+                    case eof:
+                        t.emit(new Token.EOF());
+                        break;
+                    default:
+                        String data = r.consumeData();
+                        t.emit(data);
+                        break;
+                }
             }
-        }
-    },
-    CharacterReferenceInData {
-        // from & in data
-        void read(Tokeniser t, CharacterReader r) {
-            readCharRef(t, Data);
-        }
-    },
-    Rcdata {
-        /// handles data in title, textarea etc
-        void read(Tokeniser t, CharacterReader r) {
-            switch (r.current()) {
-                case '&':
-                    t.advanceTransition(CharacterReferenceInRcdata);
-                    break;
-                case '<':
-                    t.advanceTransition(RcdataLessthanSign);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    r.advance();
-                    t.emit(replacementChar);
-                    break;
-                case eof:
-                    t.emit(new Token.EOF());
-                    break;
-                default:
-                    String data = r.consumeToAny('&', '<', nullChar);
-                    t.emit(data);
-                    break;
+        },
+    CharacterReferenceInData
+        {
+            // from & in data
+            void read(Tokeniser t, CharacterReader r)
+            {
+                readCharRef(t, Data);
             }
-        }
-    },
-    CharacterReferenceInRcdata {
-        void read(Tokeniser t, CharacterReader r) {
-            readCharRef(t, Rcdata);
-        }
-    },
-    Rawtext {
-        void read(Tokeniser t, CharacterReader r) {
-            readData(t, r, this, RawtextLessthanSign);
-        }
-    },
-    ScriptData {
-        void read(Tokeniser t, CharacterReader r) {
-            readData(t, r, this, ScriptDataLessthanSign);
-        }
-    },
-    PLAINTEXT {
-        void read(Tokeniser t, CharacterReader r) {
-            switch (r.current()) {
-                case nullChar:
-                    t.error(this);
-                    r.advance();
-                    t.emit(replacementChar);
-                    break;
-                case eof:
-                    t.emit(new Token.EOF());
-                    break;
-                default:
-                    String data = r.consumeTo(nullChar);
-                    t.emit(data);
-                    break;
-            }
-        }
-    },
-    TagOpen {
-        // from < in data
-        void read(Tokeniser t, CharacterReader r) {
-            switch (r.current()) {
-                case '!':
-                    t.advanceTransition(MarkupDeclarationOpen);
-                    break;
-                case '/':
-                    t.advanceTransition(EndTagOpen);
-                    break;
-                case '?':
-                    t.advanceTransition(BogusComment);
-                    break;
-                default:
-                    if (r.matchesLetter()) {
-                        t.createTagPending(true);
-                        t.transition(TagName);
-                    } else {
+        },
+    Rcdata
+        {
+            /// handles data in title, textarea etc
+            void read(Tokeniser t, CharacterReader r)
+            {
+                switch (r.current())
+                {
+                    case '&':
+                        t.advanceTransition(CharacterReferenceInRcdata);
+                        break;
+                    case '<':
+                        t.advanceTransition(RcdataLessthanSign);
+                        break;
+                    case nullChar:
                         t.error(this);
-                        t.emit('<'); // char that got us here
-                        t.transition(Data);
-                    }
-                    break;
+                        r.advance();
+                        t.emit(replacementChar);
+                        break;
+                    case eof:
+                        t.emit(new Token.EOF());
+                        break;
+                    default:
+                        String data = r.consumeToAny('&', '<', nullChar);
+                        t.emit(data);
+                        break;
+                }
             }
-        }
-    },
-    EndTagOpen {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.isEmpty()) {
-                t.eofError(this);
-                t.emit("</");
-                t.transition(Data);
-            } else if (r.matchesLetter()) {
-                t.createTagPending(false);
-                t.transition(TagName);
-            } else if (r.matches('>')) {
-                t.error(this);
-                t.advanceTransition(Data);
-            } else {
-                t.error(this);
-                t.advanceTransition(BogusComment);
+        },
+    CharacterReferenceInRcdata
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                readCharRef(t, Rcdata);
             }
-        }
-    },
-    TagName {
-        // from < or </ in data, will have start or end tag pending
-        void read(Tokeniser t, CharacterReader r) {
-            // previous TagOpen state did NOT consume, will have a letter char in current
-            //String tagName = r.consumeToAnySorted(tagCharsSorted).toLowerCase();
-            String tagName = r.consumeTagName();
-            t.tagPending.appendTagName(tagName);
-
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(BeforeAttributeName);
-                    break;
-                case '/':
-                    t.transition(SelfClosingStartTag);
-                    break;
-                case '>':
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case nullChar: // replacement
-                    t.tagPending.appendTagName(replacementStr);
-                    break;
-                case eof: // should emit pending tag?
+        },
+    Rawtext
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                readData(t, r, this, RawtextLessthanSign);
+            }
+        },
+    ScriptData
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                readData(t, r, this, ScriptDataLessthanSign);
+            }
+        },
+    PLAINTEXT
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                switch (r.current())
+                {
+                    case nullChar:
+                        t.error(this);
+                        r.advance();
+                        t.emit(replacementChar);
+                        break;
+                    case eof:
+                        t.emit(new Token.EOF());
+                        break;
+                    default:
+                        String data = r.consumeTo(nullChar);
+                        t.emit(data);
+                        break;
+                }
+            }
+        },
+    TagOpen
+        {
+            // from < in data
+            void read(Tokeniser t, CharacterReader r)
+            {
+                switch (r.current())
+                {
+                    case '!':
+                        t.advanceTransition(MarkupDeclarationOpen);
+                        break;
+                    case '/':
+                        t.advanceTransition(EndTagOpen);
+                        break;
+                    case '?':
+                        t.advanceTransition(BogusComment);
+                        break;
+                    default:
+                        if (r.matchesLetter())
+                        {
+                            t.createTagPending(true);
+                            t.transition(TagName);
+                        } else
+                        {
+                            t.error(this);
+                            t.emit('<'); // char that got us here
+                            t.transition(Data);
+                        }
+                        break;
+                }
+            }
+        },
+    EndTagOpen
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.isEmpty())
+                {
                     t.eofError(this);
+                    t.emit("</");
                     t.transition(Data);
-                    break;
-                default: // buffer underrun
-                    t.tagPending.appendTagName(c);
+                } else if (r.matchesLetter())
+                {
+                    t.createTagPending(false);
+                    t.transition(TagName);
+                } else if (r.matches('>'))
+                {
+                    t.error(this);
+                    t.advanceTransition(Data);
+                } else
+                {
+                    t.error(this);
+                    t.advanceTransition(BogusComment);
+                }
             }
-        }
-    },
-    RcdataLessthanSign {
-        // from < in rcdata
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matches('/')) {
-                t.createTempBuffer();
-                t.advanceTransition(RCDATAEndTagOpen);
-            } else if (r.matchesLetter() && t.appropriateEndTagName() != null && !r.containsIgnoreCase("</" + t.appropriateEndTagName())) {
-                // diverge from spec: got a start tag, but there's no appropriate end tag (</title>), so rather than
-                // consuming to EOF; break out here
-                t.tagPending = t.createTagPending(false).name(t.appropriateEndTagName());
-                t.emitTagPending();
-                r.unconsume(); // undo "<"
-                t.transition(Data);
-            } else {
-                t.emit("<");
-                t.transition(Rcdata);
-            }
-        }
-    },
-    RCDATAEndTagOpen {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesLetter()) {
-                t.createTagPending(false);
-                t.tagPending.appendTagName(r.current());
-                t.dataBuffer.append(r.current());
-                t.advanceTransition(RCDATAEndTagName);
-            } else {
-                t.emit("</");
-                t.transition(Rcdata);
-            }
-        }
-    },
-    RCDATAEndTagName {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesLetter()) {
-                String name = r.consumeLetterSequence();
-                t.tagPending.appendTagName(name);
-                t.dataBuffer.append(name);
-                return;
-            }
+        },
+    TagName
+        {
+            // from < or </ in data, will have start or end tag pending
+            void read(Tokeniser t, CharacterReader r)
+            {
+                // previous TagOpen state did NOT consume, will have a letter char in current
+                //String tagName = r.consumeToAnySorted(tagCharsSorted).toLowerCase();
+                String tagName = r.consumeTagName();
+                t.tagPending.appendTagName(tagName);
 
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    if (t.isAppropriateEndTagToken())
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
                         t.transition(BeforeAttributeName);
-                    else
-                        anythingElse(t, r);
-                    break;
-                case '/':
-                    if (t.isAppropriateEndTagToken())
+                        break;
+                    case '/':
                         t.transition(SelfClosingStartTag);
-                    else
-                        anythingElse(t, r);
-                    break;
-                case '>':
-                    if (t.isAppropriateEndTagToken()) {
+                        break;
+                    case '>':
                         t.emitTagPending();
                         t.transition(Data);
-                    }
-                    else
-                        anythingElse(t, r);
-                    break;
-                default:
-                    anythingElse(t, r);
+                        break;
+                    case nullChar: // replacement
+                        t.tagPending.appendTagName(replacementStr);
+                        break;
+                    case eof: // should emit pending tag?
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default: // buffer underrun
+                        t.tagPending.appendTagName(c);
+                }
             }
-        }
-
-        private void anythingElse(Tokeniser t, CharacterReader r) {
-            t.emit("</" + t.dataBuffer.toString());
-            r.unconsume();
-            t.transition(Rcdata);
-        }
-    },
-    RawtextLessthanSign {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matches('/')) {
-                t.createTempBuffer();
-                t.advanceTransition(RawtextEndTagOpen);
-            } else {
-                t.emit('<');
-                t.transition(Rawtext);
-            }
-        }
-    },
-    RawtextEndTagOpen {
-        void read(Tokeniser t, CharacterReader r) {
-            readEndTag(t, r, RawtextEndTagName, Rawtext);
-        }
-    },
-    RawtextEndTagName {
-        void read(Tokeniser t, CharacterReader r) {
-            handleDataEndTag(t, r, Rawtext);
-        }
-    },
-    ScriptDataLessthanSign {
-        void read(Tokeniser t, CharacterReader r) {
-            switch (r.consume()) {
-                case '/':
+        },
+    RcdataLessthanSign
+        {
+            // from < in rcdata
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matches('/'))
+                {
                     t.createTempBuffer();
-                    t.transition(ScriptDataEndTagOpen);
-                    break;
-                case '!':
-                    t.emit("<!");
-                    t.transition(ScriptDataEscapeStart);
-                    break;
-                default:
+                    t.advanceTransition(RCDATAEndTagOpen);
+                } else if (r.matchesLetter() && t.appropriateEndTagName() != null && !r.containsIgnoreCase("</" + t.appropriateEndTagName()))
+                {
+                    // diverge from spec: got a start tag, but there's no appropriate end tag (</title>), so rather than
+                    // consuming to EOF; break out here
+                    t.tagPending = t.createTagPending(false).name(t.appropriateEndTagName());
+                    t.emitTagPending();
+                    r.unconsume(); // undo "<"
+                    t.transition(Data);
+                } else
+                {
                     t.emit("<");
-                    r.unconsume();
-                    t.transition(ScriptData);
+                    t.transition(Rcdata);
+                }
             }
-        }
-    },
-    ScriptDataEndTagOpen {
-        void read(Tokeniser t, CharacterReader r) {
-            readEndTag(t, r, ScriptDataEndTagName, ScriptData);
-        }
-    },
-    ScriptDataEndTagName {
-        void read(Tokeniser t, CharacterReader r) {
-            handleDataEndTag(t, r, ScriptData);
-        }
-    },
-    ScriptDataEscapeStart {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matches('-')) {
-                t.emit('-');
-                t.advanceTransition(ScriptDataEscapeStartDash);
-            } else {
-                t.transition(ScriptData);
+        },
+    RCDATAEndTagOpen
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matchesLetter())
+                {
+                    t.createTagPending(false);
+                    t.tagPending.appendTagName(r.current());
+                    t.dataBuffer.append(r.current());
+                    t.advanceTransition(RCDATAEndTagName);
+                } else
+                {
+                    t.emit("</");
+                    t.transition(Rcdata);
+                }
             }
-        }
-    },
-    ScriptDataEscapeStartDash {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matches('-')) {
-                t.emit('-');
-                t.advanceTransition(ScriptDataEscapedDashDash);
-            } else {
-                t.transition(ScriptData);
-            }
-        }
-    },
-    ScriptDataEscaped {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.isEmpty()) {
-                t.eofError(this);
-                t.transition(Data);
-                return;
+        },
+    RCDATAEndTagName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matchesLetter())
+                {
+                    String name = r.consumeLetterSequence();
+                    t.tagPending.appendTagName(name);
+                    t.dataBuffer.append(name);
+                    return;
+                }
+
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        if (t.isAppropriateEndTagToken())
+                            t.transition(BeforeAttributeName);
+                        else
+                            anythingElse(t, r);
+                        break;
+                    case '/':
+                        if (t.isAppropriateEndTagToken())
+                            t.transition(SelfClosingStartTag);
+                        else
+                            anythingElse(t, r);
+                        break;
+                    case '>':
+                        if (t.isAppropriateEndTagToken())
+                        {
+                            t.emitTagPending();
+                            t.transition(Data);
+                        } else
+                            anythingElse(t, r);
+                        break;
+                    default:
+                        anythingElse(t, r);
+                }
             }
 
-            switch (r.current()) {
-                case '-':
+            private void anythingElse(Tokeniser t, CharacterReader r)
+            {
+                t.emit("</" + t.dataBuffer.toString());
+                r.unconsume();
+                t.transition(Rcdata);
+            }
+        },
+    RawtextLessthanSign
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matches('/'))
+                {
+                    t.createTempBuffer();
+                    t.advanceTransition(RawtextEndTagOpen);
+                } else
+                {
+                    t.emit('<');
+                    t.transition(Rawtext);
+                }
+            }
+        },
+    RawtextEndTagOpen
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                readEndTag(t, r, RawtextEndTagName, Rawtext);
+            }
+        },
+    RawtextEndTagName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                handleDataEndTag(t, r, Rawtext);
+            }
+        },
+    ScriptDataLessthanSign
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                switch (r.consume())
+                {
+                    case '/':
+                        t.createTempBuffer();
+                        t.transition(ScriptDataEndTagOpen);
+                        break;
+                    case '!':
+                        t.emit("<!");
+                        t.transition(ScriptDataEscapeStart);
+                        break;
+                    default:
+                        t.emit("<");
+                        r.unconsume();
+                        t.transition(ScriptData);
+                }
+            }
+        },
+    ScriptDataEndTagOpen
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                readEndTag(t, r, ScriptDataEndTagName, ScriptData);
+            }
+        },
+    ScriptDataEndTagName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                handleDataEndTag(t, r, ScriptData);
+            }
+        },
+    ScriptDataEscapeStart
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matches('-'))
+                {
                     t.emit('-');
-                    t.advanceTransition(ScriptDataEscapedDash);
-                    break;
-                case '<':
-                    t.advanceTransition(ScriptDataEscapedLessthanSign);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    r.advance();
-                    t.emit(replacementChar);
-                    break;
-                default:
-                    String data = r.consumeToAny('-', '<', nullChar);
-                    t.emit(data);
-            }
-        }
-    },
-    ScriptDataEscapedDash {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.isEmpty()) {
-                t.eofError(this);
-                t.transition(Data);
-                return;
-            }
-
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.emit(c);
-                    t.transition(ScriptDataEscapedDashDash);
-                    break;
-                case '<':
-                    t.transition(ScriptDataEscapedLessthanSign);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.emit(replacementChar);
-                    t.transition(ScriptDataEscaped);
-                    break;
-                default:
-                    t.emit(c);
-                    t.transition(ScriptDataEscaped);
-            }
-        }
-    },
-    ScriptDataEscapedDashDash {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.isEmpty()) {
-                t.eofError(this);
-                t.transition(Data);
-                return;
-            }
-
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.emit(c);
-                    break;
-                case '<':
-                    t.transition(ScriptDataEscapedLessthanSign);
-                    break;
-                case '>':
-                    t.emit(c);
+                    t.advanceTransition(ScriptDataEscapeStartDash);
+                } else
+                {
                     t.transition(ScriptData);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.emit(replacementChar);
-                    t.transition(ScriptDataEscaped);
-                    break;
-                default:
-                    t.emit(c);
-                    t.transition(ScriptDataEscaped);
+                }
             }
-        }
-    },
-    ScriptDataEscapedLessthanSign {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesLetter()) {
-                t.createTempBuffer();
-                t.dataBuffer.append(r.current());
-                t.emit("<" + r.current());
-                t.advanceTransition(ScriptDataDoubleEscapeStart);
-            } else if (r.matches('/')) {
-                t.createTempBuffer();
-                t.advanceTransition(ScriptDataEscapedEndTagOpen);
-            } else {
-                t.emit('<');
-                t.transition(ScriptDataEscaped);
-            }
-        }
-    },
-    ScriptDataEscapedEndTagOpen {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesLetter()) {
-                t.createTagPending(false);
-                t.tagPending.appendTagName(r.current());
-                t.dataBuffer.append(r.current());
-                t.advanceTransition(ScriptDataEscapedEndTagName);
-            } else {
-                t.emit("</");
-                t.transition(ScriptDataEscaped);
-            }
-        }
-    },
-    ScriptDataEscapedEndTagName {
-        void read(Tokeniser t, CharacterReader r) {
-            handleDataEndTag(t, r, ScriptDataEscaped);
-        }
-    },
-    ScriptDataDoubleEscapeStart {
-        void read(Tokeniser t, CharacterReader r) {
-            handleDataDoubleEscapeTag(t, r, ScriptDataDoubleEscaped, ScriptDataEscaped);
-        }
-    },
-    ScriptDataDoubleEscaped {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.current();
-            switch (c) {
-                case '-':
-                    t.emit(c);
-                    t.advanceTransition(ScriptDataDoubleEscapedDash);
-                    break;
-                case '<':
-                    t.emit(c);
-                    t.advanceTransition(ScriptDataDoubleEscapedLessthanSign);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    r.advance();
-                    t.emit(replacementChar);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                default:
-                    String data = r.consumeToAny('-', '<', nullChar);
-                    t.emit(data);
-            }
-        }
-    },
-    ScriptDataDoubleEscapedDash {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.emit(c);
-                    t.transition(ScriptDataDoubleEscapedDashDash);
-                    break;
-                case '<':
-                    t.emit(c);
-                    t.transition(ScriptDataDoubleEscapedLessthanSign);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.emit(replacementChar);
-                    t.transition(ScriptDataDoubleEscaped);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                default:
-                    t.emit(c);
-                    t.transition(ScriptDataDoubleEscaped);
-            }
-        }
-    },
-    ScriptDataDoubleEscapedDashDash {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.emit(c);
-                    break;
-                case '<':
-                    t.emit(c);
-                    t.transition(ScriptDataDoubleEscapedLessthanSign);
-                    break;
-                case '>':
-                    t.emit(c);
+        },
+    ScriptDataEscapeStartDash
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matches('-'))
+                {
+                    t.emit('-');
+                    t.advanceTransition(ScriptDataEscapedDashDash);
+                } else
+                {
                     t.transition(ScriptData);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.emit(replacementChar);
+                }
+            }
+        },
+    ScriptDataEscaped
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.isEmpty())
+                {
+                    t.eofError(this);
+                    t.transition(Data);
+                    return;
+                }
+
+                switch (r.current())
+                {
+                    case '-':
+                        t.emit('-');
+                        t.advanceTransition(ScriptDataEscapedDash);
+                        break;
+                    case '<':
+                        t.advanceTransition(ScriptDataEscapedLessthanSign);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        r.advance();
+                        t.emit(replacementChar);
+                        break;
+                    default:
+                        String data = r.consumeToAny('-', '<', nullChar);
+                        t.emit(data);
+                }
+            }
+        },
+    ScriptDataEscapedDash
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.isEmpty())
+                {
+                    t.eofError(this);
+                    t.transition(Data);
+                    return;
+                }
+
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.emit(c);
+                        t.transition(ScriptDataEscapedDashDash);
+                        break;
+                    case '<':
+                        t.transition(ScriptDataEscapedLessthanSign);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.emit(replacementChar);
+                        t.transition(ScriptDataEscaped);
+                        break;
+                    default:
+                        t.emit(c);
+                        t.transition(ScriptDataEscaped);
+                }
+            }
+        },
+    ScriptDataEscapedDashDash
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.isEmpty())
+                {
+                    t.eofError(this);
+                    t.transition(Data);
+                    return;
+                }
+
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.emit(c);
+                        break;
+                    case '<':
+                        t.transition(ScriptDataEscapedLessthanSign);
+                        break;
+                    case '>':
+                        t.emit(c);
+                        t.transition(ScriptData);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.emit(replacementChar);
+                        t.transition(ScriptDataEscaped);
+                        break;
+                    default:
+                        t.emit(c);
+                        t.transition(ScriptDataEscaped);
+                }
+            }
+        },
+    ScriptDataEscapedLessthanSign
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matchesLetter())
+                {
+                    t.createTempBuffer();
+                    t.dataBuffer.append(r.current());
+                    t.emit("<" + r.current());
+                    t.advanceTransition(ScriptDataDoubleEscapeStart);
+                } else if (r.matches('/'))
+                {
+                    t.createTempBuffer();
+                    t.advanceTransition(ScriptDataEscapedEndTagOpen);
+                } else
+                {
+                    t.emit('<');
+                    t.transition(ScriptDataEscaped);
+                }
+            }
+        },
+    ScriptDataEscapedEndTagOpen
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matchesLetter())
+                {
+                    t.createTagPending(false);
+                    t.tagPending.appendTagName(r.current());
+                    t.dataBuffer.append(r.current());
+                    t.advanceTransition(ScriptDataEscapedEndTagName);
+                } else
+                {
+                    t.emit("</");
+                    t.transition(ScriptDataEscaped);
+                }
+            }
+        },
+    ScriptDataEscapedEndTagName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                handleDataEndTag(t, r, ScriptDataEscaped);
+            }
+        },
+    ScriptDataDoubleEscapeStart
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                handleDataDoubleEscapeTag(t, r, ScriptDataDoubleEscaped, ScriptDataEscaped);
+            }
+        },
+    ScriptDataDoubleEscaped
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.current();
+                switch (c)
+                {
+                    case '-':
+                        t.emit(c);
+                        t.advanceTransition(ScriptDataDoubleEscapedDash);
+                        break;
+                    case '<':
+                        t.emit(c);
+                        t.advanceTransition(ScriptDataDoubleEscapedLessthanSign);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        r.advance();
+                        t.emit(replacementChar);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default:
+                        String data = r.consumeToAny('-', '<', nullChar);
+                        t.emit(data);
+                }
+            }
+        },
+    ScriptDataDoubleEscapedDash
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.emit(c);
+                        t.transition(ScriptDataDoubleEscapedDashDash);
+                        break;
+                    case '<':
+                        t.emit(c);
+                        t.transition(ScriptDataDoubleEscapedLessthanSign);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.emit(replacementChar);
+                        t.transition(ScriptDataDoubleEscaped);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.emit(c);
+                        t.transition(ScriptDataDoubleEscaped);
+                }
+            }
+        },
+    ScriptDataDoubleEscapedDashDash
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.emit(c);
+                        break;
+                    case '<':
+                        t.emit(c);
+                        t.transition(ScriptDataDoubleEscapedLessthanSign);
+                        break;
+                    case '>':
+                        t.emit(c);
+                        t.transition(ScriptData);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.emit(replacementChar);
+                        t.transition(ScriptDataDoubleEscaped);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.emit(c);
+                        t.transition(ScriptDataDoubleEscaped);
+                }
+            }
+        },
+    ScriptDataDoubleEscapedLessthanSign
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matches('/'))
+                {
+                    t.emit('/');
+                    t.createTempBuffer();
+                    t.advanceTransition(ScriptDataDoubleEscapeEnd);
+                } else
+                {
                     t.transition(ScriptDataDoubleEscaped);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                default:
-                    t.emit(c);
-                    t.transition(ScriptDataDoubleEscaped);
+                }
             }
-        }
-    },
-    ScriptDataDoubleEscapedLessthanSign {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matches('/')) {
-                t.emit('/');
-                t.createTempBuffer();
-                t.advanceTransition(ScriptDataDoubleEscapeEnd);
-            } else {
-                t.transition(ScriptDataDoubleEscaped);
+        },
+    ScriptDataDoubleEscapeEnd
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                handleDataDoubleEscapeTag(t, r, ScriptDataEscaped, ScriptDataDoubleEscaped);
             }
-        }
-    },
-    ScriptDataDoubleEscapeEnd {
-        void read(Tokeniser t, CharacterReader r) {
-            handleDataDoubleEscapeTag(t,r, ScriptDataEscaped, ScriptDataDoubleEscaped);
-        }
-    },
-    BeforeAttributeName {
-        // from tagname <xxx
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    break; // ignore whitespace
-                case '/':
-                    t.transition(SelfClosingStartTag);
-                    break;
-                case '>':
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.tagPending.newAttribute();
-                    r.unconsume();
-                    t.transition(AttributeName);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                case '"':
-                case '\'':
-                case '<':
-                case '=':
-                    t.error(this);
-                    t.tagPending.newAttribute();
-                    t.tagPending.appendAttributeName(c);
-                    t.transition(AttributeName);
-                    break;
-                default: // A-Z, anything else
-                    t.tagPending.newAttribute();
-                    r.unconsume();
-                    t.transition(AttributeName);
+        },
+    BeforeAttributeName
+        {
+            // from tagname <xxx
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        break; // ignore whitespace
+                    case '/':
+                        t.transition(SelfClosingStartTag);
+                        break;
+                    case '>':
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.tagPending.newAttribute();
+                        r.unconsume();
+                        t.transition(AttributeName);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    case '"':
+                    case '\'':
+                    case '<':
+                    case '=':
+                        t.error(this);
+                        t.tagPending.newAttribute();
+                        t.tagPending.appendAttributeName(c);
+                        t.transition(AttributeName);
+                        break;
+                    default: // A-Z, anything else
+                        t.tagPending.newAttribute();
+                        r.unconsume();
+                        t.transition(AttributeName);
+                }
             }
-        }
-    },
-    AttributeName {
-        // from before attribute name
-        void read(Tokeniser t, CharacterReader r) {
-            String name = r.consumeToAnySorted(attributeNameCharsSorted);
-            t.tagPending.appendAttributeName(name);
+        },
+    AttributeName
+        {
+            // from before attribute name
+            void read(Tokeniser t, CharacterReader r)
+            {
+                String name = r.consumeToAnySorted(attributeNameCharsSorted);
+                t.tagPending.appendAttributeName(name);
 
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(AfterAttributeName);
-                    break;
-                case '/':
-                    t.transition(SelfClosingStartTag);
-                    break;
-                case '=':
-                    t.transition(BeforeAttributeValue);
-                    break;
-                case '>':
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.tagPending.appendAttributeName(replacementChar);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                case '"':
-                case '\'':
-                case '<':
-                    t.error(this);
-                    t.tagPending.appendAttributeName(c);
-                    break;
-                default: // buffer underrun
-                    t.tagPending.appendAttributeName(c);
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(AfterAttributeName);
+                        break;
+                    case '/':
+                        t.transition(SelfClosingStartTag);
+                        break;
+                    case '=':
+                        t.transition(BeforeAttributeValue);
+                        break;
+                    case '>':
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.tagPending.appendAttributeName(replacementChar);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    case '"':
+                    case '\'':
+                    case '<':
+                        t.error(this);
+                        t.tagPending.appendAttributeName(c);
+                        break;
+                    default: // buffer underrun
+                        t.tagPending.appendAttributeName(c);
+                }
             }
-        }
-    },
-    AfterAttributeName {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    // ignore
-                    break;
-                case '/':
-                    t.transition(SelfClosingStartTag);
-                    break;
-                case '=':
-                    t.transition(BeforeAttributeValue);
-                    break;
-                case '>':
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.tagPending.appendAttributeName(replacementChar);
-                    t.transition(AttributeName);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                case '"':
-                case '\'':
-                case '<':
-                    t.error(this);
-                    t.tagPending.newAttribute();
-                    t.tagPending.appendAttributeName(c);
-                    t.transition(AttributeName);
-                    break;
-                default: // A-Z, anything else
-                    t.tagPending.newAttribute();
-                    r.unconsume();
-                    t.transition(AttributeName);
+        },
+    AfterAttributeName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        // ignore
+                        break;
+                    case '/':
+                        t.transition(SelfClosingStartTag);
+                        break;
+                    case '=':
+                        t.transition(BeforeAttributeValue);
+                        break;
+                    case '>':
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.tagPending.appendAttributeName(replacementChar);
+                        t.transition(AttributeName);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    case '"':
+                    case '\'':
+                    case '<':
+                        t.error(this);
+                        t.tagPending.newAttribute();
+                        t.tagPending.appendAttributeName(c);
+                        t.transition(AttributeName);
+                        break;
+                    default: // A-Z, anything else
+                        t.tagPending.newAttribute();
+                        r.unconsume();
+                        t.transition(AttributeName);
+                }
             }
-        }
-    },
-    BeforeAttributeValue {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    // ignore
-                    break;
-                case '"':
-                    t.transition(AttributeValue_doubleQuoted);
-                    break;
-                case '&':
-                    r.unconsume();
-                    t.transition(AttributeValue_unquoted);
-                    break;
-                case '\'':
-                    t.transition(AttributeValue_singleQuoted);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.tagPending.appendAttributeValue(replacementChar);
-                    t.transition(AttributeValue_unquoted);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case '<':
-                case '=':
-                case '`':
-                    t.error(this);
-                    t.tagPending.appendAttributeValue(c);
-                    t.transition(AttributeValue_unquoted);
-                    break;
-                default:
-                    r.unconsume();
-                    t.transition(AttributeValue_unquoted);
+        },
+    BeforeAttributeValue
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        // ignore
+                        break;
+                    case '"':
+                        t.transition(AttributeValue_doubleQuoted);
+                        break;
+                    case '&':
+                        r.unconsume();
+                        t.transition(AttributeValue_unquoted);
+                        break;
+                    case '\'':
+                        t.transition(AttributeValue_singleQuoted);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.tagPending.appendAttributeValue(replacementChar);
+                        t.transition(AttributeValue_unquoted);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case '<':
+                    case '=':
+                    case '`':
+                        t.error(this);
+                        t.tagPending.appendAttributeValue(c);
+                        t.transition(AttributeValue_unquoted);
+                        break;
+                    default:
+                        r.unconsume();
+                        t.transition(AttributeValue_unquoted);
+                }
             }
-        }
-    },
-    AttributeValue_doubleQuoted {
-        void read(Tokeniser t, CharacterReader r) {
-            String value = r.consumeToAny(attributeDoubleValueCharsSorted);
-            if (value.length() > 0)
-                t.tagPending.appendAttributeValue(value);
-            else
-                t.tagPending.setEmptyAttributeValue();
+        },
+    AttributeValue_doubleQuoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                String value = r.consumeToAny(attributeDoubleValueCharsSorted);
+                if (value.length() > 0)
+                    t.tagPending.appendAttributeValue(value);
+                else
+                    t.tagPending.setEmptyAttributeValue();
 
-            char c = r.consume();
-            switch (c) {
-                case '"':
-                    t.transition(AfterAttributeValue_quoted);
-                    break;
-                case '&':
-                    int[] ref = t.consumeCharacterReference('"', true);
-                    if (ref != null)
-                        t.tagPending.appendAttributeValue(ref);
-                    else
-                        t.tagPending.appendAttributeValue('&');
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.tagPending.appendAttributeValue(replacementChar);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                default: // hit end of buffer in first read, still in attribute
-                    t.tagPending.appendAttributeValue(c);
+                char c = r.consume();
+                switch (c)
+                {
+                    case '"':
+                        t.transition(AfterAttributeValue_quoted);
+                        break;
+                    case '&':
+                        int[] ref = t.consumeCharacterReference('"', true);
+                        if (ref != null)
+                            t.tagPending.appendAttributeValue(ref);
+                        else
+                            t.tagPending.appendAttributeValue('&');
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.tagPending.appendAttributeValue(replacementChar);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default: // hit end of buffer in first read, still in attribute
+                        t.tagPending.appendAttributeValue(c);
+                }
             }
-        }
-    },
-    AttributeValue_singleQuoted {
-        void read(Tokeniser t, CharacterReader r) {
-            String value = r.consumeToAny(attributeSingleValueCharsSorted);
-            if (value.length() > 0)
-                t.tagPending.appendAttributeValue(value);
-            else
-                t.tagPending.setEmptyAttributeValue();
+        },
+    AttributeValue_singleQuoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                String value = r.consumeToAny(attributeSingleValueCharsSorted);
+                if (value.length() > 0)
+                    t.tagPending.appendAttributeValue(value);
+                else
+                    t.tagPending.setEmptyAttributeValue();
 
-            char c = r.consume();
-            switch (c) {
-                case '\'':
-                    t.transition(AfterAttributeValue_quoted);
-                    break;
-                case '&':
-                    int[] ref = t.consumeCharacterReference('\'', true);
-                    if (ref != null)
-                        t.tagPending.appendAttributeValue(ref);
-                    else
-                        t.tagPending.appendAttributeValue('&');
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.tagPending.appendAttributeValue(replacementChar);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                default: // hit end of buffer in first read, still in attribute
-                    t.tagPending.appendAttributeValue(c);
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\'':
+                        t.transition(AfterAttributeValue_quoted);
+                        break;
+                    case '&':
+                        int[] ref = t.consumeCharacterReference('\'', true);
+                        if (ref != null)
+                            t.tagPending.appendAttributeValue(ref);
+                        else
+                            t.tagPending.appendAttributeValue('&');
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.tagPending.appendAttributeValue(replacementChar);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default: // hit end of buffer in first read, still in attribute
+                        t.tagPending.appendAttributeValue(c);
+                }
             }
-        }
-    },
-    AttributeValue_unquoted {
-        void read(Tokeniser t, CharacterReader r) {
-            String value = r.consumeToAnySorted(attributeValueUnquoted);
-            if (value.length() > 0)
-                t.tagPending.appendAttributeValue(value);
+        },
+    AttributeValue_unquoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                String value = r.consumeToAnySorted(attributeValueUnquoted);
+                if (value.length() > 0)
+                    t.tagPending.appendAttributeValue(value);
 
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(BeforeAttributeName);
-                    break;
-                case '&':
-                    int[] ref = t.consumeCharacterReference('>', true);
-                    if (ref != null)
-                        t.tagPending.appendAttributeValue(ref);
-                    else
-                        t.tagPending.appendAttributeValue('&');
-                    break;
-                case '>':
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.tagPending.appendAttributeValue(replacementChar);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                case '"':
-                case '\'':
-                case '<':
-                case '=':
-                case '`':
-                    t.error(this);
-                    t.tagPending.appendAttributeValue(c);
-                    break;
-                default: // hit end of buffer in first read, still in attribute
-                    t.tagPending.appendAttributeValue(c);
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(BeforeAttributeName);
+                        break;
+                    case '&':
+                        int[] ref = t.consumeCharacterReference('>', true);
+                        if (ref != null)
+                            t.tagPending.appendAttributeValue(ref);
+                        else
+                            t.tagPending.appendAttributeValue('&');
+                        break;
+                    case '>':
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.tagPending.appendAttributeValue(replacementChar);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    case '"':
+                    case '\'':
+                    case '<':
+                    case '=':
+                    case '`':
+                        t.error(this);
+                        t.tagPending.appendAttributeValue(c);
+                        break;
+                    default: // hit end of buffer in first read, still in attribute
+                        t.tagPending.appendAttributeValue(c);
+                }
+
             }
-
-        }
-    },
+        },
     // CharacterReferenceInAttributeValue state handled inline
-    AfterAttributeValue_quoted {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(BeforeAttributeName);
-                    break;
-                case '/':
-                    t.transition(SelfClosingStartTag);
-                    break;
-                case '>':
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    r.unconsume();
-                    t.transition(BeforeAttributeName);
-            }
+    AfterAttributeValue_quoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(BeforeAttributeName);
+                        break;
+                    case '/':
+                        t.transition(SelfClosingStartTag);
+                        break;
+                    case '>':
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        r.unconsume();
+                        t.transition(BeforeAttributeName);
+                }
 
-        }
-    },
-    SelfClosingStartTag {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '>':
-                    t.tagPending.selfClosing = true;
-                    t.emitTagPending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    r.unconsume();
-                    t.transition(BeforeAttributeName);
             }
-        }
-    },
-    BogusComment {
-        void read(Tokeniser t, CharacterReader r) {
-            // todo: handle bogus comment starting from eof. when does that trigger?
-            // rewind to capture character that lead us here
-            r.unconsume();
-            Token.Comment comment = new Token.Comment();
-            comment.bogus = true;
-            comment.data.append(r.consumeTo('>'));
-            // todo: replace nullChar with replaceChar
-            t.emit(comment);
-            t.advanceTransition(Data);
-        }
-    },
-    MarkupDeclarationOpen {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matchConsume("--")) {
-                t.createCommentPending();
-                t.transition(CommentStart);
-            } else if (r.matchConsumeIgnoreCase("DOCTYPE")) {
-                t.transition(Doctype);
-            } else if (r.matchConsume("[CDATA[")) {
-                // todo: should actually check current namepspace, and only non-html allows cdata. until namespace
-                // is implemented properly, keep handling as cdata
-                //} else if (!t.currentNodeInHtmlNS() && r.matchConsume("[CDATA[")) {
-                t.createTempBuffer();
-                t.transition(CdataSection);
-            } else {
-                t.error(this);
-                t.advanceTransition(BogusComment); // advance so this character gets in bogus comment data's rewind
+        },
+    SelfClosingStartTag
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '>':
+                        t.tagPending.selfClosing = true;
+                        t.emitTagPending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        r.unconsume();
+                        t.transition(BeforeAttributeName);
+                }
             }
-        }
-    },
-    CommentStart {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.transition(CommentStartDash);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.commentPending.data.append(replacementChar);
-                    t.transition(Comment);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.commentPending.data.append(c);
-                    t.transition(Comment);
-            }
-        }
-    },
-    CommentStartDash {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.transition(CommentStartDash);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.commentPending.data.append(replacementChar);
-                    t.transition(Comment);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.commentPending.data.append(c);
-                    t.transition(Comment);
-            }
-        }
-    },
-    Comment {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.current();
-            switch (c) {
-                case '-':
-                    t.advanceTransition(CommentEndDash);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    r.advance();
-                    t.commentPending.data.append(replacementChar);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.commentPending.data.append(r.consumeToAny('-', nullChar));
-            }
-        }
-    },
-    CommentEndDash {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.transition(CommentEnd);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.commentPending.data.append('-').append(replacementChar);
-                    t.transition(Comment);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.commentPending.data.append('-').append(c);
-                    t.transition(Comment);
-            }
-        }
-    },
-    CommentEnd {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '>':
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.commentPending.data.append("--").append(replacementChar);
-                    t.transition(Comment);
-                    break;
-                case '!':
-                    t.error(this);
-                    t.transition(CommentEndBang);
-                    break;
-                case '-':
-                    t.error(this);
-                    t.commentPending.data.append('-');
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.commentPending.data.append("--").append(c);
-                    t.transition(Comment);
-            }
-        }
-    },
-    CommentEndBang {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '-':
-                    t.commentPending.data.append("--!");
-                    t.transition(CommentEndDash);
-                    break;
-                case '>':
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.commentPending.data.append("--!").append(replacementChar);
-                    t.transition(Comment);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.emitCommentPending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.commentPending.data.append("--!").append(c);
-                    t.transition(Comment);
-            }
-        }
-    },
-    Doctype {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(BeforeDoctypeName);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    // note: fall through to > case
-                case '>': // catch invalid <!DOCTYPE>
-                    t.error(this);
-                    t.createDoctypePending();
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.transition(BeforeDoctypeName);
-            }
-        }
-    },
-    BeforeDoctypeName {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesLetter()) {
-                t.createDoctypePending();
-                t.transition(DoctypeName);
-                return;
-            }
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    break; // ignore whitespace
-                case nullChar:
-                    t.error(this);
-                    t.createDoctypePending();
-                    t.doctypePending.name.append(replacementChar);
-                    t.transition(DoctypeName);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.createDoctypePending();
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.createDoctypePending();
-                    t.doctypePending.name.append(c);
-                    t.transition(DoctypeName);
-            }
-        }
-    },
-    DoctypeName {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesLetter()) {
-                String name = r.consumeLetterSequence();
-                t.doctypePending.name.append(name);
-                return;
-            }
-            char c = r.consume();
-            switch (c) {
-                case '>':
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(AfterDoctypeName);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.doctypePending.name.append(replacementChar);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.doctypePending.name.append(c);
-            }
-        }
-    },
-    AfterDoctypeName {
-        void read(Tokeniser t, CharacterReader r) {
-            if (r.isEmpty()) {
-                t.eofError(this);
-                t.doctypePending.forceQuirks = true;
-                t.emitDoctypePending();
-                t.transition(Data);
-                return;
-            }
-            if (r.matchesAny('\t', '\n', '\r', '\f', ' '))
-                r.advance(); // ignore whitespace
-            else if (r.matches('>')) {
-                t.emitDoctypePending();
+        },
+    BogusComment
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                // todo: handle bogus comment starting from eof. when does that trigger?
+                // rewind to capture character that lead us here
+                r.unconsume();
+                Token.Comment comment = new Token.Comment();
+                comment.bogus = true;
+                comment.data.append(r.consumeTo('>'));
+                // todo: replace nullChar with replaceChar
+                t.emit(comment);
                 t.advanceTransition(Data);
-            } else if (r.matchConsumeIgnoreCase(DocumentType.PUBLIC_KEY)) {
-                t.doctypePending.pubSysKey = DocumentType.PUBLIC_KEY;
-                t.transition(AfterDoctypePublicKeyword);
-            } else if (r.matchConsumeIgnoreCase(DocumentType.SYSTEM_KEY)) {
-                t.doctypePending.pubSysKey = DocumentType.SYSTEM_KEY;
-                t.transition(AfterDoctypeSystemKeyword);
-            } else {
-                t.error(this);
-                t.doctypePending.forceQuirks = true;
-                t.advanceTransition(BogusDoctype);
             }
+        },
+    MarkupDeclarationOpen
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matchConsume("--"))
+                {
+                    t.createCommentPending();
+                    t.transition(CommentStart);
+                } else if (r.matchConsumeIgnoreCase("DOCTYPE"))
+                {
+                    t.transition(Doctype);
+                } else if (r.matchConsume("[CDATA["))
+                {
+                    // todo: should actually check current namepspace, and only non-html allows cdata. until namespace
+                    // is implemented properly, keep handling as cdata
+                    //} else if (!t.currentNodeInHtmlNS() && r.matchConsume("[CDATA[")) {
+                    t.createTempBuffer();
+                    t.transition(CdataSection);
+                } else
+                {
+                    t.error(this);
+                    t.advanceTransition(BogusComment); // advance so this character gets in bogus comment data's rewind
+                }
+            }
+        },
+    CommentStart
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.transition(CommentStartDash);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.commentPending.data.append(replacementChar);
+                        t.transition(Comment);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.commentPending.data.append(c);
+                        t.transition(Comment);
+                }
+            }
+        },
+    CommentStartDash
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.transition(CommentStartDash);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.commentPending.data.append(replacementChar);
+                        t.transition(Comment);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.commentPending.data.append(c);
+                        t.transition(Comment);
+                }
+            }
+        },
+    Comment
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.current();
+                switch (c)
+                {
+                    case '-':
+                        t.advanceTransition(CommentEndDash);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        r.advance();
+                        t.commentPending.data.append(replacementChar);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.commentPending.data.append(r.consumeToAny('-', nullChar));
+                }
+            }
+        },
+    CommentEndDash
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.transition(CommentEnd);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.commentPending.data.append('-').append(replacementChar);
+                        t.transition(Comment);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.commentPending.data.append('-').append(c);
+                        t.transition(Comment);
+                }
+            }
+        },
+    CommentEnd
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '>':
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.commentPending.data.append("--").append(replacementChar);
+                        t.transition(Comment);
+                        break;
+                    case '!':
+                        t.error(this);
+                        t.transition(CommentEndBang);
+                        break;
+                    case '-':
+                        t.error(this);
+                        t.commentPending.data.append('-');
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.commentPending.data.append("--").append(c);
+                        t.transition(Comment);
+                }
+            }
+        },
+    CommentEndBang
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '-':
+                        t.commentPending.data.append("--!");
+                        t.transition(CommentEndDash);
+                        break;
+                    case '>':
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.commentPending.data.append("--!").append(replacementChar);
+                        t.transition(Comment);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.emitCommentPending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.commentPending.data.append("--!").append(c);
+                        t.transition(Comment);
+                }
+            }
+        },
+    Doctype
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(BeforeDoctypeName);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        // note: fall through to > case
+                    case '>': // catch invalid <!DOCTYPE>
+                        t.error(this);
+                        t.createDoctypePending();
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.transition(BeforeDoctypeName);
+                }
+            }
+        },
+    BeforeDoctypeName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matchesLetter())
+                {
+                    t.createDoctypePending();
+                    t.transition(DoctypeName);
+                    return;
+                }
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        break; // ignore whitespace
+                    case nullChar:
+                        t.error(this);
+                        t.createDoctypePending();
+                        t.doctypePending.name.append(replacementChar);
+                        t.transition(DoctypeName);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.createDoctypePending();
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.createDoctypePending();
+                        t.doctypePending.name.append(c);
+                        t.transition(DoctypeName);
+                }
+            }
+        },
+    DoctypeName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.matchesLetter())
+                {
+                    String name = r.consumeLetterSequence();
+                    t.doctypePending.name.append(name);
+                    return;
+                }
+                char c = r.consume();
+                switch (c)
+                {
+                    case '>':
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(AfterDoctypeName);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.doctypePending.name.append(replacementChar);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.doctypePending.name.append(c);
+                }
+            }
+        },
+    AfterDoctypeName
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                if (r.isEmpty())
+                {
+                    t.eofError(this);
+                    t.doctypePending.forceQuirks = true;
+                    t.emitDoctypePending();
+                    t.transition(Data);
+                    return;
+                }
+                if (r.matchesAny('\t', '\n', '\r', '\f', ' '))
+                    r.advance(); // ignore whitespace
+                else if (r.matches('>'))
+                {
+                    t.emitDoctypePending();
+                    t.advanceTransition(Data);
+                } else if (r.matchConsumeIgnoreCase(DocumentType.PUBLIC_KEY))
+                {
+                    t.doctypePending.pubSysKey = DocumentType.PUBLIC_KEY;
+                    t.transition(AfterDoctypePublicKeyword);
+                } else if (r.matchConsumeIgnoreCase(DocumentType.SYSTEM_KEY))
+                {
+                    t.doctypePending.pubSysKey = DocumentType.SYSTEM_KEY;
+                    t.transition(AfterDoctypeSystemKeyword);
+                } else
+                {
+                    t.error(this);
+                    t.doctypePending.forceQuirks = true;
+                    t.advanceTransition(BogusDoctype);
+                }
 
-        }
-    },
-    AfterDoctypePublicKeyword {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(BeforeDoctypePublicIdentifier);
-                    break;
-                case '"':
-                    t.error(this);
-                    // set public id to empty string
-                    t.transition(DoctypePublicIdentifier_doubleQuoted);
-                    break;
-                case '\'':
-                    t.error(this);
-                    // set public id to empty string
-                    t.transition(DoctypePublicIdentifier_singleQuoted);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.transition(BogusDoctype);
             }
-        }
-    },
-    BeforeDoctypePublicIdentifier {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    break;
-                case '"':
-                    // set public id to empty string
-                    t.transition(DoctypePublicIdentifier_doubleQuoted);
-                    break;
-                case '\'':
-                    // set public id to empty string
-                    t.transition(DoctypePublicIdentifier_singleQuoted);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.transition(BogusDoctype);
+        },
+    AfterDoctypePublicKeyword
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(BeforeDoctypePublicIdentifier);
+                        break;
+                    case '"':
+                        t.error(this);
+                        // set public id to empty string
+                        t.transition(DoctypePublicIdentifier_doubleQuoted);
+                        break;
+                    case '\'':
+                        t.error(this);
+                        // set public id to empty string
+                        t.transition(DoctypePublicIdentifier_singleQuoted);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.transition(BogusDoctype);
+                }
             }
-        }
-    },
-    DoctypePublicIdentifier_doubleQuoted {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '"':
-                    t.transition(AfterDoctypePublicIdentifier);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.doctypePending.publicIdentifier.append(replacementChar);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.doctypePending.publicIdentifier.append(c);
+        },
+    BeforeDoctypePublicIdentifier
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        break;
+                    case '"':
+                        // set public id to empty string
+                        t.transition(DoctypePublicIdentifier_doubleQuoted);
+                        break;
+                    case '\'':
+                        // set public id to empty string
+                        t.transition(DoctypePublicIdentifier_singleQuoted);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.transition(BogusDoctype);
+                }
             }
-        }
-    },
-    DoctypePublicIdentifier_singleQuoted {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\'':
-                    t.transition(AfterDoctypePublicIdentifier);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.doctypePending.publicIdentifier.append(replacementChar);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.doctypePending.publicIdentifier.append(c);
+        },
+    DoctypePublicIdentifier_doubleQuoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '"':
+                        t.transition(AfterDoctypePublicIdentifier);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.doctypePending.publicIdentifier.append(replacementChar);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.doctypePending.publicIdentifier.append(c);
+                }
             }
-        }
-    },
-    AfterDoctypePublicIdentifier {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(BetweenDoctypePublicAndSystemIdentifiers);
-                    break;
-                case '>':
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case '"':
-                    t.error(this);
-                    // system id empty
-                    t.transition(DoctypeSystemIdentifier_doubleQuoted);
-                    break;
-                case '\'':
-                    t.error(this);
-                    // system id empty
-                    t.transition(DoctypeSystemIdentifier_singleQuoted);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.transition(BogusDoctype);
+        },
+    DoctypePublicIdentifier_singleQuoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\'':
+                        t.transition(AfterDoctypePublicIdentifier);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.doctypePending.publicIdentifier.append(replacementChar);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.doctypePending.publicIdentifier.append(c);
+                }
             }
-        }
-    },
-    BetweenDoctypePublicAndSystemIdentifiers {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    break;
-                case '>':
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case '"':
-                    t.error(this);
-                    // system id empty
-                    t.transition(DoctypeSystemIdentifier_doubleQuoted);
-                    break;
-                case '\'':
-                    t.error(this);
-                    // system id empty
-                    t.transition(DoctypeSystemIdentifier_singleQuoted);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.transition(BogusDoctype);
+        },
+    AfterDoctypePublicIdentifier
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(BetweenDoctypePublicAndSystemIdentifiers);
+                        break;
+                    case '>':
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case '"':
+                        t.error(this);
+                        // system id empty
+                        t.transition(DoctypeSystemIdentifier_doubleQuoted);
+                        break;
+                    case '\'':
+                        t.error(this);
+                        // system id empty
+                        t.transition(DoctypeSystemIdentifier_singleQuoted);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.transition(BogusDoctype);
+                }
             }
-        }
-    },
-    AfterDoctypeSystemKeyword {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    t.transition(BeforeDoctypeSystemIdentifier);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case '"':
-                    t.error(this);
-                    // system id empty
-                    t.transition(DoctypeSystemIdentifier_doubleQuoted);
-                    break;
-                case '\'':
-                    t.error(this);
-                    // system id empty
-                    t.transition(DoctypeSystemIdentifier_singleQuoted);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
+        },
+    BetweenDoctypePublicAndSystemIdentifiers
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        break;
+                    case '>':
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case '"':
+                        t.error(this);
+                        // system id empty
+                        t.transition(DoctypeSystemIdentifier_doubleQuoted);
+                        break;
+                    case '\'':
+                        t.error(this);
+                        // system id empty
+                        t.transition(DoctypeSystemIdentifier_singleQuoted);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.transition(BogusDoctype);
+                }
             }
-        }
-    },
-    BeforeDoctypeSystemIdentifier {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    break;
-                case '"':
-                    // set system id to empty string
-                    t.transition(DoctypeSystemIdentifier_doubleQuoted);
-                    break;
-                case '\'':
-                    // set public id to empty string
-                    t.transition(DoctypeSystemIdentifier_singleQuoted);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.transition(BogusDoctype);
+        },
+    AfterDoctypeSystemKeyword
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        t.transition(BeforeDoctypeSystemIdentifier);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case '"':
+                        t.error(this);
+                        // system id empty
+                        t.transition(DoctypeSystemIdentifier_doubleQuoted);
+                        break;
+                    case '\'':
+                        t.error(this);
+                        // system id empty
+                        t.transition(DoctypeSystemIdentifier_singleQuoted);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                }
             }
-        }
-    },
-    DoctypeSystemIdentifier_doubleQuoted {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '"':
-                    t.transition(AfterDoctypeSystemIdentifier);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.doctypePending.systemIdentifier.append(replacementChar);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.doctypePending.systemIdentifier.append(c);
+        },
+    BeforeDoctypeSystemIdentifier
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        break;
+                    case '"':
+                        // set system id to empty string
+                        t.transition(DoctypeSystemIdentifier_doubleQuoted);
+                        break;
+                    case '\'':
+                        // set public id to empty string
+                        t.transition(DoctypeSystemIdentifier_singleQuoted);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.transition(BogusDoctype);
+                }
             }
-        }
-    },
-    DoctypeSystemIdentifier_singleQuoted {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\'':
-                    t.transition(AfterDoctypeSystemIdentifier);
-                    break;
-                case nullChar:
-                    t.error(this);
-                    t.doctypePending.systemIdentifier.append(replacementChar);
-                    break;
-                case '>':
-                    t.error(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.doctypePending.systemIdentifier.append(c);
+        },
+    DoctypeSystemIdentifier_doubleQuoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '"':
+                        t.transition(AfterDoctypeSystemIdentifier);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.doctypePending.systemIdentifier.append(replacementChar);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.doctypePending.systemIdentifier.append(c);
+                }
             }
-        }
-    },
-    AfterDoctypeSystemIdentifier {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    break;
-                case '>':
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.eofError(this);
-                    t.doctypePending.forceQuirks = true;
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    t.error(this);
-                    t.transition(BogusDoctype);
-                    // NOT force quirks
+        },
+    DoctypeSystemIdentifier_singleQuoted
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\'':
+                        t.transition(AfterDoctypeSystemIdentifier);
+                        break;
+                    case nullChar:
+                        t.error(this);
+                        t.doctypePending.systemIdentifier.append(replacementChar);
+                        break;
+                    case '>':
+                        t.error(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.doctypePending.systemIdentifier.append(c);
+                }
             }
-        }
-    },
-    BogusDoctype {
-        void read(Tokeniser t, CharacterReader r) {
-            char c = r.consume();
-            switch (c) {
-                case '>':
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                case eof:
-                    t.emitDoctypePending();
-                    t.transition(Data);
-                    break;
-                default:
-                    // ignore char
-                    break;
+        },
+    AfterDoctypeSystemIdentifier
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '\t':
+                    case '\n':
+                    case '\r':
+                    case '\f':
+                    case ' ':
+                        break;
+                    case '>':
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.eofError(this);
+                        t.doctypePending.forceQuirks = true;
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        t.error(this);
+                        t.transition(BogusDoctype);
+                        // NOT force quirks
+                }
             }
-        }
-    },
-    CdataSection {
-        void read(Tokeniser t, CharacterReader r) {
-            String data = r.consumeTo("]]>");
-            t.dataBuffer.append(data);
-            if (r.matchConsume("]]>") || r.isEmpty()) {
-                t.emit(new Token.CData(t.dataBuffer.toString()));
-                t.transition(Data);
-            }// otherwise, buffer underrun, stay in data section
-        }
-    };
+        },
+    BogusDoctype
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                char c = r.consume();
+                switch (c)
+                {
+                    case '>':
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    case eof:
+                        t.emitDoctypePending();
+                        t.transition(Data);
+                        break;
+                    default:
+                        // ignore char
+                        break;
+                }
+            }
+        },
+    CdataSection
+        {
+            void read(Tokeniser t, CharacterReader r)
+            {
+                String data = r.consumeTo("]]>");
+                t.dataBuffer.append(data);
+                if (r.matchConsume("]]>") || r.isEmpty())
+                {
+                    t.emit(new Token.CData(t.dataBuffer.toString()));
+                    t.transition(Data);
+                }// otherwise, buffer underrun, stay in data section
+            }
+        };
 
-
-    abstract void read(Tokeniser t, CharacterReader r);
 
     static final char nullChar = '\u0000';
     // char searches. must be sorted, used in inSorted. MUST update TokenisetStateTest if more arrays are added.
@@ -1618,7 +1835,6 @@ enum TokeniserState {
     static final char[] attributeDoubleValueCharsSorted = new char[]{nullChar, '"', '&'};
     static final char[] attributeNameCharsSorted = new char[]{nullChar, '\t', '\n', '\f', '\r', ' ', '"', '\'', '/', '<', '=', '>'};
     static final char[] attributeValueUnquoted = new char[]{nullChar, '\t', '\n', '\f', '\r', ' ', '"', '&', '\'', '<', '=', '>', '`'};
-
     private static final char replacementChar = Tokeniser.replacementChar;
     private static final String replacementStr = String.valueOf(Tokeniser.replacementChar);
     private static final char eof = CharacterReader.EOF;
@@ -1627,8 +1843,10 @@ enum TokeniserState {
      * Handles RawtextEndTagName, ScriptDataEndTagName, and ScriptDataEscapedEndTagName. Same body impl, just
      * different else exit transitions.
      */
-    private static void handleDataEndTag(Tokeniser t, CharacterReader r, TokeniserState elseTransition) {
-        if (r.matchesLetter()) {
+    private static void handleDataEndTag(Tokeniser t, CharacterReader r, TokeniserState elseTransition)
+    {
+        if (r.matchesLetter())
+        {
             String name = r.consumeLetterSequence();
             t.tagPending.appendTagName(name);
             t.dataBuffer.append(name);
@@ -1636,9 +1854,11 @@ enum TokeniserState {
         }
 
         boolean needsExitTransition = false;
-        if (t.isAppropriateEndTagToken() && !r.isEmpty()) {
+        if (t.isAppropriateEndTagToken() && !r.isEmpty())
+        {
             char c = r.consume();
-            switch (c) {
+            switch (c)
+            {
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1657,18 +1877,22 @@ enum TokeniserState {
                     t.dataBuffer.append(c);
                     needsExitTransition = true;
             }
-        } else {
+        } else
+        {
             needsExitTransition = true;
         }
 
-        if (needsExitTransition) {
+        if (needsExitTransition)
+        {
             t.emit("</" + t.dataBuffer.toString());
             t.transition(elseTransition);
         }
     }
 
-    private static void readData(Tokeniser t, CharacterReader r, TokeniserState current, TokeniserState advance) {
-        switch (r.current()) {
+    private static void readData(Tokeniser t, CharacterReader r, TokeniserState current, TokeniserState advance)
+    {
+        switch (r.current())
+        {
             case '<':
                 t.advanceTransition(advance);
                 break;
@@ -1687,7 +1911,8 @@ enum TokeniserState {
         }
     }
 
-    private static void readCharRef(Tokeniser t, TokeniserState advance) {
+    private static void readCharRef(Tokeniser t, TokeniserState advance)
+    {
         int[] c = t.consumeCharacterReference(null, false);
         if (c == null)
             t.emit('&');
@@ -1696,18 +1921,23 @@ enum TokeniserState {
         t.transition(advance);
     }
 
-    private static void readEndTag(Tokeniser t, CharacterReader r, TokeniserState a, TokeniserState b) {
-        if (r.matchesLetter()) {
+    private static void readEndTag(Tokeniser t, CharacterReader r, TokeniserState a, TokeniserState b)
+    {
+        if (r.matchesLetter())
+        {
             t.createTagPending(false);
             t.transition(a);
-        } else {
+        } else
+        {
             t.emit("</");
             t.transition(b);
         }
     }
 
-    private static void handleDataDoubleEscapeTag(Tokeniser t, CharacterReader r, TokeniserState primary, TokeniserState fallback) {
-        if (r.matchesLetter()) {
+    private static void handleDataDoubleEscapeTag(Tokeniser t, CharacterReader r, TokeniserState primary, TokeniserState fallback)
+    {
+        if (r.matchesLetter())
+        {
             String name = r.consumeLetterSequence();
             t.dataBuffer.append(name);
             t.emit(name);
@@ -1715,7 +1945,8 @@ enum TokeniserState {
         }
 
         char c = r.consume();
-        switch (c) {
+        switch (c)
+        {
             case '\t':
             case '\n':
             case '\r':
@@ -1734,4 +1965,6 @@ enum TokeniserState {
                 t.transition(fallback);
         }
     }
+
+    abstract void read(Tokeniser t, CharacterReader r);
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/span/SubScriptSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/span/SubScriptSpan.java
@@ -7,19 +7,23 @@ import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.html.HtmlPlugin;
 
-public class SubScriptSpan extends MetricAffectingSpan {
+public class SubScriptSpan extends MetricAffectingSpan
+{
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(TextPaint tp)
+    {
         apply(tp);
     }
 
     @Override
-    public void updateMeasureState(@NonNull TextPaint tp) {
+    public void updateMeasureState(@NonNull TextPaint tp)
+    {
         apply(tp);
     }
 
-    private void apply(TextPaint paint) {
+    private void apply(TextPaint paint)
+    {
         paint.setTextSize(paint.getTextSize() * HtmlPlugin.SCRIPT_DEF_TEXT_SIZE_RATIO);
         paint.baselineShift -= (int) (paint.ascent() / 2);
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/span/SuperScriptSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/span/SuperScriptSpan.java
@@ -7,19 +7,23 @@ import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.html.HtmlPlugin;
 
-public class SuperScriptSpan extends MetricAffectingSpan {
+public class SuperScriptSpan extends MetricAffectingSpan
+{
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(TextPaint tp)
+    {
         apply(tp);
     }
 
     @Override
-    public void updateMeasureState(@NonNull TextPaint tp) {
+    public void updateMeasureState(@NonNull TextPaint tp)
+    {
         apply(tp);
     }
 
-    private void apply(TextPaint paint) {
+    private void apply(TextPaint paint)
+    {
         paint.setTextSize(paint.getTextSize() * HtmlPlugin.SCRIPT_DEF_TEXT_SIZE_RATIO);
         paint.baselineShift += (int) (paint.ascent() / 2);
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/BlockquoteHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/BlockquoteHandler.java
@@ -2,47 +2,51 @@ package com.zeoflow.stylar.html.tag;
 
 import androidx.annotation.NonNull;
 
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.SpannableBuilder;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.StylarVisitor;
+import com.zeoflow.stylar.html.HtmlTag;
+import com.zeoflow.stylar.html.StylarHtmlRenderer;
+import com.zeoflow.stylar.html.TagHandler;
 
 import org.commonmark.node.BlockQuote;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.SpannableBuilder;
-import com.zeoflow.stylar.html.HtmlTag;
-import com.zeoflow.stylar.html.StylarHtmlRenderer;
-import com.zeoflow.stylar.html.TagHandler;
-
-public class BlockquoteHandler extends TagHandler {
+public class BlockquoteHandler extends TagHandler
+{
 
     @Override
     public void handle(
-            @NonNull StylarVisitor visitor,
-            @NonNull StylarHtmlRenderer renderer,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarVisitor visitor,
+        @NonNull StylarHtmlRenderer renderer,
+        @NonNull HtmlTag tag)
+    {
 
-        if (tag.isBlock()) {
+        if (tag.isBlock())
+        {
             visitChildren(visitor, renderer, tag.getAsBlock());
         }
 
         final StylarConfiguration configuration = visitor.configuration();
         final SpanFactory factory = configuration.spansFactory().get(BlockQuote.class);
-        if (factory != null) {
+        if (factory != null)
+        {
             SpannableBuilder.setSpans(
-                    visitor.builder(),
-                    factory.getSpans(configuration, visitor.renderProps()),
-                    tag.start(),
-                    tag.end()
+                visitor.builder(),
+                factory.getSpans(configuration, visitor.renderProps()),
+                tag.start(),
+                tag.end()
             );
         }
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Collections.singleton("blockquote");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/EmphasisHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/EmphasisHandler.java
@@ -3,25 +3,28 @@ package com.zeoflow.stylar.html.tag;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.html.HtmlTag;
+
 import org.commonmark.node.Emphasis;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.html.HtmlTag;
-
-public class EmphasisHandler extends SimpleTagHandler {
+public class EmphasisHandler extends SimpleTagHandler
+{
     @Nullable
     @Override
     public Object getSpans(
-            @NonNull StylarConfiguration configuration,
-            @NonNull RenderProps renderProps,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarConfiguration configuration,
+        @NonNull RenderProps renderProps,
+        @NonNull HtmlTag tag)
+    {
         final SpanFactory spanFactory = configuration.spansFactory().get(Emphasis.class);
-        if (spanFactory == null) {
+        if (spanFactory == null)
+        {
             return null;
         }
         return spanFactory.getSpans(configuration, renderProps);
@@ -29,7 +32,8 @@ public class EmphasisHandler extends SimpleTagHandler {
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Arrays.asList("i", "em", "cite", "dfn");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/HeadingHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/HeadingHandler.java
@@ -3,40 +3,46 @@ package com.zeoflow.stylar.html.tag;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.core.CoreProps;
+import com.zeoflow.stylar.html.HtmlTag;
+
 import org.commonmark.node.Heading;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.core.CoreProps;
-import com.zeoflow.stylar.html.HtmlTag;
-
-public class HeadingHandler extends SimpleTagHandler {
+public class HeadingHandler extends SimpleTagHandler
+{
 
     @Nullable
     @Override
     public Object getSpans(
-            @NonNull StylarConfiguration configuration,
-            @NonNull RenderProps renderProps,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarConfiguration configuration,
+        @NonNull RenderProps renderProps,
+        @NonNull HtmlTag tag)
+    {
 
         final SpanFactory factory = configuration.spansFactory().get(Heading.class);
-        if (factory == null) {
+        if (factory == null)
+        {
             return null;
         }
 
         int level;
-        try {
+        try
+        {
             level = Integer.parseInt(tag.name().substring(1));
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException e)
+        {
             e.printStackTrace();
             level = 0;
         }
 
-        if (level < 1 || level > 6) {
+        if (level < 1 || level > 6)
+        {
             return null;
         }
 
@@ -47,7 +53,8 @@ public class HeadingHandler extends SimpleTagHandler {
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Arrays.asList("h1", "h2", "h3", "h4", "h5", "h6");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/ImageHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/ImageHandler.java
@@ -5,60 +5,62 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.html.CssInlineStyleParser;
+import com.zeoflow.stylar.html.HtmlTag;
+import com.zeoflow.stylar.image.ImageProps;
+import com.zeoflow.stylar.image.ImageSize;
+
 import org.commonmark.node.Image;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.html.CssInlineStyleParser;
-import com.zeoflow.stylar.html.HtmlTag;
-import com.zeoflow.stylar.image.ImageProps;
-import com.zeoflow.stylar.image.ImageSize;
-
-public class ImageHandler extends SimpleTagHandler {
-
-    @NonNull
-    @Override
-    public Collection<String> supportedTags() {
-        return Collections.singleton("img");
-    }
-
-    interface ImageSizeParser {
-        @Nullable
-        ImageSize parse(@NonNull Map<String, String> attributes);
-    }
-
-    @NonNull
-    public static ImageHandler create() {
-        return new ImageHandler(new ImageSizeParserImpl(CssInlineStyleParser.create()));
-    }
+public class ImageHandler extends SimpleTagHandler
+{
 
     private final ImageSizeParser imageSizeParser;
 
     @SuppressWarnings("WeakerAccess")
-    ImageHandler(@NonNull ImageSizeParser imageSizeParser) {
+    ImageHandler(@NonNull ImageSizeParser imageSizeParser)
+    {
         this.imageSizeParser = imageSizeParser;
+    }
+
+    @NonNull
+    public static ImageHandler create()
+    {
+        return new ImageHandler(new ImageSizeParserImpl(CssInlineStyleParser.create()));
+    }
+
+    @NonNull
+    @Override
+    public Collection<String> supportedTags()
+    {
+        return Collections.singleton("img");
     }
 
     @Nullable
     @Override
     public Object getSpans(
-            @NonNull StylarConfiguration configuration,
-            @NonNull RenderProps renderProps,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarConfiguration configuration,
+        @NonNull RenderProps renderProps,
+        @NonNull HtmlTag tag)
+    {
 
         final Map<String, String> attributes = tag.attributes();
         final String src = attributes.get("src");
-        if (TextUtils.isEmpty(src)) {
+        if (TextUtils.isEmpty(src))
+        {
             return null;
         }
 
         final SpanFactory spanFactory = configuration.spansFactory().get(Image.class);
-        if (spanFactory == null) {
+        if (spanFactory == null)
+        {
             return null;
         }
 
@@ -76,5 +78,11 @@ public class ImageHandler extends SimpleTagHandler {
         ImageProps.REPLACEMENT_TEXT_IS_LINK.set(renderProps, false);
 
         return spanFactory.getSpans(configuration, renderProps);
+    }
+
+    interface ImageSizeParser
+    {
+        @Nullable
+        ImageSize parse(@NonNull Map<String, String> attributes);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/ImageSizeParserImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/ImageSizeParserImpl.java
@@ -6,22 +6,25 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
-import java.util.Map;
-
 import com.zeoflow.stylar.html.CssInlineStyleParser;
 import com.zeoflow.stylar.html.CssProperty;
 import com.zeoflow.stylar.image.ImageSize;
 
-class ImageSizeParserImpl implements ImageHandler.ImageSizeParser {
+import java.util.Map;
+
+class ImageSizeParserImpl implements ImageHandler.ImageSizeParser
+{
 
     private final CssInlineStyleParser inlineStyleParser;
 
-    ImageSizeParserImpl(@NonNull CssInlineStyleParser inlineStyleParser) {
+    ImageSizeParserImpl(@NonNull CssInlineStyleParser inlineStyleParser)
+    {
         this.inlineStyleParser = inlineStyleParser;
     }
 
     @Override
-    public ImageSize parse(@NonNull Map<String, String> attributes) {
+    public ImageSize parse(@NonNull Map<String, String> attributes)
+    {
 
         // strictly speaking percents when specified directly on an attribute
         // are not part of the HTML spec (I couldn't find any reference)
@@ -32,43 +35,52 @@ class ImageSizeParserImpl implements ImageHandler.ImageSizeParser {
         // okay, let's first check styles
         final String style = attributes.get("style");
 
-        if (!TextUtils.isEmpty(style)) {
+        if (!TextUtils.isEmpty(style))
+        {
 
             String key;
 
-            for (CssProperty cssProperty : inlineStyleParser.parse(style)) {
+            for (CssProperty cssProperty : inlineStyleParser.parse(style))
+            {
 
                 key = cssProperty.key();
 
-                if ("width".equals(key)) {
+                if ("width".equals(key))
+                {
                     width = dimension(cssProperty.value());
-                } else if ("height".equals(key)) {
+                } else if ("height".equals(key))
+                {
                     height = dimension(cssProperty.value());
                 }
 
                 if (width != null
-                        && height != null) {
+                    && height != null)
+                {
                     break;
                 }
             }
         }
 
         if (width != null
-                && height != null) {
+            && height != null)
+        {
             return new ImageSize(width, height);
         }
 
         // check tag attributes
-        if (width == null) {
+        if (width == null)
+        {
             width = dimension(attributes.get("width"));
         }
 
-        if (height == null) {
+        if (height == null)
+        {
             height = dimension(attributes.get("height"));
         }
 
         if (width == null
-                && height == null) {
+            && height == null)
+        {
             return null;
         }
 
@@ -77,29 +89,37 @@ class ImageSizeParserImpl implements ImageHandler.ImageSizeParser {
 
     @Nullable
     @VisibleForTesting
-    ImageSize.Dimension dimension(@Nullable String value) {
+    ImageSize.Dimension dimension(@Nullable String value)
+    {
 
-        if (TextUtils.isEmpty(value)) {
+        if (TextUtils.isEmpty(value))
+        {
             return null;
         }
 
         final int length = value.length();
 
-        for (int i = length - 1; i > -1; i--) {
+        for (int i = length - 1; i > -1; i--)
+        {
 
-            if (Character.isDigit(value.charAt(i))) {
+            if (Character.isDigit(value.charAt(i)))
+            {
 
-                try {
+                try
+                {
                     final float val = Float.parseFloat(value.substring(0, i + 1));
                     final String unit;
-                    if (i == length - 1) {
+                    if (i == length - 1)
+                    {
                         // no unit info
                         unit = null;
-                    } else {
+                    } else
+                    {
                         unit = value.substring(i + 1, length);
                     }
                     return new ImageSize.Dimension(val, unit);
-                } catch (NumberFormatException e) {
+                } catch (NumberFormatException e)
+                {
                     // value cannot not be represented as a float
                     return null;
                 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/LinkHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/LinkHandler.java
@@ -5,29 +5,33 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.core.CoreProps;
+import com.zeoflow.stylar.html.HtmlTag;
+
 import org.commonmark.node.Link;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.core.CoreProps;
-import com.zeoflow.stylar.html.HtmlTag;
-
-public class LinkHandler extends SimpleTagHandler {
+public class LinkHandler extends SimpleTagHandler
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps, @NonNull HtmlTag tag) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps, @NonNull HtmlTag tag)
+    {
         final String destination = tag.attributes().get("href");
-        if (!TextUtils.isEmpty(destination)) {
+        if (!TextUtils.isEmpty(destination))
+        {
             final SpanFactory spanFactory = configuration.spansFactory().get(Link.class);
-            if (spanFactory != null) {
+            if (spanFactory != null)
+            {
 
                 CoreProps.LINK_DESTINATION.set(
-                        renderProps,
-                        destination
+                    renderProps,
+                    destination
                 );
 
                 return spanFactory.getSpans(configuration, renderProps);
@@ -38,7 +42,8 @@ public class LinkHandler extends SimpleTagHandler {
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Collections.singleton("a");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/ListHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/ListHandler.java
@@ -2,31 +2,47 @@ package com.zeoflow.stylar.html.tag;
 
 import androidx.annotation.NonNull;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.SpannableBuilder;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.StylarVisitor;
+import com.zeoflow.stylar.core.CoreProps;
+import com.zeoflow.stylar.html.HtmlTag;
+import com.zeoflow.stylar.html.StylarHtmlRenderer;
+import com.zeoflow.stylar.html.TagHandler;
 
 import org.commonmark.node.ListItem;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.SpannableBuilder;
-import com.zeoflow.stylar.core.CoreProps;
-import com.zeoflow.stylar.html.HtmlTag;
-import com.zeoflow.stylar.html.StylarHtmlRenderer;
-import com.zeoflow.stylar.html.TagHandler;
+public class ListHandler extends TagHandler
+{
 
-public class ListHandler extends TagHandler {
+    private static int currentBulletListLevel(@NonNull HtmlTag.Block block)
+    {
+        int level = 0;
+        while ((block = block.parent()) != null)
+        {
+            if ("ul".equals(block.name())
+                || "ol".equals(block.name()))
+            {
+                level += 1;
+            }
+        }
+        return level;
+    }
 
     @Override
     public void handle(
-            @NonNull StylarVisitor visitor,
-            @NonNull StylarHtmlRenderer renderer,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarVisitor visitor,
+        @NonNull StylarHtmlRenderer renderer,
+        @NonNull HtmlTag tag)
+    {
 
-        if (!tag.isBlock()) {
+        if (!tag.isBlock())
+        {
             return;
         }
 
@@ -34,7 +50,8 @@ public class ListHandler extends TagHandler {
         final boolean ol = "ol".equals(block.name());
         final boolean ul = "ul".equals(block.name());
 
-        if (!ol && !ul) {
+        if (!ol && !ul)
+        {
             return;
         }
 
@@ -45,44 +62,38 @@ public class ListHandler extends TagHandler {
         int number = 1;
         final int bulletLevel = currentBulletListLevel(block);
 
-        for (HtmlTag.Block child : block.children()) {
+        for (HtmlTag.Block child : block.children())
+        {
 
             visitChildren(visitor, renderer, child);
 
-            if (spanFactory != null && "li".equals(child.name())) {
+            if (spanFactory != null && "li".equals(child.name()))
+            {
 
                 // insert list item here
-                if (ol) {
+                if (ol)
+                {
                     CoreProps.LIST_ITEM_TYPE.set(renderProps, CoreProps.ListItemType.ORDERED);
                     CoreProps.ORDERED_LIST_ITEM_NUMBER.set(renderProps, number++);
-                } else {
+                } else
+                {
                     CoreProps.LIST_ITEM_TYPE.set(renderProps, CoreProps.ListItemType.BULLET);
                     CoreProps.BULLET_LIST_ITEM_LEVEL.set(renderProps, bulletLevel);
                 }
 
                 SpannableBuilder.setSpans(
-                        visitor.builder(),
-                        spanFactory.getSpans(configuration, renderProps),
-                        child.start(),
-                        child.end());
+                    visitor.builder(),
+                    spanFactory.getSpans(configuration, renderProps),
+                    child.start(),
+                    child.end());
             }
         }
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Arrays.asList("ol", "ul");
-    }
-
-    private static int currentBulletListLevel(@NonNull HtmlTag.Block block) {
-        int level = 0;
-        while ((block = block.parent()) != null) {
-            if ("ul".equals(block.name())
-                    || "ol".equals(block.name())) {
-                level += 1;
-            }
-        }
-        return level;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/SimpleTagHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/SimpleTagHandler.java
@@ -3,24 +3,24 @@ package com.zeoflow.stylar.html.tag;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarVisitor;
-
-import java.util.Collection;
-
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpannableBuilder;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.StylarVisitor;
 import com.zeoflow.stylar.html.HtmlTag;
 import com.zeoflow.stylar.html.StylarHtmlRenderer;
 import com.zeoflow.stylar.html.TagHandler;
 
-public abstract class SimpleTagHandler extends TagHandler {
+import java.util.Collection;
+
+public abstract class SimpleTagHandler extends TagHandler
+{
 
     @Nullable
     public abstract Object getSpans(
-            @NonNull StylarConfiguration configuration,
-            @NonNull RenderProps renderProps,
-            @NonNull HtmlTag tag);
+        @NonNull StylarConfiguration configuration,
+        @NonNull RenderProps renderProps,
+        @NonNull HtmlTag tag);
 
     @NonNull
     @Override
@@ -28,14 +28,17 @@ public abstract class SimpleTagHandler extends TagHandler {
 
 
     @Override
-    public void handle(@NonNull StylarVisitor visitor, @NonNull StylarHtmlRenderer renderer, @NonNull HtmlTag tag) {
+    public void handle(@NonNull StylarVisitor visitor, @NonNull StylarHtmlRenderer renderer, @NonNull HtmlTag tag)
+    {
         // @since 4.5.0 check if tag is block one and visit children
-        if (tag.isBlock()) {
+        if (tag.isBlock())
+        {
             visitChildren(visitor, renderer, tag.getAsBlock());
         }
 
         final Object spans = getSpans(visitor.configuration(), visitor.renderProps(), tag);
-        if (spans != null) {
+        if (spans != null)
+        {
             SpannableBuilder.setSpans(visitor.builder(), spans, tag.start(), tag.end());
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/StrikeHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/StrikeHandler.java
@@ -5,69 +5,77 @@ import android.text.style.StrikethroughSpan;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarVisitor;
-
-import java.util.Arrays;
-import java.util.Collection;
-
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.SpanFactory;
 import com.zeoflow.stylar.SpannableBuilder;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.StylarVisitor;
 import com.zeoflow.stylar.html.HtmlTag;
 import com.zeoflow.stylar.html.StylarHtmlRenderer;
 import com.zeoflow.stylar.html.TagHandler;
 
-public class StrikeHandler extends TagHandler {
+import java.util.Arrays;
+import java.util.Collection;
+
+public class StrikeHandler extends TagHandler
+{
 
     // flag to detect if commonmark-java-strikethrough is in classpath, so we use SpanFactory
     // to obtain strikethrough span
     private static final boolean HAS_MARKDOWN_IMPLEMENTATION;
 
-    static {
+    static
+    {
         boolean hasMarkdownImplementation;
-        try {
+        try
+        {
             // @since 4.3.1 we class Class.forName instead of trying
             //  to access the class by full qualified name (which caused issues with DexGuard)
             Class.forName("org.commonmark.ext.gfm.strikethrough.Strikethrough");
             hasMarkdownImplementation = true;
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             hasMarkdownImplementation = false;
         }
         HAS_MARKDOWN_IMPLEMENTATION = hasMarkdownImplementation;
     }
 
+    @Nullable
+    private static Object getMarkdownSpans(@NonNull StylarVisitor visitor)
+    {
+        final StylarConfiguration configuration = visitor.configuration();
+        final SpanFactory spanFactory = configuration.spansFactory()
+            .get(org.commonmark.ext.gfm.strikethrough.Strikethrough.class);
+        if (spanFactory == null)
+        {
+            return null;
+        }
+        return spanFactory.getSpans(configuration, visitor.renderProps());
+    }
+
     @Override
     public void handle(
-            @NonNull StylarVisitor visitor,
-            @NonNull StylarHtmlRenderer renderer,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarVisitor visitor,
+        @NonNull StylarHtmlRenderer renderer,
+        @NonNull HtmlTag tag)
+    {
 
-        if (tag.isBlock()) {
+        if (tag.isBlock())
+        {
             visitChildren(visitor, renderer, tag.getAsBlock());
         }
 
         SpannableBuilder.setSpans(
-                visitor.builder(),
-                HAS_MARKDOWN_IMPLEMENTATION ? getMarkdownSpans(visitor) : new StrikethroughSpan(),
-                tag.start(),
-                tag.end()
+            visitor.builder(),
+            HAS_MARKDOWN_IMPLEMENTATION ? getMarkdownSpans(visitor) : new StrikethroughSpan(),
+            tag.start(),
+            tag.end()
         );
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Arrays.asList("s", "del");
-    }
-
-    @Nullable
-    private static Object getMarkdownSpans(@NonNull StylarVisitor visitor) {
-        final StylarConfiguration configuration = visitor.configuration();
-        final SpanFactory spanFactory = configuration.spansFactory()
-                .get(org.commonmark.ext.gfm.strikethrough.Strikethrough.class);
-        if (spanFactory == null) {
-            return null;
-        }
-        return spanFactory.getSpans(configuration, visitor.renderProps());
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/StrongEmphasisHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/StrongEmphasisHandler.java
@@ -3,25 +3,28 @@ package com.zeoflow.stylar.html.tag;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.html.HtmlTag;
+
 import org.commonmark.node.StrongEmphasis;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.html.HtmlTag;
-
-public class StrongEmphasisHandler extends SimpleTagHandler {
+public class StrongEmphasisHandler extends SimpleTagHandler
+{
     @Nullable
     @Override
     public Object getSpans(
-            @NonNull StylarConfiguration configuration,
-            @NonNull RenderProps renderProps,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarConfiguration configuration,
+        @NonNull RenderProps renderProps,
+        @NonNull HtmlTag tag)
+    {
         final SpanFactory spanFactory = configuration.spansFactory().get(StrongEmphasis.class);
-        if (spanFactory == null) {
+        if (spanFactory == null)
+        {
             return null;
         }
         return spanFactory.getSpans(configuration, renderProps);
@@ -29,7 +32,8 @@ public class StrongEmphasisHandler extends SimpleTagHandler {
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Arrays.asList("b", "strong");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/SubScriptHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/SubScriptHandler.java
@@ -3,25 +3,27 @@ package com.zeoflow.stylar.html.tag;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.html.HtmlTag;
 import com.zeoflow.stylar.html.span.SubScriptSpan;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.html.HtmlTag;
-
-public class SubScriptHandler extends SimpleTagHandler {
+public class SubScriptHandler extends SimpleTagHandler
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps, @NonNull HtmlTag tag) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps, @NonNull HtmlTag tag)
+    {
         return new SubScriptSpan();
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Collections.singleton("sub");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/SuperScriptHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/SuperScriptHandler.java
@@ -3,25 +3,27 @@ package com.zeoflow.stylar.html.tag;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.RenderProps;
+import com.zeoflow.stylar.StylarConfiguration;
+import com.zeoflow.stylar.html.HtmlTag;
 import com.zeoflow.stylar.html.span.SuperScriptSpan;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import com.zeoflow.stylar.StylarConfiguration;
-import com.zeoflow.stylar.RenderProps;
-import com.zeoflow.stylar.html.HtmlTag;
-
-public class SuperScriptHandler extends SimpleTagHandler {
+public class SuperScriptHandler extends SimpleTagHandler
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps, @NonNull HtmlTag tag) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps renderProps, @NonNull HtmlTag tag)
+    {
         return new SuperScriptSpan();
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Collections.singleton("sup");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/html/tag/UnderlineHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/html/tag/UnderlineHandler.java
@@ -4,42 +4,45 @@ import android.text.style.UnderlineSpan;
 
 import androidx.annotation.NonNull;
 
-import com.zeoflow.stylar.StylarVisitor;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import com.zeoflow.stylar.SpannableBuilder;
+import com.zeoflow.stylar.StylarVisitor;
 import com.zeoflow.stylar.html.HtmlTag;
 import com.zeoflow.stylar.html.StylarHtmlRenderer;
 import com.zeoflow.stylar.html.TagHandler;
 
-public class UnderlineHandler extends TagHandler {
+import java.util.Arrays;
+import java.util.Collection;
+
+public class UnderlineHandler extends TagHandler
+{
 
     @Override
     public void handle(
-            @NonNull StylarVisitor visitor,
-            @NonNull StylarHtmlRenderer renderer,
-            @NonNull HtmlTag tag) {
+        @NonNull StylarVisitor visitor,
+        @NonNull StylarHtmlRenderer renderer,
+        @NonNull HtmlTag tag)
+    {
 
         // as parser doesn't treat U tag as an inline one,
         // thus doesn't allow children, we must visit them first
 
-        if (tag.isBlock()) {
+        if (tag.isBlock())
+        {
             visitChildren(visitor, renderer, tag.getAsBlock());
         }
 
         SpannableBuilder.setSpans(
-                visitor.builder(),
-                new UnderlineSpan(),
-                tag.start(),
-                tag.end()
+            visitor.builder(),
+            new UnderlineSpan(),
+            tag.start(),
+            tag.end()
         );
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedTags() {
+    public Collection<String> supportedTags()
+    {
         return Arrays.asList("u", "ins");
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableLoader.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableLoader.java
@@ -5,13 +5,15 @@ import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-public abstract class AsyncDrawableLoader {
+public abstract class AsyncDrawableLoader
+{
 
     /**
      * @since 3.0.0
      */
     @NonNull
-    public static AsyncDrawableLoader noOp() {
+    public static AsyncDrawableLoader noOp()
+    {
         return new AsyncDrawableLoaderNoOp();
     }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableLoaderBuilder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableLoaderBuilder.java
@@ -4,6 +4,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.zeoflow.stylar.image.data.DataUriSchemeHandler;
+import com.zeoflow.stylar.image.gif.GifMediaDecoder;
+import com.zeoflow.stylar.image.gif.GifSupport;
 import com.zeoflow.stylar.image.network.NetworkSchemeHandler;
 import com.zeoflow.stylar.image.svg.SvgMediaDecoder;
 import com.zeoflow.stylar.image.svg.SvgSupport;
@@ -13,21 +15,20 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.zeoflow.stylar.image.gif.GifMediaDecoder;
-import com.zeoflow.stylar.image.gif.GifSupport;
+class AsyncDrawableLoaderBuilder
+{
 
-class AsyncDrawableLoaderBuilder {
-
-    ExecutorService executorService;
     final Map<String, SchemeHandler> schemeHandlers = new HashMap<>(3);
     final Map<String, MediaDecoder> mediaDecoders = new HashMap<>(3);
+    ExecutorService executorService;
     MediaDecoder defaultMediaDecoder;
     ImagesPlugin.PlaceholderProvider placeholderProvider;
     ImagesPlugin.ErrorHandler errorHandler;
 
     boolean isBuilt;
 
-    AsyncDrawableLoaderBuilder() {
+    AsyncDrawableLoaderBuilder()
+    {
 
         // @since 4.0.0
         // okay, let's add supported schemes at the start, this would be : data-uri and default network
@@ -36,47 +37,57 @@ class AsyncDrawableLoaderBuilder {
         addSchemeHandler(NetworkSchemeHandler.create());
 
         // add SVG and GIF, but only if they are present in the class-path
-        if (SvgSupport.hasSvgSupport()) {
+        if (SvgSupport.hasSvgSupport())
+        {
             addMediaDecoder(SvgMediaDecoder.create());
         }
 
-        if (GifSupport.hasGifSupport()) {
+        if (GifSupport.hasGifSupport())
+        {
             addMediaDecoder(GifMediaDecoder.create());
         }
 
         defaultMediaDecoder = DefaultMediaDecoder.create();
     }
 
-    void executorService(@NonNull ExecutorService executorService) {
+    void executorService(@NonNull ExecutorService executorService)
+    {
         checkState();
         this.executorService = executorService;
     }
 
-    void addSchemeHandler(@NonNull SchemeHandler schemeHandler) {
+    void addSchemeHandler(@NonNull SchemeHandler schemeHandler)
+    {
         checkState();
-        for (String scheme : schemeHandler.supportedSchemes()) {
+        for (String scheme : schemeHandler.supportedSchemes())
+        {
             schemeHandlers.put(scheme, schemeHandler);
         }
     }
 
-    void addMediaDecoder(@NonNull MediaDecoder mediaDecoder) {
+    void addMediaDecoder(@NonNull MediaDecoder mediaDecoder)
+    {
         checkState();
-        for (String type : mediaDecoder.supportedTypes()) {
+        for (String type : mediaDecoder.supportedTypes())
+        {
             mediaDecoders.put(type, mediaDecoder);
         }
     }
 
-    void defaultMediaDecoder(@Nullable MediaDecoder mediaDecoder) {
+    void defaultMediaDecoder(@Nullable MediaDecoder mediaDecoder)
+    {
         checkState();
         this.defaultMediaDecoder = mediaDecoder;
     }
 
-    void removeSchemeHandler(@NonNull String scheme) {
+    void removeSchemeHandler(@NonNull String scheme)
+    {
         checkState();
         schemeHandlers.remove(scheme);
     }
 
-    void removeMediaDecoder(@NonNull String contentType) {
+    void removeMediaDecoder(@NonNull String contentType)
+    {
         checkState();
         mediaDecoders.remove(contentType);
     }
@@ -84,7 +95,8 @@ class AsyncDrawableLoaderBuilder {
     /**
      * @since 3.0.0
      */
-    void placeholderProvider(@NonNull ImagesPlugin.PlaceholderProvider placeholderDrawableProvider) {
+    void placeholderProvider(@NonNull ImagesPlugin.PlaceholderProvider placeholderDrawableProvider)
+    {
         checkState();
         this.placeholderProvider = placeholderDrawableProvider;
     }
@@ -92,29 +104,34 @@ class AsyncDrawableLoaderBuilder {
     /**
      * @since 3.0.0
      */
-    void errorHandler(@NonNull ImagesPlugin.ErrorHandler errorHandler) {
+    void errorHandler(@NonNull ImagesPlugin.ErrorHandler errorHandler)
+    {
         checkState();
         this.errorHandler = errorHandler;
     }
 
     @NonNull
-    AsyncDrawableLoader build() {
+    AsyncDrawableLoader build()
+    {
 
         checkState();
 
         isBuilt = true;
 
-        if (executorService == null) {
+        if (executorService == null)
+        {
             executorService = Executors.newCachedThreadPool();
         }
 
         return new AsyncDrawableLoaderImpl(this);
     }
 
-    private void checkState() {
-        if (isBuilt) {
+    private void checkState()
+    {
+        if (isBuilt)
+        {
             throw new IllegalStateException("ImagesPlugin has already been configured " +
-                    "and cannot be modified any further");
+                "and cannot be modified any further");
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableLoaderNoOp.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableLoaderNoOp.java
@@ -5,20 +5,24 @@ import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-class AsyncDrawableLoaderNoOp extends AsyncDrawableLoader {
+class AsyncDrawableLoaderNoOp extends AsyncDrawableLoader
+{
     @Override
-    public void load(@NonNull AsyncDrawable drawable) {
+    public void load(@NonNull AsyncDrawable drawable)
+    {
 
     }
 
     @Override
-    public void cancel(@NonNull AsyncDrawable drawable) {
+    public void cancel(@NonNull AsyncDrawable drawable)
+    {
 
     }
 
     @Nullable
     @Override
-    public Drawable placeholder(@NonNull AsyncDrawable drawable) {
+    public Drawable placeholder(@NonNull AsyncDrawable drawable)
+    {
         return null;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableScheduler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableScheduler.java
@@ -16,6 +16,10 @@ import com.zeoflow.stylar.R;
 public abstract class AsyncDrawableScheduler
 {
 
+    private AsyncDrawableScheduler()
+    {
+    }
+
     public static void schedule(@NonNull final TextView textView)
     {
 
@@ -122,23 +126,11 @@ public abstract class AsyncDrawableScheduler
         return ((Spanned) cs).getSpans(0, length, AsyncDrawableSpan.class);
     }
 
-    private AsyncDrawableScheduler()
-    {
-    }
-
     private static class DrawableCallbackImpl implements Drawable.Callback
     {
 
-        // @since 4.1.0
-        // interface to be used when bounds change and view must be invalidated
-        interface Invalidator
-        {
-            void invalidate();
-        }
-
         private final TextView view;
         private final Invalidator invalidator; // @since 4.1.0
-
         private Rect previousBounds;
 
         DrawableCallbackImpl(
@@ -198,6 +190,13 @@ public abstract class AsyncDrawableScheduler
         public void unscheduleDrawable(@NonNull Drawable who, @NonNull Runnable what)
         {
             view.removeCallbacks(what);
+        }
+
+        // @since 4.1.0
+        // interface to be used when bounds change and view must be invalidated
+        interface Invalidator
+        {
+            void invalidate();
         }
     }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/AsyncDrawableSpan.java
@@ -10,35 +10,29 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.core.StylarTheme;
 import com.zeoflow.stylar.utils.SpanUtils;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import com.zeoflow.stylar.core.StylarTheme;
-
 @SuppressWarnings("WeakerAccess")
-public class AsyncDrawableSpan extends ReplacementSpan {
-
-    @IntDef({ALIGN_BOTTOM, ALIGN_BASELINE, ALIGN_CENTER})
-    @Retention(RetentionPolicy.SOURCE)
-    @interface Alignment {
-    }
+public class AsyncDrawableSpan extends ReplacementSpan
+{
 
     public static final int ALIGN_BOTTOM = 0;
     public static final int ALIGN_BASELINE = 1;
     public static final int ALIGN_CENTER = 2; // will only center if drawable height is less than text line height
-
     private final StylarTheme theme;
     private final AsyncDrawable drawable;
     private final int alignment;
     private final boolean replacementTextIsLink;
-
     public AsyncDrawableSpan(
-            @NonNull StylarTheme theme,
-            @NonNull AsyncDrawable drawable,
-            @Alignment int alignment,
-            boolean replacementTextIsLink) {
+        @NonNull StylarTheme theme,
+        @NonNull AsyncDrawable drawable,
+        @Alignment int alignment,
+        boolean replacementTextIsLink)
+    {
         this.theme = theme;
         this.drawable = drawable;
         this.alignment = alignment;
@@ -49,23 +43,32 @@ public class AsyncDrawableSpan extends ReplacementSpan {
         //  will trigger another invalidation when we will have bounds
     }
 
+    private static float textCenterY(int top, int bottom, @NonNull Paint paint)
+    {
+        // @since 1.1.1 it's `top +` and not `bottom -`
+        return (int) (top + ((bottom - top) / 2) - ((paint.descent() + paint.ascent()) / 2.F + .5F));
+    }
+
     @Override
     public int getSize(
-            @NonNull Paint paint,
-            CharSequence text,
-            @IntRange(from = 0) int start,
-            @IntRange(from = 0) int end,
-            @Nullable Paint.FontMetricsInt fm) {
+        @NonNull Paint paint,
+        CharSequence text,
+        @IntRange(from = 0) int start,
+        @IntRange(from = 0) int end,
+        @Nullable Paint.FontMetricsInt fm)
+    {
 
         // if we have no async drawable result - we will just render text
 
         final int size;
 
-        if (drawable.hasResult()) {
+        if (drawable.hasResult())
+        {
 
             final Rect rect = drawable.getBounds();
 
-            if (fm != null) {
+            if (fm != null)
+            {
                 fm.ascent = -rect.bottom;
                 fm.descent = 0;
 
@@ -75,10 +78,12 @@ public class AsyncDrawableSpan extends ReplacementSpan {
 
             size = rect.right;
 
-        } else {
+        } else
+        {
 
             // we will apply style here in case if theme modifies textSize or style (affects metrics)
-            if (replacementTextIsLink) {
+            if (replacementTextIsLink)
+            {
                 theme.applyLinkStyle(paint);
             }
 
@@ -91,50 +96,59 @@ public class AsyncDrawableSpan extends ReplacementSpan {
 
     @Override
     public void draw(
-            @NonNull Canvas canvas,
-            CharSequence text,
-            @IntRange(from = 0) int start,
-            @IntRange(from = 0) int end,
-            float x,
-            int top,
-            int y,
-            int bottom,
-            @NonNull Paint paint) {
+        @NonNull Canvas canvas,
+        CharSequence text,
+        @IntRange(from = 0) int start,
+        @IntRange(from = 0) int end,
+        float x,
+        int top,
+        int y,
+        int bottom,
+        @NonNull Paint paint)
+    {
 
         // @since 4.4.0 use SpanUtils instead of `canvas.getWidth`
         drawable.initWithKnownDimensions(
-                SpanUtils.width(canvas, text),
-                paint.getTextSize()
+            SpanUtils.width(canvas, text),
+            paint.getTextSize()
         );
 
         final AsyncDrawable drawable = this.drawable;
 
-        if (drawable.hasResult()) {
+        if (drawable.hasResult())
+        {
 
             final int b = bottom - drawable.getBounds().bottom;
 
             final int save = canvas.save();
-            try {
+            try
+            {
                 final int translationY;
-                if (ALIGN_CENTER == alignment) {
+                if (ALIGN_CENTER == alignment)
+                {
                     translationY = b - ((bottom - top - drawable.getBounds().height()) / 2);
-                } else if (ALIGN_BASELINE == alignment) {
+                } else if (ALIGN_BASELINE == alignment)
+                {
                     translationY = b - paint.getFontMetricsInt().descent;
-                } else {
+                } else
+                {
                     translationY = b;
                 }
                 canvas.translate(x, translationY);
                 drawable.draw(canvas);
-            } finally {
+            } finally
+            {
                 canvas.restoreToCount(save);
             }
-        } else {
+        } else
+        {
 
             // will it make sense to have additional background/borders for an image replacement?
             // let's focus on main functionality and then think of it
 
             final float textY = textCenterY(top, bottom, paint);
-            if (replacementTextIsLink) {
+            if (replacementTextIsLink)
+            {
                 theme.applyLinkStyle(paint);
             }
 
@@ -144,12 +158,14 @@ public class AsyncDrawableSpan extends ReplacementSpan {
     }
 
     @NonNull
-    public AsyncDrawable getDrawable() {
+    public AsyncDrawable getDrawable()
+    {
         return drawable;
     }
 
-    private static float textCenterY(int top, int bottom, @NonNull Paint paint) {
-        // @since 1.1.1 it's `top +` and not `bottom -`
-        return (int) (top + ((bottom - top) / 2) - ((paint.descent() + paint.ascent()) / 2.F + .5F));
+    @IntDef({ALIGN_BOTTOM, ALIGN_BASELINE, ALIGN_CENTER})
+    @Retention(RetentionPolicy.SOURCE)
+    @interface Alignment
+    {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/DefaultMediaDecoder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/DefaultMediaDecoder.java
@@ -19,34 +19,41 @@ import java.util.Collections;
  *
  * @since 1.1.0
  */
-public class DefaultMediaDecoder extends MediaDecoder {
-
-    @NonNull
-    public static DefaultMediaDecoder create() {
-        return new DefaultMediaDecoder(Resources.getSystem());
-    }
-
-    @NonNull
-    public static DefaultMediaDecoder create(@NonNull Resources resources) {
-        return new DefaultMediaDecoder(resources);
-    }
+public class DefaultMediaDecoder extends MediaDecoder
+{
 
     private final Resources resources;
 
     @SuppressWarnings("WeakerAccess")
-    DefaultMediaDecoder(Resources resources) {
+    DefaultMediaDecoder(Resources resources)
+    {
         this.resources = resources;
     }
 
     @NonNull
+    public static DefaultMediaDecoder create()
+    {
+        return new DefaultMediaDecoder(Resources.getSystem());
+    }
+
+    @NonNull
+    public static DefaultMediaDecoder create(@NonNull Resources resources)
+    {
+        return new DefaultMediaDecoder(resources);
+    }
+
+    @NonNull
     @Override
-    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream) {
+    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream)
+    {
 
         final Bitmap bitmap;
-        try {
+        try
+        {
             // absolutely not optimal... thing
             bitmap = BitmapFactory.decodeStream(inputStream);
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             throw new IllegalStateException("Exception decoding input-stream", t);
         }
 
@@ -55,7 +62,8 @@ public class DefaultMediaDecoder extends MediaDecoder {
 
     @NonNull
     @Override
-    public Collection<String> supportedTypes() {
+    public Collection<String> supportedTypes()
+    {
         return Collections.emptySet();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/DrawableUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/DrawableUtils.java
@@ -9,24 +9,30 @@ import androidx.annotation.NonNull;
 /**
  * @since 3.0.1
  */
-public abstract class DrawableUtils {
+public abstract class DrawableUtils
+{
+
+    private DrawableUtils()
+    {
+    }
 
     @NonNull
     @CheckResult
-    public static Rect intrinsicBounds(@NonNull Drawable drawable) {
+    public static Rect intrinsicBounds(@NonNull Drawable drawable)
+    {
         return new Rect(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
     }
 
-    public static void applyIntrinsicBounds(@NonNull Drawable drawable) {
+    public static void applyIntrinsicBounds(@NonNull Drawable drawable)
+    {
         drawable.setBounds(intrinsicBounds(drawable));
     }
 
-    public static void applyIntrinsicBoundsIfEmpty(@NonNull Drawable drawable) {
-        if (drawable.getBounds().isEmpty()) {
+    public static void applyIntrinsicBoundsIfEmpty(@NonNull Drawable drawable)
+    {
+        if (drawable.getBounds().isEmpty())
+        {
             drawable.setBounds(intrinsicBounds(drawable));
         }
-    }
-
-    private DrawableUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/ImageItem.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/ImageItem.java
@@ -10,7 +10,12 @@ import java.io.InputStream;
 /**
  * @since 2.0.0
  */
-public abstract class ImageItem {
+public abstract class ImageItem
+{
+
+    private ImageItem()
+    {
+    }
 
     /**
      * Create an {@link ImageItem} with result, so no further decoding is required.
@@ -20,7 +25,8 @@ public abstract class ImageItem {
      * @since 4.0.0
      */
     @NonNull
-    public static ImageItem withResult(@NonNull Drawable drawable) {
+    public static ImageItem withResult(@NonNull Drawable drawable)
+    {
         return new WithResult(drawable);
     }
 
@@ -33,13 +39,10 @@ public abstract class ImageItem {
      */
     @NonNull
     public static ImageItem withDecodingNeeded(
-            @Nullable String contentType,
-            @NonNull InputStream inputStream) {
+        @Nullable String contentType,
+        @NonNull InputStream inputStream)
+    {
         return new WithDecodingNeeded(contentType, inputStream);
-    }
-
-
-    private ImageItem() {
     }
 
     /**
@@ -69,38 +72,45 @@ public abstract class ImageItem {
     /**
      * @since 4.0.0
      */
-    public static class WithResult extends ImageItem {
+    public static class WithResult extends ImageItem
+    {
 
         private final Drawable result;
 
-        private WithResult(@NonNull Drawable drawable) {
+        private WithResult(@NonNull Drawable drawable)
+        {
             result = drawable;
         }
 
         @NonNull
-        public Drawable result() {
+        public Drawable result()
+        {
             return result;
         }
 
         @Override
-        public boolean hasResult() {
+        public boolean hasResult()
+        {
             return true;
         }
 
         @Override
-        public boolean hasDecodingNeeded() {
+        public boolean hasDecodingNeeded()
+        {
             return false;
         }
 
         @NonNull
         @Override
-        public WithResult getAsWithResult() {
+        public WithResult getAsWithResult()
+        {
             return this;
         }
 
         @NonNull
         @Override
-        public WithDecodingNeeded getAsWithDecodingNeeded() {
+        public WithDecodingNeeded getAsWithDecodingNeeded()
+        {
             throw new IllegalStateException();
         }
     }
@@ -108,47 +118,55 @@ public abstract class ImageItem {
     /**
      * @since 4.0.0
      */
-    public static class WithDecodingNeeded extends ImageItem {
+    public static class WithDecodingNeeded extends ImageItem
+    {
 
         private final String contentType;
         private final InputStream inputStream;
 
         private WithDecodingNeeded(
-                @Nullable String contentType,
-                @NonNull InputStream inputStream) {
+            @Nullable String contentType,
+            @NonNull InputStream inputStream)
+        {
             this.contentType = contentType;
             this.inputStream = inputStream;
         }
 
         @Nullable
-        public String contentType() {
+        public String contentType()
+        {
             return contentType;
         }
 
         @NonNull
-        public InputStream inputStream() {
+        public InputStream inputStream()
+        {
             return inputStream;
         }
 
         @Override
-        public boolean hasResult() {
+        public boolean hasResult()
+        {
             return false;
         }
 
         @Override
-        public boolean hasDecodingNeeded() {
+        public boolean hasDecodingNeeded()
+        {
             return true;
         }
 
         @NonNull
         @Override
-        public WithResult getAsWithResult() {
+        public WithResult getAsWithResult()
+        {
             throw new IllegalStateException();
         }
 
         @NonNull
         @Override
-        public WithDecodingNeeded getAsWithDecodingNeeded() {
+        public WithDecodingNeeded getAsWithDecodingNeeded()
+        {
             return this;
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/ImageProps.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/ImageProps.java
@@ -5,16 +5,18 @@ import com.zeoflow.stylar.Prop;
 /**
  * @since 3.0.0
  */
-public abstract class ImageProps {
+public abstract class ImageProps
+{
 
     public static final Prop<String> DESTINATION = Prop.of("image-destination");
 
     public static final Prop<Boolean> REPLACEMENT_TEXT_IS_LINK =
-            Prop.of("image-replacement-text-is-link");
+        Prop.of("image-replacement-text-is-link");
 
     public static final Prop<ImageSize> IMAGE_SIZE = Prop.of("image-size");
 
 
-    private ImageProps() {
+    private ImageProps()
+    {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/ImageSize.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/ImageSize.java
@@ -6,40 +6,45 @@ import androidx.annotation.Nullable;
  * @since 1.0.1
  */
 @SuppressWarnings("WeakerAccess")
-public class ImageSize {
-
-    public static class Dimension {
-
-        public final float value;
-        public final String unit;
-
-        public Dimension(float value, @Nullable String unit) {
-            this.value = value;
-            this.unit = unit;
-        }
-
-        @Override
-        public String toString() {
-            return "Dimension{" +
-                    "value=" + value +
-                    ", unit='" + unit + '\'' +
-                    '}';
-        }
-    }
+public class ImageSize
+{
 
     public final Dimension width;
     public final Dimension height;
-
-    public ImageSize(@Nullable Dimension width, @Nullable Dimension height) {
+    public ImageSize(@Nullable Dimension width, @Nullable Dimension height)
+    {
         this.width = width;
         this.height = height;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "ImageSize{" +
-                "width=" + width +
-                ", height=" + height +
+            "width=" + width +
+            ", height=" + height +
+            '}';
+    }
+
+    public static class Dimension
+    {
+
+        public final float value;
+        public final String unit;
+
+        public Dimension(float value, @Nullable String unit)
+        {
+            this.value = value;
+            this.unit = unit;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Dimension{" +
+                "value=" + value +
+                ", unit='" + unit + '\'' +
                 '}';
+        }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/ImageSizeResolver.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/ImageSizeResolver.java
@@ -11,7 +11,8 @@ import com.zeoflow.stylar.StylarConfiguration;
  * @see StylarConfiguration.Builder#imageSizeResolver(ImageSizeResolver)
  * @since 1.0.1
  */
-public abstract class ImageSizeResolver {
+public abstract class ImageSizeResolver
+{
 
     /**
      * @since 4.0.0

--- a/stylar/src/main/java/com/zeoflow/stylar/image/ImageSizeResolverDef.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/ImageSizeResolverDef.java
@@ -9,7 +9,8 @@ import androidx.annotation.Nullable;
  * @since 1.0.1
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class ImageSizeResolverDef extends ImageSizeResolver {
+public class ImageSizeResolverDef extends ImageSizeResolver
+{
 
     // we track these two, others are considered to be pixels
     protected static final String UNIT_PERCENT = "%";
@@ -17,36 +18,41 @@ public class ImageSizeResolverDef extends ImageSizeResolver {
 
     @NonNull
     @Override
-    public Rect resolveImageSize(@NonNull AsyncDrawable drawable) {
+    public Rect resolveImageSize(@NonNull AsyncDrawable drawable)
+    {
         return resolveImageSize(
-                drawable.getImageSize(),
-                drawable.getResult().getBounds(),
-                drawable.getLastKnownCanvasWidth(),
-                drawable.getLastKnowTextSize());
+            drawable.getImageSize(),
+            drawable.getResult().getBounds(),
+            drawable.getLastKnownCanvasWidth(),
+            drawable.getLastKnowTextSize());
     }
 
     @NonNull
     protected Rect resolveImageSize(
-            @Nullable ImageSize imageSize,
-            @NonNull Rect imageBounds,
-            int canvasWidth,
-            float textSize
-    ) {
+        @Nullable ImageSize imageSize,
+        @NonNull Rect imageBounds,
+        int canvasWidth,
+        float textSize
+    )
+    {
 
-        if (imageSize == null) {
+        if (imageSize == null)
+        {
             // @since 2.0.0 post process bounds to fit canvasWidth (previously was inside AsyncDrawable)
             //      must be applied only if imageSize is null
             final Rect rect;
             final int w = imageBounds.width();
-            if (w > canvasWidth) {
+            if (w > canvasWidth)
+            {
                 final float reduceRatio = (float) w / canvasWidth;
                 rect = new Rect(
-                        0,
-                        0,
-                        canvasWidth,
-                        (int) (imageBounds.height() / reduceRatio + .5F)
+                    0,
+                    0,
+                    canvasWidth,
+                    (int) (imageBounds.height() / reduceRatio + .5F)
                 );
-            } else {
+            } else
+            {
                 rect = imageBounds;
             }
             return rect;
@@ -62,47 +68,59 @@ public class ImageSizeResolverDef extends ImageSizeResolver {
 
         final float ratio = (float) imageWidth / imageHeight;
 
-        if (width != null) {
+        if (width != null)
+        {
 
             final int w;
             final int h;
 
-            if (UNIT_PERCENT.equals(width.unit)) {
+            if (UNIT_PERCENT.equals(width.unit))
+            {
                 w = (int) (canvasWidth * (width.value / 100.F) + .5F);
-            } else {
+            } else
+            {
                 w = resolveAbsolute(width, imageWidth, textSize);
             }
 
             if (height == null
-                    || UNIT_PERCENT.equals(height.unit)) {
+                || UNIT_PERCENT.equals(height.unit))
+            {
                 h = (int) (w / ratio + .5F);
-            } else {
+            } else
+            {
                 h = resolveAbsolute(height, imageHeight, textSize);
             }
 
             rect = new Rect(0, 0, w, h);
 
-        } else if (height != null) {
+        } else if (height != null)
+        {
 
-            if (!UNIT_PERCENT.equals(height.unit)) {
+            if (!UNIT_PERCENT.equals(height.unit))
+            {
                 final int h = resolveAbsolute(height, imageHeight, textSize);
                 final int w = (int) (h * ratio + .5F);
                 rect = new Rect(0, 0, w, h);
-            } else {
+            } else
+            {
                 rect = imageBounds;
             }
-        } else {
+        } else
+        {
             rect = imageBounds;
         }
 
         return rect;
     }
 
-    protected int resolveAbsolute(@NonNull ImageSize.Dimension dimension, int original, float textSize) {
+    protected int resolveAbsolute(@NonNull ImageSize.Dimension dimension, int original, float textSize)
+    {
         final int out;
-        if (UNIT_EM.equals(dimension.unit)) {
+        if (UNIT_EM.equals(dimension.unit))
+        {
             out = (int) (dimension.value * textSize + .5F);
-        } else {
+        } else
+        {
             out = (int) (dimension.value + .5F);
         }
         return out;

--- a/stylar/src/main/java/com/zeoflow/stylar/image/ImageSpanFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/ImageSpanFactory.java
@@ -3,24 +3,26 @@ package com.zeoflow.stylar.image;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.RenderProps;
 import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.StylarConfiguration;
 
-public class ImageSpanFactory implements SpanFactory {
+public class ImageSpanFactory implements SpanFactory
+{
     @Nullable
     @Override
-    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props) {
+    public Object getSpans(@NonNull StylarConfiguration configuration, @NonNull RenderProps props)
+    {
         return new AsyncDrawableSpan(
-                configuration.theme(),
-                new AsyncDrawable(
-                        ImageProps.DESTINATION.require(props),
-                        configuration.asyncDrawableLoader(),
-                        configuration.imageSizeResolver(),
-                        ImageProps.IMAGE_SIZE.get(props)
-                ),
-                AsyncDrawableSpan.ALIGN_BOTTOM,
-                ImageProps.REPLACEMENT_TEXT_IS_LINK.get(props, false)
+            configuration.theme(),
+            new AsyncDrawable(
+                ImageProps.DESTINATION.require(props),
+                configuration.asyncDrawableLoader(),
+                configuration.imageSizeResolver(),
+                ImageProps.IMAGE_SIZE.get(props)
+            ),
+            AsyncDrawableSpan.ALIGN_BOTTOM,
+            ImageProps.REPLACEMENT_TEXT_IS_LINK.get(props, false)
         );
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/ImagesPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/ImagesPlugin.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.zeoflow.stylar.AbstractStylarPlugin;
+import com.zeoflow.stylar.StylarConfiguration;
 import com.zeoflow.stylar.StylarPlugin;
 import com.zeoflow.stylar.StylarSpansFactory;
 import com.zeoflow.stylar.image.data.DataUriSchemeHandler;
@@ -22,37 +23,23 @@ import org.commonmark.node.Image;
 
 import java.util.concurrent.ExecutorService;
 
-import com.zeoflow.stylar.StylarConfiguration;
-
 @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
 public class ImagesPlugin extends AbstractStylarPlugin
 {
 
-    /**
-     * @since 4.0.0
-     */
-    public interface ImagesConfigure {
-        void configureImages(@NonNull ImagesPlugin plugin);
+    private final AsyncDrawableLoaderBuilder builder;
+
+    // @since 4.0.0
+    ImagesPlugin()
+    {
+        this(new AsyncDrawableLoaderBuilder());
     }
 
-    /**
-     * @since 4.0.0
-     */
-    public interface PlaceholderProvider {
-        @Nullable
-        Drawable providePlaceholder(@NonNull AsyncDrawable drawable);
-    }
-
-    /**
-     * @since 4.0.0
-     */
-    public interface ErrorHandler {
-
-        /**
-         * Can optionally return a Drawable that will be displayed in case of an error
-         */
-        @Nullable
-        Drawable handleError(@NonNull String url, @NonNull Throwable throwable);
+    // @since 4.0.0
+    @VisibleForTesting
+    ImagesPlugin(@NonNull AsyncDrawableLoaderBuilder builder)
+    {
+        this.builder = builder;
     }
 
     /**
@@ -63,28 +50,17 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @see #create(ImagesConfigure)
      */
     @NonNull
-    public static ImagesPlugin create() {
+    public static ImagesPlugin create()
+    {
         return new ImagesPlugin();
     }
 
     @NonNull
-    public static ImagesPlugin create(@NonNull ImagesConfigure configure) {
+    public static ImagesPlugin create(@NonNull ImagesConfigure configure)
+    {
         final ImagesPlugin plugin = new ImagesPlugin();
         configure.configureImages(plugin);
         return plugin;
-    }
-
-    private final AsyncDrawableLoaderBuilder builder;
-
-    // @since 4.0.0
-    ImagesPlugin() {
-        this(new AsyncDrawableLoaderBuilder());
-    }
-
-    // @since 4.0.0
-    @VisibleForTesting
-    ImagesPlugin(@NonNull AsyncDrawableLoaderBuilder builder) {
-        this.builder = builder;
     }
 
     /**
@@ -93,7 +69,8 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin executorService(@NonNull ExecutorService executorService) {
+    public ImagesPlugin executorService(@NonNull ExecutorService executorService)
+    {
         builder.executorService(executorService);
         return this;
     }
@@ -107,7 +84,8 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin addSchemeHandler(@NonNull SchemeHandler schemeHandler) {
+    public ImagesPlugin addSchemeHandler(@NonNull SchemeHandler schemeHandler)
+    {
         builder.addSchemeHandler(schemeHandler);
         return this;
     }
@@ -119,7 +97,8 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin addMediaDecoder(@NonNull MediaDecoder mediaDecoder) {
+    public ImagesPlugin addMediaDecoder(@NonNull MediaDecoder mediaDecoder)
+    {
         builder.addMediaDecoder(mediaDecoder);
         return this;
     }
@@ -132,7 +111,8 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin defaultMediaDecoder(@Nullable MediaDecoder mediaDecoder) {
+    public ImagesPlugin defaultMediaDecoder(@Nullable MediaDecoder mediaDecoder)
+    {
         builder.defaultMediaDecoder(mediaDecoder);
         return this;
     }
@@ -141,7 +121,8 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin removeSchemeHandler(@NonNull String scheme) {
+    public ImagesPlugin removeSchemeHandler(@NonNull String scheme)
+    {
         builder.removeSchemeHandler(scheme);
         return this;
     }
@@ -150,7 +131,8 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin removeMediaDecoder(@NonNull String contentType) {
+    public ImagesPlugin removeMediaDecoder(@NonNull String contentType)
+    {
         builder.removeMediaDecoder(contentType);
         return this;
     }
@@ -159,7 +141,8 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin placeholderProvider(@NonNull PlaceholderProvider placeholderProvider) {
+    public ImagesPlugin placeholderProvider(@NonNull PlaceholderProvider placeholderProvider)
+    {
         builder.placeholderProvider(placeholderProvider);
         return this;
     }
@@ -169,28 +152,63 @@ public class ImagesPlugin extends AbstractStylarPlugin
      * @since 4.0.0
      */
     @NonNull
-    public ImagesPlugin errorHandler(@NonNull ErrorHandler errorHandler) {
+    public ImagesPlugin errorHandler(@NonNull ErrorHandler errorHandler)
+    {
         builder.errorHandler(errorHandler);
         return this;
     }
 
     @Override
-    public void configureConfiguration(@NonNull StylarConfiguration.Builder builder) {
+    public void configureConfiguration(@NonNull StylarConfiguration.Builder builder)
+    {
         builder.asyncDrawableLoader(this.builder.build());
     }
 
     @Override
-    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder) {
+    public void configureSpansFactory(@NonNull StylarSpansFactory.Builder builder)
+    {
         builder.setFactory(Image.class, new ImageSpanFactory());
     }
 
     @Override
-    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown) {
+    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown)
+    {
         AsyncDrawableScheduler.unschedule(textView);
     }
 
     @Override
-    public void afterSetText(@NonNull TextView textView) {
+    public void afterSetText(@NonNull TextView textView)
+    {
         AsyncDrawableScheduler.schedule(textView);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public interface ImagesConfigure
+    {
+        void configureImages(@NonNull ImagesPlugin plugin);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public interface PlaceholderProvider
+    {
+        @Nullable
+        Drawable providePlaceholder(@NonNull AsyncDrawable drawable);
+    }
+
+    /**
+     * @since 4.0.0
+     */
+    public interface ErrorHandler
+    {
+
+        /**
+         * Can optionally return a Drawable that will be displayed in case of an error
+         */
+        @Nullable
+        Drawable handleError(@NonNull String url, @NonNull Throwable throwable);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/MediaDecoder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/MediaDecoder.java
@@ -11,7 +11,8 @@ import java.util.Collection;
 /**
  * @since 3.0.0
  */
-public abstract class MediaDecoder {
+public abstract class MediaDecoder
+{
 
     /**
      * Changes since 4.0.0:
@@ -22,8 +23,8 @@ public abstract class MediaDecoder {
      */
     @NonNull
     public abstract Drawable decode(
-            @Nullable String contentType,
-            @NonNull InputStream inputStream
+        @Nullable String contentType,
+        @NonNull InputStream inputStream
     );
 
     /**

--- a/stylar/src/main/java/com/zeoflow/stylar/image/SchemeHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/SchemeHandler.java
@@ -9,7 +9,8 @@ import java.util.Collection;
 /**
  * @since 3.0.0
  */
-public abstract class SchemeHandler {
+public abstract class SchemeHandler
+{
 
     /**
      * Changes since 4.0.0:

--- a/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUri.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUri.java
@@ -2,43 +2,50 @@ package com.zeoflow.stylar.image.data;
 
 import androidx.annotation.Nullable;
 
-public class DataUri {
+public class DataUri
+{
 
     private final String contentType;
     private final boolean base64;
     private final String data;
 
-    public DataUri(@Nullable String contentType, boolean base64, @Nullable String data) {
+    public DataUri(@Nullable String contentType, boolean base64, @Nullable String data)
+    {
         this.contentType = contentType;
         this.base64 = base64;
         this.data = data;
     }
 
     @Nullable
-    public String contentType() {
+    public String contentType()
+    {
         return contentType;
     }
 
-    public boolean base64() {
+    public boolean base64()
+    {
         return base64;
     }
 
     @Nullable
-    public String data() {
+    public String data()
+    {
         return data;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "DataUri{" +
-                "contentType='" + contentType + '\'' +
-                ", base64=" + base64 +
-                ", data='" + data + '\'' +
-                '}';
+            "contentType='" + contentType + '\'' +
+            ", base64=" + base64 +
+            ", data='" + data + '\'' +
+            '}';
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(Object o)
+    {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -51,7 +58,8 @@ public class DataUri {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = contentType != null ? contentType.hashCode() : 0;
         result = 31 * result + (base64 ? 1 : 0);
         result = 31 * result + (data != null ? data.hashCode() : 0);

--- a/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUriDecoder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUriDecoder.java
@@ -1,37 +1,46 @@
 package com.zeoflow.stylar.image.data;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Base64;
 
-public abstract class DataUriDecoder {
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public abstract class DataUriDecoder
+{
+
+    @NonNull
+    public static DataUriDecoder create()
+    {
+        return new Impl();
+    }
 
     @Nullable
     public abstract byte[] decode(@NonNull DataUri dataUri) throws Throwable;
 
-    @NonNull
-    public static DataUriDecoder create() {
-        return new Impl();
-    }
-
-    static class Impl extends DataUriDecoder {
+    static class Impl extends DataUriDecoder
+    {
 
         private static final String CHARSET = "UTF-8";
 
         @Nullable
         @Override
-        public byte[] decode(@NonNull DataUri dataUri) throws Throwable {
+        public byte[] decode(@NonNull DataUri dataUri) throws Throwable
+        {
 
             final String data = dataUri.data();
 
-            if (!TextUtils.isEmpty(data)) {
-                if (dataUri.base64()) {
+            if (!TextUtils.isEmpty(data))
+            {
+                if (dataUri.base64())
+                {
                     return Base64.decode(data.getBytes(CHARSET), Base64.DEFAULT);
-                } else {
+                } else
+                {
                     return data.getBytes(CHARSET);
                 }
-            } else {
+            } else
+            {
                 return null;
             }
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUriParser.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUriParser.java
@@ -3,73 +3,89 @@ package com.zeoflow.stylar.image.data;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-public abstract class DataUriParser {
+public abstract class DataUriParser
+{
+
+    @NonNull
+    public static DataUriParser create()
+    {
+        return new Impl();
+    }
 
     @Nullable
     public abstract DataUri parse(@NonNull String input);
 
-
-    @NonNull
-    public static DataUriParser create() {
-        return new Impl();
-    }
-
-    static class Impl extends DataUriParser {
+    static class Impl extends DataUriParser
+    {
 
         @Nullable
         @Override
-        public DataUri parse(@NonNull String input) {
+        public DataUri parse(@NonNull String input)
+        {
 
             final int index = input.indexOf(',');
             // we expect exactly one comma
-            if (index < 0) {
+            if (index < 0)
+            {
                 return null;
             }
 
             final String contentType;
             final boolean base64;
 
-            if (index > 0) {
+            if (index > 0)
+            {
                 final String part = input.substring(0, index);
                 final String[] parts = part.split(";");
                 final int length = parts.length;
-                if (length > 0) {
+                if (length > 0)
+                {
                     // if one: either content-type or base64
-                    if (length == 1) {
+                    if (length == 1)
+                    {
                         final String value = parts[0];
-                        if ("base64".equals(value)) {
+                        if ("base64".equals(value))
+                        {
                             contentType = null;
                             base64 = true;
-                        } else {
+                        } else
+                        {
                             contentType = value.indexOf('/') > -1
-                                    ? value
-                                    : null;
+                                ? value
+                                : null;
                             base64 = false;
                         }
-                    } else {
+                    } else
+                    {
                         contentType = parts[0].indexOf('/') > -1
-                                ? parts[0]
-                                : null;
+                            ? parts[0]
+                            : null;
                         base64 = "base64".equals(parts[length - 1]);
                     }
-                } else {
+                } else
+                {
                     contentType = null;
                     base64 = false;
                 }
-            } else {
+            } else
+            {
                 contentType = null;
                 base64 = false;
             }
 
             final String data;
-            if (index < input.length()) {
+            if (index < input.length())
+            {
                 final String value = input.substring(index + 1, input.length()).replaceAll("\n", "");
-                if (value.length() == 0) {
+                if (value.length() == 0)
+                {
                     data = null;
-                } else {
+                } else
+                {
                     data = value;
                 }
-            } else {
+            } else
+            {
                 data = null;
             }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUriSchemeHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/data/DataUriSchemeHandler.java
@@ -1,72 +1,80 @@
 package com.zeoflow.stylar.image.data;
 
 import android.net.Uri;
+
 import androidx.annotation.NonNull;
+
+import com.zeoflow.stylar.image.ImageItem;
+import com.zeoflow.stylar.image.SchemeHandler;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collection;
 import java.util.Collections;
 
-import com.zeoflow.stylar.image.ImageItem;
-import com.zeoflow.stylar.image.SchemeHandler;
-
 /**
  * @since 2.0.0
  */
-public class DataUriSchemeHandler extends SchemeHandler {
+public class DataUriSchemeHandler extends SchemeHandler
+{
 
     public static final String SCHEME = "data";
-
-    @NonNull
-    public static DataUriSchemeHandler create() {
-        return new DataUriSchemeHandler(DataUriParser.create(), DataUriDecoder.create());
-    }
-
     private static final String START = "data:";
-
     private final DataUriParser uriParser;
     private final DataUriDecoder uriDecoder;
-
     @SuppressWarnings("WeakerAccess")
-    DataUriSchemeHandler(@NonNull DataUriParser uriParser, @NonNull DataUriDecoder uriDecoder) {
+    DataUriSchemeHandler(@NonNull DataUriParser uriParser, @NonNull DataUriDecoder uriDecoder)
+    {
         this.uriParser = uriParser;
         this.uriDecoder = uriDecoder;
     }
 
     @NonNull
-    @Override
-    public ImageItem handle(@NonNull String raw, @NonNull Uri uri) {
+    public static DataUriSchemeHandler create()
+    {
+        return new DataUriSchemeHandler(DataUriParser.create(), DataUriDecoder.create());
+    }
 
-        if (!raw.startsWith(START)) {
+    @NonNull
+    @Override
+    public ImageItem handle(@NonNull String raw, @NonNull Uri uri)
+    {
+
+        if (!raw.startsWith(START))
+        {
             throw new IllegalStateException("Invalid data-uri: " + raw);
         }
 
         final String part = raw.substring(START.length());
 
         final DataUri dataUri = uriParser.parse(part);
-        if (dataUri == null) {
+        if (dataUri == null)
+        {
             throw new IllegalStateException("Invalid data-uri: " + raw);
         }
 
         final byte[] bytes;
-        try {
+        try
+        {
             bytes = uriDecoder.decode(dataUri);
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             throw new IllegalStateException("Cannot decode data-uri: " + raw, t);
         }
 
-        if (bytes == null) {
+        if (bytes == null)
+        {
             throw new IllegalStateException("Decoding data-uri failed: " + raw);
         }
 
         return ImageItem.withDecodingNeeded(
-                dataUri.contentType(),
-                new ByteArrayInputStream(bytes));
+            dataUri.contentType(),
+            new ByteArrayInputStream(bytes));
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedSchemes() {
+    public Collection<String> supportedSchemes()
+    {
         return Collections.singleton(SCHEME);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/destination/ImageDestinationProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/destination/ImageDestinationProcessor.java
@@ -7,20 +7,24 @@ import androidx.annotation.NonNull;
  *
  * @since 4.4.0
  */
-public abstract class ImageDestinationProcessor {
+public abstract class ImageDestinationProcessor
+{
     @NonNull
-    public abstract String process(@NonNull String destination);
-
-    @NonNull
-    public static ImageDestinationProcessor noOp() {
+    public static ImageDestinationProcessor noOp()
+    {
         return new NoOp();
     }
 
-    private static class NoOp extends ImageDestinationProcessor {
+    @NonNull
+    public abstract String process(@NonNull String destination);
+
+    private static class NoOp extends ImageDestinationProcessor
+    {
 
         @NonNull
         @Override
-        public String process(@NonNull String destination) {
+        public String process(@NonNull String destination)
+        {
             return destination;
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/destination/ImageDestinationProcessorAssets.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/destination/ImageDestinationProcessorAssets.java
@@ -17,40 +17,47 @@ import androidx.annotation.Nullable;
  *
  * @since 4.4.0
  */
-public class ImageDestinationProcessorAssets extends ImageDestinationProcessor {
-
-    @NonNull
-    public static ImageDestinationProcessorAssets create(@Nullable ImageDestinationProcessor parent) {
-        return new ImageDestinationProcessorAssets(parent);
-    }
+public class ImageDestinationProcessorAssets extends ImageDestinationProcessor
+{
 
     static final String MOCK = "https://android.asset/";
     static final String BASE = "file:///android_asset/";
-
     private final ImageDestinationProcessorRelativeToAbsolute assetsProcessor
-            = new ImageDestinationProcessorRelativeToAbsolute(MOCK);
-
+        = new ImageDestinationProcessorRelativeToAbsolute(MOCK);
     private final ImageDestinationProcessor processor;
 
-    public ImageDestinationProcessorAssets() {
+    public ImageDestinationProcessorAssets()
+    {
         this(null);
     }
 
-    public ImageDestinationProcessorAssets(@Nullable ImageDestinationProcessor parent) {
+    public ImageDestinationProcessorAssets(@Nullable ImageDestinationProcessor parent)
+    {
         this.processor = parent;
     }
 
     @NonNull
+    public static ImageDestinationProcessorAssets create(@Nullable ImageDestinationProcessor parent)
+    {
+        return new ImageDestinationProcessorAssets(parent);
+    }
+
+    @NonNull
     @Override
-    public String process(@NonNull String destination) {
+    public String process(@NonNull String destination)
+    {
         final String out;
         final Uri uri = Uri.parse(destination);
-        if (TextUtils.isEmpty(uri.getScheme())) {
+        if (TextUtils.isEmpty(uri.getScheme()))
+        {
             out = assetsProcessor.process(destination).replace(MOCK, BASE);
-        } else {
-            if (processor != null) {
+        } else
+        {
+            if (processor != null)
+            {
                 out = processor.process(destination);
-            } else {
+            } else
+            {
                 out = destination;
             }
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/destination/ImageDestinationProcessorRelativeToAbsolute.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/destination/ImageDestinationProcessorRelativeToAbsolute.java
@@ -9,51 +9,63 @@ import java.net.URL;
 /**
  * @since 4.4.0
  */
-public class ImageDestinationProcessorRelativeToAbsolute extends ImageDestinationProcessor {
-
-    @NonNull
-    public static ImageDestinationProcessorRelativeToAbsolute create(@NonNull String base) {
-        return new ImageDestinationProcessorRelativeToAbsolute(base);
-    }
-
-    public static ImageDestinationProcessorRelativeToAbsolute create(@NonNull URL base) {
-        return new ImageDestinationProcessorRelativeToAbsolute(base);
-    }
+public class ImageDestinationProcessorRelativeToAbsolute extends ImageDestinationProcessor
+{
 
     private final URL base;
 
-    public ImageDestinationProcessorRelativeToAbsolute(@NonNull String base) {
+    public ImageDestinationProcessorRelativeToAbsolute(@NonNull String base)
+    {
         this.base = obtain(base);
     }
 
-    public ImageDestinationProcessorRelativeToAbsolute(@NonNull URL base) {
+    public ImageDestinationProcessorRelativeToAbsolute(@NonNull URL base)
+    {
         this.base = base;
     }
 
     @NonNull
+    public static ImageDestinationProcessorRelativeToAbsolute create(@NonNull String base)
+    {
+        return new ImageDestinationProcessorRelativeToAbsolute(base);
+    }
+
+    public static ImageDestinationProcessorRelativeToAbsolute create(@NonNull URL base)
+    {
+        return new ImageDestinationProcessorRelativeToAbsolute(base);
+    }
+
+    @Nullable
+    private static URL obtain(String base)
+    {
+        try
+        {
+            return new URL(base);
+        } catch (MalformedURLException e)
+        {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @NonNull
     @Override
-    public String process(@NonNull String destination) {
+    public String process(@NonNull String destination)
+    {
 
         String out = destination;
 
-        if (base != null) {
-            try {
+        if (base != null)
+        {
+            try
+            {
                 final URL u = new URL(base, destination);
                 out = u.toString();
-            } catch (MalformedURLException e) {
+            } catch (MalformedURLException e)
+            {
                 e.printStackTrace();
             }
         }
         return out;
-    }
-
-    @Nullable
-    private static URL obtain(String base) {
-        try {
-            return new URL(base);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            return null;
-        }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/file/FileSchemeHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/file/FileSchemeHandler.java
@@ -9,6 +9,8 @@ import android.webkit.MimeTypeMap;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.zeoflow.stylar.image.ImageItem;
+import com.zeoflow.stylar.image.SchemeHandler;
 import com.zeoflow.stylar.image.destination.ImageDestinationProcessorAssets;
 
 import java.io.BufferedInputStream;
@@ -21,21 +23,29 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import com.zeoflow.stylar.image.ImageItem;
-import com.zeoflow.stylar.image.SchemeHandler;
-
 /**
  * @since 3.0.0
  */
-public class FileSchemeHandler extends SchemeHandler {
+public class FileSchemeHandler extends SchemeHandler
+{
 
     public static final String SCHEME = "file";
+    private static final String FILE_ANDROID_ASSETS = "android_asset";
+    @Nullable
+    private final AssetManager assetManager;
+
+    @SuppressWarnings("WeakerAccess")
+    FileSchemeHandler(@Nullable AssetManager assetManager)
+    {
+        this.assetManager = assetManager;
+    }
 
     /**
      * @see ImageDestinationProcessorAssets
      */
     @NonNull
-    public static FileSchemeHandler createWithAssets(@NonNull AssetManager assetManager) {
+    public static FileSchemeHandler createWithAssets(@NonNull AssetManager assetManager)
+    {
         return new FileSchemeHandler(assetManager);
     }
 
@@ -45,32 +55,26 @@ public class FileSchemeHandler extends SchemeHandler {
      * @since 4.0.0
      */
     @NonNull
-    public static FileSchemeHandler createWithAssets(@NonNull Context context) {
+    public static FileSchemeHandler createWithAssets(@NonNull Context context)
+    {
         return new FileSchemeHandler(context.getAssets());
     }
 
     @NonNull
-    public static FileSchemeHandler create() {
+    public static FileSchemeHandler create()
+    {
         return new FileSchemeHandler(null);
-    }
-
-    private static final String FILE_ANDROID_ASSETS = "android_asset";
-
-    @Nullable
-    private final AssetManager assetManager;
-
-    @SuppressWarnings("WeakerAccess")
-    FileSchemeHandler(@Nullable AssetManager assetManager) {
-        this.assetManager = assetManager;
     }
 
     @NonNull
     @Override
-    public ImageItem handle(@NonNull String raw, @NonNull Uri uri) {
+    public ImageItem handle(@NonNull String raw, @NonNull Uri uri)
+    {
 
         final List<String> segments = uri.getPathSegments();
         if (segments == null
-                || segments.size() == 0) {
+            || segments.size() == 0)
+        {
             // pointing to file & having no path segments is no use
             throw new IllegalStateException("Invalid file path: " + raw);
         }
@@ -80,57 +84,69 @@ public class FileSchemeHandler extends SchemeHandler {
         final boolean assets = FILE_ANDROID_ASSETS.equals(segments.get(0));
         final String fileName = uri.getLastPathSegment();
 
-        if (assets) {
+        if (assets)
+        {
 
             // no handling of assets here if we have no assetsManager
-            if (assetManager != null) {
+            if (assetManager != null)
+            {
 
                 final StringBuilder path = new StringBuilder();
-                for (int i = 1, size = segments.size(); i < size; i++) {
-                    if (i != 1) {
+                for (int i = 1, size = segments.size(); i < size; i++)
+                {
+                    if (i != 1)
+                    {
                         path.append('/');
                     }
                     path.append(segments.get(i));
                 }
                 // load assets
 
-                try {
+                try
+                {
                     inputStream = assetManager.open(path.toString());
-                } catch (IOException e) {
+                } catch (IOException e)
+                {
                     throw new IllegalStateException("Exception obtaining asset file: " +
-                            "" + raw + ", path: " + path.toString(), e);
+                        "" + raw + ", path: " + path.toString(), e);
                 }
-            } else {
+            } else
+            {
                 throw new IllegalStateException("Supplied file path points to assets, " +
-                        "but FileSchemeHandler was not supplied with AssetsManager. " +
-                        "Use `#createWithAssets` factory method to create FileSchemeHandler " +
-                        "that can handle android assets");
+                    "but FileSchemeHandler was not supplied with AssetsManager. " +
+                    "Use `#createWithAssets` factory method to create FileSchemeHandler " +
+                    "that can handle android assets");
             }
 
-        } else {
+        } else
+        {
 
             final String path = uri.getPath();
-            if (TextUtils.isEmpty(path)) {
+            if (TextUtils.isEmpty(path))
+            {
                 throw new IllegalStateException("Invalid file path: " + raw + ", " + path);
             }
 
-            try {
+            try
+            {
                 inputStream = new BufferedInputStream(new FileInputStream(new File(path)));
-            } catch (FileNotFoundException e) {
+            } catch (FileNotFoundException e)
+            {
                 throw new IllegalStateException("Exception reading file: " + raw, e);
             }
         }
 
         final String contentType = MimeTypeMap
-                .getSingleton()
-                .getMimeTypeFromExtension(MimeTypeMap.getFileExtensionFromUrl(fileName));
+            .getSingleton()
+            .getMimeTypeFromExtension(MimeTypeMap.getFileExtensionFromUrl(fileName));
 
         return ImageItem.withDecodingNeeded(contentType, inputStream);
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedSchemes() {
+    public Collection<String> supportedSchemes()
+    {
         return Collections.singleton(SCHEME);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/gif/GifMediaDecoder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/gif/GifMediaDecoder.java
@@ -23,6 +23,15 @@ public class GifMediaDecoder extends MediaDecoder
 {
 
     public static final String CONTENT_TYPE = "image/gif";
+    private final boolean autoPlayGif;
+
+    protected GifMediaDecoder(boolean autoPlayGif)
+    {
+        this.autoPlayGif = autoPlayGif;
+
+        // @since 4.0.0
+        validate();
+    }
 
     /**
      * Creates a {@link GifMediaDecoder} with {@code autoPlayGif = true}
@@ -30,43 +39,64 @@ public class GifMediaDecoder extends MediaDecoder
      * @since 4.0.0
      */
     @NonNull
-    public static GifMediaDecoder create() {
+    public static GifMediaDecoder create()
+    {
         return create(true);
     }
 
     @NonNull
-    public static GifMediaDecoder create(boolean autoPlayGif) {
+    public static GifMediaDecoder create(boolean autoPlayGif)
+    {
         return new GifMediaDecoder(autoPlayGif);
     }
 
-    private final boolean autoPlayGif;
+    @NonNull
+    protected static byte[] readBytes(@NonNull InputStream stream) throws IOException
+    {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final int length = 1024 * 8;
+        final byte[] buffer = new byte[length];
+        int read;
+        while ((read = stream.read(buffer, 0, length)) != -1)
+        {
+            outputStream.write(buffer, 0, read);
+        }
+        return outputStream.toByteArray();
+    }
 
-    protected GifMediaDecoder(boolean autoPlayGif) {
-        this.autoPlayGif = autoPlayGif;
-
-        // @since 4.0.0
-        validate();
+    private static void validate()
+    {
+        if (!GifSupport.hasGifSupport())
+        {
+            throw new IllegalStateException(GifSupport.missingMessage());
+        }
     }
 
     @NonNull
     @Override
-    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream) {
+    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream)
+    {
 
         final byte[] bytes;
-        try {
+        try
+        {
             bytes = readBytes(inputStream);
-        } catch (IOException e) {
+        } catch (IOException e)
+        {
             throw new IllegalStateException("Cannot read GIF input-stream", e);
         }
 
         final GifDrawable drawable;
-        try {
+        try
+        {
             drawable = newGifDrawable(bytes);
-        } catch (IOException e) {
+        } catch (IOException e)
+        {
             throw new IllegalStateException("Exception creating GifDrawable", e);
         }
 
-        if (!autoPlayGif) {
+        if (!autoPlayGif)
+        {
             drawable.pause();
         }
 
@@ -75,30 +105,14 @@ public class GifMediaDecoder extends MediaDecoder
 
     @NonNull
     @Override
-    public Collection<String> supportedTypes() {
+    public Collection<String> supportedTypes()
+    {
         return Collections.singleton(CONTENT_TYPE);
     }
 
     @NonNull
-    protected GifDrawable newGifDrawable(@NonNull byte[] bytes) throws IOException {
+    protected GifDrawable newGifDrawable(@NonNull byte[] bytes) throws IOException
+    {
         return new GifDrawable(bytes);
-    }
-
-    @NonNull
-    protected static byte[] readBytes(@NonNull InputStream stream) throws IOException {
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        final int length = 1024 * 8;
-        final byte[] buffer = new byte[length];
-        int read;
-        while ((read = stream.read(buffer, 0, length)) != -1) {
-            outputStream.write(buffer, 0, read);
-        }
-        return outputStream.toByteArray();
-    }
-
-    private static void validate() {
-        if (!GifSupport.hasGifSupport()) {
-            throw new IllegalStateException(GifSupport.missingMessage());
-        }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/gif/GifSupport.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/gif/GifSupport.java
@@ -7,17 +7,21 @@ import androidx.annotation.NonNull;
 /**
  * @since 4.0.0
  */
-public abstract class GifSupport {
+public abstract class GifSupport
+{
 
     private static boolean HAS_GIF;
 
-    static {
+    static
+    {
         boolean result;
-        try {
+        try
+        {
             // @since 4.3.1
             Class.forName("pl.droidsonroids.gif.GifDrawable");
             result = true;
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             // @since 4.1.1 instead of printing full stacktrace of the exception,
             // just print a warning to the console
             Log.w("MarkwonImagesPlugin", missingMessage());
@@ -26,7 +30,12 @@ public abstract class GifSupport {
         HAS_GIF = result;
     }
 
-    public static boolean hasGifSupport() {
+    private GifSupport()
+    {
+    }
+
+    public static boolean hasGifSupport()
+    {
         return HAS_GIF;
     }
 
@@ -34,12 +43,10 @@ public abstract class GifSupport {
      * @since 4.1.1
      */
     @NonNull
-    static String missingMessage() {
+    static String missingMessage()
+    {
         return "`pl.droidsonroids.gif:android-gif-drawable:*` " +
-                "dependency is missing, please add to your project explicitly if you " +
-                "wish to use GIF media-decoder";
-    }
-
-    private GifSupport() {
+            "dependency is missing, please add to your project explicitly if you " +
+            "wish to use GIF media-decoder";
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/network/NetworkSchemeHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/network/NetworkSchemeHandler.java
@@ -1,8 +1,12 @@
 package com.zeoflow.stylar.image.network;
 
 import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.zeoflow.stylar.image.ImageItem;
+import com.zeoflow.stylar.image.SchemeHandler;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -12,51 +16,74 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.zeoflow.stylar.image.ImageItem;
-import com.zeoflow.stylar.image.SchemeHandler;
-
 /**
  * A simple network scheme handler that is not dependent on any external libraries.
  *
  * @see #create()
  * @since 3.0.0
  */
-public class NetworkSchemeHandler extends SchemeHandler {
+public class NetworkSchemeHandler extends SchemeHandler
+{
 
     public static final String SCHEME_HTTP = "http";
     public static final String SCHEME_HTTPS = "https";
 
+    @SuppressWarnings("WeakerAccess")
+    NetworkSchemeHandler()
+    {
+
+    }
+
     @NonNull
-    public static NetworkSchemeHandler create() {
+    public static NetworkSchemeHandler create()
+    {
         return new NetworkSchemeHandler();
     }
 
-    @SuppressWarnings("WeakerAccess")
-    NetworkSchemeHandler() {
+    @Nullable
+    static String contentType(@Nullable String contentType)
+    {
 
+        if (contentType == null)
+        {
+            return null;
+        }
+
+        final int index = contentType.indexOf(';');
+        if (index > -1)
+        {
+            return contentType.substring(0, index);
+        }
+
+        return contentType;
     }
 
     @NonNull
     @Override
-    public ImageItem handle(@NonNull String raw, @NonNull Uri uri) {
+    public ImageItem handle(@NonNull String raw, @NonNull Uri uri)
+    {
 
         final ImageItem imageItem;
-        try {
+        try
+        {
 
             final URL url = new URL(raw);
             final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.connect();
 
             final int responseCode = connection.getResponseCode();
-            if (responseCode >= 200 && responseCode < 300) {
+            if (responseCode >= 200 && responseCode < 300)
+            {
                 final String contentType = contentType(connection.getHeaderField("Content-Type"));
                 final InputStream inputStream = new BufferedInputStream(connection.getInputStream());
                 imageItem = ImageItem.withDecodingNeeded(contentType, inputStream);
-            } else {
+            } else
+            {
                 throw new IOException("Bad response code: " + responseCode + ", url: " + raw);
             }
 
-        } catch (IOException e) {
+        } catch (IOException e)
+        {
             throw new IllegalStateException("Exception obtaining network resource: " + raw, e);
         }
 
@@ -65,22 +92,8 @@ public class NetworkSchemeHandler extends SchemeHandler {
 
     @NonNull
     @Override
-    public Collection<String> supportedSchemes() {
+    public Collection<String> supportedSchemes()
+    {
         return Arrays.asList(SCHEME_HTTP, SCHEME_HTTPS);
-    }
-
-    @Nullable
-    static String contentType(@Nullable String contentType) {
-
-        if (contentType == null) {
-            return null;
-        }
-
-        final int index = contentType.indexOf(';');
-        if (index > -1) {
-            return contentType.substring(0, index);
-        }
-
-        return contentType;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/network/OkHttpNetworkSchemeHandler.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/network/OkHttpNetworkSchemeHandler.java
@@ -1,14 +1,16 @@
 package com.zeoflow.stylar.image.network;
 
 import android.net.Uri;
+
 import androidx.annotation.NonNull;
+
+import com.zeoflow.stylar.image.ImageItem;
+import com.zeoflow.stylar.image.SchemeHandler;
 
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.zeoflow.stylar.image.ImageItem;
-import com.zeoflow.stylar.image.SchemeHandler;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -18,18 +20,31 @@ import okhttp3.ResponseBody;
 /**
  * @since 4.0.0
  */
-public class OkHttpNetworkSchemeHandler extends SchemeHandler {
+public class OkHttpNetworkSchemeHandler extends SchemeHandler
+{
+
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+    // @since 4.0.0, previously just OkHttpClient
+    private final Call.Factory factory;
+
+    @SuppressWarnings("WeakerAccess")
+    OkHttpNetworkSchemeHandler(@NonNull Call.Factory factory)
+    {
+        this.factory = factory;
+    }
 
     /**
      * @see #create(OkHttpClient)
      */
     @NonNull
-    public static OkHttpNetworkSchemeHandler create() {
+    public static OkHttpNetworkSchemeHandler create()
+    {
         return create(new OkHttpClient());
     }
 
     @NonNull
-    public static OkHttpNetworkSchemeHandler create(@NonNull OkHttpClient client) {
+    public static OkHttpNetworkSchemeHandler create(@NonNull OkHttpClient client)
+    {
         // explicit cast, otherwise a recursive call
         return create((Call.Factory) client);
     }
@@ -38,61 +53,58 @@ public class OkHttpNetworkSchemeHandler extends SchemeHandler {
      * @since 4.0.0
      */
     @NonNull
-    public static OkHttpNetworkSchemeHandler create(@NonNull Call.Factory factory) {
+    public static OkHttpNetworkSchemeHandler create(@NonNull Call.Factory factory)
+    {
         return new OkHttpNetworkSchemeHandler(factory);
-    }
-
-    private static final String HEADER_CONTENT_TYPE = "Content-Type";
-
-    // @since 4.0.0, previously just OkHttpClient
-    private final Call.Factory factory;
-
-    @SuppressWarnings("WeakerAccess")
-    OkHttpNetworkSchemeHandler(@NonNull Call.Factory factory) {
-        this.factory = factory;
     }
 
     @NonNull
     @Override
-    public ImageItem handle(@NonNull String raw, @NonNull Uri uri) {
+    public ImageItem handle(@NonNull String raw, @NonNull Uri uri)
+    {
 
         final Request request = new Request.Builder()
-                .url(raw)
-                .tag(raw)
-                .build();
+            .url(raw)
+            .tag(raw)
+            .build();
 
         final Response response;
-        try {
+        try
+        {
             response = factory.newCall(request).execute();
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             throw new IllegalStateException("Exception obtaining network resource: " + raw, t);
         }
 
-        if (response == null) {
+        if (response == null)
+        {
             throw new IllegalStateException("Could not obtain network response: " + raw);
         }
 
         final ResponseBody body = response.body();
         final InputStream inputStream = body != null
-                ? body.byteStream()
-                : null;
+            ? body.byteStream()
+            : null;
 
-        if (inputStream == null) {
+        if (inputStream == null)
+        {
             throw new IllegalStateException("Response does not contain body: " + raw);
         }
 
         // important to process content-type as it can have encoding specified (which we should remove)
         final String contentType =
-                NetworkSchemeHandler.contentType(response.header(HEADER_CONTENT_TYPE));
+            NetworkSchemeHandler.contentType(response.header(HEADER_CONTENT_TYPE));
 
         return ImageItem.withDecodingNeeded(contentType, inputStream);
     }
 
     @NonNull
     @Override
-    public Collection<String> supportedSchemes() {
+    public Collection<String> supportedSchemes()
+    {
         return Arrays.asList(
-                NetworkSchemeHandler.SCHEME_HTTP,
-                NetworkSchemeHandler.SCHEME_HTTPS);
+            NetworkSchemeHandler.SCHEME_HTTP,
+            NetworkSchemeHandler.SCHEME_HTTPS);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/svg/SvgMediaDecoder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/svg/SvgMediaDecoder.java
@@ -11,52 +11,65 @@ import androidx.annotation.Nullable;
 
 import com.caverock.androidsvg.SVG;
 import com.caverock.androidsvg.SVGParseException;
+import com.zeoflow.stylar.image.MediaDecoder;
 
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 
-import com.zeoflow.stylar.image.MediaDecoder;
-
 /**
  * @since 1.1.0
  */
-public class SvgMediaDecoder extends MediaDecoder {
+public class SvgMediaDecoder extends MediaDecoder
+{
 
     public static final String CONTENT_TYPE = "image/svg+xml";
-
-    /**
-     * @see #create(Resources)
-     * @since 4.0.0
-     */
-    @NonNull
-    public static SvgMediaDecoder create() {
-        return create(Resources.getSystem());
-    }
-
-    @NonNull
-    public static SvgMediaDecoder create(@NonNull Resources resources) {
-        return new SvgMediaDecoder(resources);
-    }
-
     private final Resources resources;
 
     @SuppressWarnings("WeakerAccess")
-    SvgMediaDecoder(Resources resources) {
+    SvgMediaDecoder(Resources resources)
+    {
         this.resources = resources;
 
         // @since 4.0.0
         validate();
     }
 
+    /**
+     * @see #create(Resources)
+     * @since 4.0.0
+     */
+    @NonNull
+    public static SvgMediaDecoder create()
+    {
+        return create(Resources.getSystem());
+    }
+
+    @NonNull
+    public static SvgMediaDecoder create(@NonNull Resources resources)
+    {
+        return new SvgMediaDecoder(resources);
+    }
+
+    private static void validate()
+    {
+        if (!SvgSupport.hasSvgSupport())
+        {
+            throw new IllegalStateException(SvgSupport.missingMessage());
+        }
+    }
+
     @NonNull
     @Override
-    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream) {
+    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream)
+    {
 
         final SVG svg;
-        try {
+        try
+        {
             svg = SVG.getFromInputStream(inputStream);
-        } catch (SVGParseException e) {
+        } catch (SVGParseException e)
+        {
             throw new IllegalStateException("Exception decoding SVG", e);
         }
 
@@ -77,13 +90,8 @@ public class SvgMediaDecoder extends MediaDecoder {
 
     @NonNull
     @Override
-    public Collection<String> supportedTypes() {
+    public Collection<String> supportedTypes()
+    {
         return Collections.singleton(CONTENT_TYPE);
-    }
-
-    private static void validate() {
-        if (!SvgSupport.hasSvgSupport()) {
-            throw new IllegalStateException(SvgSupport.missingMessage());
-        }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/svg/SvgPictureMediaDecoder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/svg/SvgPictureMediaDecoder.java
@@ -24,18 +24,22 @@ public class SvgPictureMediaDecoder extends MediaDecoder
     public static final String CONTENT_TYPE = "image/svg+xml";
 
     @NonNull
-    public static SvgPictureMediaDecoder create() {
+    public static SvgPictureMediaDecoder create()
+    {
         return new SvgPictureMediaDecoder();
     }
 
     @NonNull
     @Override
-    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream) {
+    public Drawable decode(@Nullable String contentType, @NonNull InputStream inputStream)
+    {
 
         final SVG svg;
-        try {
+        try
+        {
             svg = SVG.getFromInputStream(inputStream);
-        } catch (SVGParseException e) {
+        } catch (SVGParseException e)
+        {
             throw new IllegalStateException("Exception decoding SVG", e);
         }
 
@@ -45,7 +49,8 @@ public class SvgPictureMediaDecoder extends MediaDecoder
 
     @NonNull
     @Override
-    public Collection<String> supportedTypes() {
+    public Collection<String> supportedTypes()
+    {
         return Collections.singleton(CONTENT_TYPE);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/image/svg/SvgSupport.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/image/svg/SvgSupport.java
@@ -7,16 +7,20 @@ import androidx.annotation.NonNull;
 /**
  * @since 4.0.0
  */
-public abstract class SvgSupport {
+public abstract class SvgSupport
+{
 
     private static final boolean HAS_SVG;
 
-    static {
+    static
+    {
         boolean result;
-        try {
+        try
+        {
             Class.forName("com.caverock.androidsvg.SVG");
             result = true;
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             // @since 4.1.1 instead of printing full stacktrace of the exception,
             // just print a warning to the console
             Log.w("MarkwonImagesPlugin", missingMessage());
@@ -25,7 +29,12 @@ public abstract class SvgSupport {
         HAS_SVG = result;
     }
 
-    public static boolean hasSvgSupport() {
+    private SvgSupport()
+    {
+    }
+
+    public static boolean hasSvgSupport()
+    {
         return HAS_SVG;
     }
 
@@ -33,11 +42,9 @@ public abstract class SvgSupport {
      * @since 4.1.1
      */
     @NonNull
-    static String missingMessage() {
+    static String missingMessage()
+    {
         return "`com.caverock:androidsvg:*` dependency is missing, " +
-                "please add to your project explicitly if you wish to use SVG media-decoder";
-    }
-
-    private SvgSupport() {
+            "please add to your project explicitly if you wish to use SVG media-decoder";
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/AutolinkInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/AutolinkInlineProcessor.java
@@ -11,33 +11,39 @@ import java.util.regex.Pattern;
  *
  * @since 4.2.0
  */
-public class AutolinkInlineProcessor extends InlineProcessor {
+public class AutolinkInlineProcessor extends InlineProcessor
+{
 
     private static final Pattern EMAIL_AUTOLINK = Pattern
-            .compile("^<([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>");
+        .compile("^<([a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>");
 
     private static final Pattern AUTOLINK = Pattern
-            .compile("^<[a-zA-Z][a-zA-Z0-9.+-]{1,31}:[^<>\u0000-\u0020]*>");
+        .compile("^<[a-zA-Z][a-zA-Z0-9.+-]{1,31}:[^<>\u0000-\u0020]*>");
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '<';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         String m;
-        if ((m = match(EMAIL_AUTOLINK)) != null) {
+        if ((m = match(EMAIL_AUTOLINK)) != null)
+        {
             String dest = m.substring(1, m.length() - 1);
             Link node = new Link("mailto:" + dest, null);
             node.appendChild(new Text(dest));
             return node;
-        } else if ((m = match(AUTOLINK)) != null) {
+        } else if ((m = match(AUTOLINK)) != null)
+        {
             String dest = m.substring(1, m.length() - 1);
             Link node = new Link(dest, null);
             node.appendChild(new Text(dest));
             return node;
-        } else {
+        } else
+        {
             return null;
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/BackslashInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/BackslashInlineProcessor.java
@@ -8,26 +8,32 @@ import java.util.regex.Pattern;
 /**
  * @since 4.2.0
  */
-public class BackslashInlineProcessor extends InlineProcessor {
+public class BackslashInlineProcessor extends InlineProcessor
+{
 
     private static final Pattern ESCAPABLE = StylarInlineParser.ESCAPABLE;
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '\\';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         index++;
         Node node;
-        if (peek() == '\n') {
+        if (peek() == '\n')
+        {
             node = new HardLineBreak();
             index++;
-        } else if (index < input.length() && ESCAPABLE.matcher(input.substring(index, index + 1)).matches()) {
+        } else if (index < input.length() && ESCAPABLE.matcher(input.substring(index, index + 1)).matches())
+        {
             node = text(input, index, index + 1);
             index++;
-        } else {
+        } else
+        {
             node = text("\\");
         }
         return node;

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/BackticksInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/BackticksInlineProcessor.java
@@ -11,27 +11,33 @@ import java.util.regex.Pattern;
  *
  * @since 4.2.0
  */
-public class BackticksInlineProcessor extends InlineProcessor {
+public class BackticksInlineProcessor extends InlineProcessor
+{
 
     private static final Pattern TICKS = Pattern.compile("`+");
 
     private static final Pattern TICKS_HERE = Pattern.compile("^`+");
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '`';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         String ticks = match(TICKS_HERE);
-        if (ticks == null) {
+        if (ticks == null)
+        {
             return null;
         }
         int afterOpenTicks = index;
         String matched;
-        while ((matched = match(TICKS)) != null) {
-            if (matched.equals(ticks)) {
+        while ((matched = match(TICKS)) != null)
+        {
+            if (matched.equals(ticks))
+            {
                 Code node = new Code();
                 String content = input.substring(afterOpenTicks, index - ticks.length());
                 content = content.replace('\n', ' ');
@@ -39,9 +45,10 @@ public class BackticksInlineProcessor extends InlineProcessor {
                 // spec: If the resulting string both begins and ends with a space character, but does not consist
                 // entirely of space characters, a single space character is removed from the front and back.
                 if (content.length() >= 3 &&
-                        content.charAt(0) == ' ' &&
-                        content.charAt(content.length() - 1) == ' ' &&
-                        Parsing.hasNonSpace(content)) {
+                    content.charAt(0) == ' ' &&
+                    content.charAt(content.length() - 1) == ' ' &&
+                    Parsing.hasNonSpace(content))
+                {
                     content = content.substring(1, content.length() - 1);
                 }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/BangInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/BangInlineProcessor.java
@@ -9,17 +9,21 @@ import org.commonmark.node.Text;
  *
  * @since 4.2.0
  */
-public class BangInlineProcessor extends InlineProcessor {
+public class BangInlineProcessor extends InlineProcessor
+{
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '!';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         int startIndex = index;
         index++;
-        if (peek() == '[') {
+        if (peek() == '[')
+        {
             index++;
 
             Text node = text("![");
@@ -28,7 +32,8 @@ public class BangInlineProcessor extends InlineProcessor {
             addBracket(Bracket.image(node, startIndex + 1, lastBracket(), lastDelimiter()));
 
             return node;
-        } else {
+        } else
+        {
             return null;
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/CloseBracketInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/CloseBracketInlineProcessor.java
@@ -15,28 +15,33 @@ import java.util.regex.Pattern;
  *
  * @since 4.2.0
  */
-public class CloseBracketInlineProcessor extends InlineProcessor {
+public class CloseBracketInlineProcessor extends InlineProcessor
+{
 
     private static final Pattern WHITESPACE = StylarInlineParser.WHITESPACE;
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return ']';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         index++;
         int startIndex = index;
 
         // Get previous `[` or `![`
         Bracket opener = lastBracket();
-        if (opener == null) {
+        if (opener == null)
+        {
             // No matching opener, just return a literal.
             return text("]");
         }
 
-        if (!opener.allowed) {
+        if (!opener.allowed)
+        {
             // Matching opener but it's not allowed, just return a literal.
             removeLastBracket();
             return text("]");
@@ -49,46 +54,56 @@ public class CloseBracketInlineProcessor extends InlineProcessor {
         boolean isLinkOrImage = false;
 
         // Maybe a inline link like `[foo](/uri "title")`
-        if (peek() == '(') {
+        if (peek() == '(')
+        {
             index++;
             spnl();
-            if ((dest = parseLinkDestination()) != null) {
+            if ((dest = parseLinkDestination()) != null)
+            {
                 spnl();
                 // title needs a whitespace before
-                if (WHITESPACE.matcher(input.substring(index - 1, index)).matches()) {
+                if (WHITESPACE.matcher(input.substring(index - 1, index)).matches())
+                {
                     title = parseLinkTitle();
                     spnl();
                 }
-                if (peek() == ')') {
+                if (peek() == ')')
+                {
                     index++;
                     isLinkOrImage = true;
-                } else {
+                } else
+                {
                     index = startIndex;
                 }
             }
         }
 
         // Maybe a reference link like `[foo][bar]`, `[foo][]` or `[foo]`
-        if (!isLinkOrImage) {
+        if (!isLinkOrImage)
+        {
 
             // See if there's a link label like `[bar]` or `[]`
             int beforeLabel = index;
             parseLinkLabel();
             int labelLength = index - beforeLabel;
             String ref = null;
-            if (labelLength > 2) {
+            if (labelLength > 2)
+            {
                 ref = input.substring(beforeLabel, beforeLabel + labelLength);
-            } else if (!opener.bracketAfter) {
+            } else if (!opener.bracketAfter)
+            {
                 // If the second label is empty `[foo][]` or missing `[foo]`, then the first label is the reference.
                 // But it can only be a reference when there's no (unescaped) bracket in it.
                 // If there is, we don't even need to try to look up the reference. This is an optimization.
                 ref = input.substring(opener.index, startIndex);
             }
 
-            if (ref != null) {
+            if (ref != null)
+            {
                 String label = Escaping.normalizeReference(ref);
                 LinkReferenceDefinition definition = context.getLinkReferenceDefinition(label);
-                if (definition != null) {
+                if (definition != null)
+                {
                     dest = definition.getDestination();
                     title = definition.getTitle();
                     isLinkOrImage = true;
@@ -96,12 +111,14 @@ public class CloseBracketInlineProcessor extends InlineProcessor {
             }
         }
 
-        if (isLinkOrImage) {
+        if (isLinkOrImage)
+        {
             // If we got here, open is a potential opener
             Node linkOrImage = opener.image ? new Image(dest, title) : new Link(dest, title);
 
             Node node = opener.node.getNext();
-            while (node != null) {
+            while (node != null)
+            {
                 Node next = node.getNext();
                 linkOrImage.appendChild(node);
                 node = next;
@@ -115,10 +132,13 @@ public class CloseBracketInlineProcessor extends InlineProcessor {
             removeLastBracket();
 
             // Links within links are not allowed. We found this link, so there can be no other link around it.
-            if (!opener.image) {
+            if (!opener.image)
+            {
                 Bracket bracket = lastBracket();
-                while (bracket != null) {
-                    if (!bracket.image) {
+                while (bracket != null)
+                {
+                    if (!bracket.image)
+                    {
                         // Disallow link opener. It will still get matched, but will not result in a link.
                         bracket.allowed = false;
                     }
@@ -128,7 +148,8 @@ public class CloseBracketInlineProcessor extends InlineProcessor {
 
             return linkOrImage;
 
-        } else { // no link or image
+        } else
+        { // no link or image
             index = startIndex;
             removeLastBracket();
 

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/EntityInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/EntityInlineProcessor.java
@@ -11,21 +11,26 @@ import java.util.regex.Pattern;
  *
  * @since 4.2.0
  */
-public class EntityInlineProcessor extends InlineProcessor {
+public class EntityInlineProcessor extends InlineProcessor
+{
 
     private static final Pattern ENTITY_HERE = Pattern.compile('^' + Escaping.ENTITY, Pattern.CASE_INSENSITIVE);
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '&';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         String m;
-        if ((m = match(ENTITY_HERE)) != null) {
+        if ((m = match(ENTITY_HERE)) != null)
+        {
             return text(Html5Entities.entityToString(m));
-        } else {
+        } else
+        {
             return null;
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/HtmlInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/HtmlInlineProcessor.java
@@ -11,29 +11,34 @@ import java.util.regex.Pattern;
  *
  * @since 4.2.0
  */
-public class HtmlInlineProcessor extends InlineProcessor {
+public class HtmlInlineProcessor extends InlineProcessor
+{
 
     private static final String HTMLCOMMENT = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->";
     private static final String PROCESSINGINSTRUCTION = "[<][?].*?[?][>]";
     private static final String DECLARATION = "<![A-Z]+\\s+[^>]*>";
     private static final String CDATA = "<!\\[CDATA\\[[\\s\\S]*?\\]\\]>";
     private static final String HTMLTAG = "(?:" + Parsing.OPENTAG + "|" + Parsing.CLOSETAG + "|" + HTMLCOMMENT
-            + "|" + PROCESSINGINSTRUCTION + "|" + DECLARATION + "|" + CDATA + ")";
+        + "|" + PROCESSINGINSTRUCTION + "|" + DECLARATION + "|" + CDATA + ")";
     private static final Pattern HTML_TAG = Pattern.compile('^' + HTMLTAG, Pattern.CASE_INSENSITIVE);
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '<';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         String m = match(HTML_TAG);
-        if (m != null) {
+        if (m != null)
+        {
             HtmlInline node = new HtmlInline();
             node.setLiteral(m);
             return node;
-        } else {
+        } else
+        {
             return null;
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/InlineParserUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/InlineParserUtils.java
@@ -6,47 +6,62 @@ import org.commonmark.node.Text;
 /**
  * @since 4.2.0
  */
-public abstract class InlineParserUtils {
+public abstract class InlineParserUtils
+{
 
-    public static void mergeTextNodesBetweenExclusive(Node fromNode, Node toNode) {
+    private InlineParserUtils()
+    {
+    }
+
+    public static void mergeTextNodesBetweenExclusive(Node fromNode, Node toNode)
+    {
         // No nodes between them
-        if (fromNode == toNode || fromNode.getNext() == toNode) {
+        if (fromNode == toNode || fromNode.getNext() == toNode)
+        {
             return;
         }
 
         mergeTextNodesInclusive(fromNode.getNext(), toNode.getPrevious());
     }
 
-    public static void mergeChildTextNodes(Node node) {
+    public static void mergeChildTextNodes(Node node)
+    {
         // No children or just one child node, no need for merging
-        if (node.getFirstChild() == node.getLastChild()) {
+        if (node.getFirstChild() == node.getLastChild())
+        {
             return;
         }
 
         mergeTextNodesInclusive(node.getFirstChild(), node.getLastChild());
     }
 
-    public static void mergeTextNodesInclusive(Node fromNode, Node toNode) {
+    public static void mergeTextNodesInclusive(Node fromNode, Node toNode)
+    {
         Text first = null;
         Text last = null;
         int length = 0;
 
         Node node = fromNode;
-        while (node != null) {
-            if (node instanceof Text) {
+        while (node != null)
+        {
+            if (node instanceof Text)
+            {
                 Text text = (Text) node;
-                if (first == null) {
+                if (first == null)
+                {
                     first = text;
                 }
                 length += text.getLiteral().length();
                 last = text;
-            } else {
+            } else
+            {
                 mergeIfNeeded(first, last, length);
                 first = null;
                 last = null;
                 length = 0;
             }
-            if (node == toNode) {
+            if (node == toNode)
+            {
                 break;
             }
             node = node.getNext();
@@ -55,13 +70,16 @@ public abstract class InlineParserUtils {
         mergeIfNeeded(first, last, length);
     }
 
-    public static void mergeIfNeeded(Text first, Text last, int textLength) {
-        if (first != null && last != null && first != last) {
+    public static void mergeIfNeeded(Text first, Text last, int textLength)
+    {
+        if (first != null && last != null && first != last)
+        {
             StringBuilder sb = new StringBuilder(textLength);
             sb.append(first.getLiteral());
             Node node = first.getNext();
             Node stop = last.getNext();
-            while (node != stop) {
+            while (node != stop)
+            {
                 sb.append(((Text) node).getLiteral());
                 Node unlink = node;
                 node = node.getNext();
@@ -70,8 +88,5 @@ public abstract class InlineParserUtils {
             String literal = sb.toString();
             first.setLiteral(literal);
         }
-    }
-
-    private InlineParserUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/InlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/InlineProcessor.java
@@ -24,7 +24,13 @@ import java.util.regex.Pattern;
  * @see StylarInlineParser.FactoryBuilder#excludeInlineProcessor(Class)
  * @since 4.2.0
  */
-public abstract class InlineProcessor {
+public abstract class InlineProcessor
+{
+
+    protected StylarInlineParserContext context;
+    protected Node block;
+    protected String input;
+    protected int index;
 
     /**
      * Special character that triggers parsing attempt
@@ -37,14 +43,9 @@ public abstract class InlineProcessor {
     @Nullable
     protected abstract Node parse();
 
-
-    protected StylarInlineParserContext context;
-    protected Node block;
-    protected String input;
-    protected int index;
-
     @Nullable
-    public Node parse(@NonNull StylarInlineParserContext context) {
+    public Node parse(@NonNull StylarInlineParserContext context)
+    {
         this.context = context;
         this.block = context.block();
         this.input = context.input();
@@ -58,30 +59,36 @@ public abstract class InlineProcessor {
         return result;
     }
 
-    protected Bracket lastBracket() {
+    protected Bracket lastBracket()
+    {
         return context.lastBracket();
     }
 
-    protected Delimiter lastDelimiter() {
+    protected Delimiter lastDelimiter()
+    {
         return context.lastDelimiter();
     }
 
-    protected void addBracket(Bracket bracket) {
+    protected void addBracket(Bracket bracket)
+    {
         context.addBracket(bracket);
     }
 
-    protected void removeLastBracket() {
+    protected void removeLastBracket()
+    {
         context.removeLastBracket();
     }
 
-    protected void spnl() {
+    protected void spnl()
+    {
         context.setIndex(index);
         context.spnl();
         index = context.index();
     }
 
     @Nullable
-    protected String match(@NonNull Pattern re) {
+    protected String match(@NonNull Pattern re)
+    {
         // before trying to match, we must notify context about our index (which we store additionally here)
         context.setIndex(index);
 
@@ -94,7 +101,8 @@ public abstract class InlineProcessor {
     }
 
     @Nullable
-    protected String parseLinkDestination() {
+    protected String parseLinkDestination()
+    {
         context.setIndex(index);
         final String result = context.parseLinkDestination();
         this.index = context.index();
@@ -102,37 +110,43 @@ public abstract class InlineProcessor {
     }
 
     @Nullable
-    protected String parseLinkTitle() {
+    protected String parseLinkTitle()
+    {
         context.setIndex(index);
         final String result = context.parseLinkTitle();
         this.index = context.index();
         return result;
     }
 
-    protected int parseLinkLabel() {
+    protected int parseLinkLabel()
+    {
         context.setIndex(index);
         final int result = context.parseLinkLabel();
         this.index = context.index();
         return result;
     }
 
-    protected void processDelimiters(Delimiter stackBottom) {
+    protected void processDelimiters(Delimiter stackBottom)
+    {
         context.setIndex(index);
         context.processDelimiters(stackBottom);
         this.index = context.index();
     }
 
     @NonNull
-    protected Text text(@NonNull String text) {
+    protected Text text(@NonNull String text)
+    {
         return context.text(text);
     }
 
     @NonNull
-    protected Text text(@NonNull String text, int start, int end) {
+    protected Text text(@NonNull String text, int start, int end)
+    {
         return context.text(text, start, end);
     }
 
-    protected char peek() {
+    protected char peek()
+    {
         context.setIndex(index);
         return context.peek();
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/NewLineInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/NewLineInlineProcessor.java
@@ -11,37 +11,45 @@ import java.util.regex.Pattern;
 /**
  * @since 4.2.0
  */
-public class NewLineInlineProcessor extends InlineProcessor {
+public class NewLineInlineProcessor extends InlineProcessor
+{
 
     private static final Pattern FINAL_SPACE = Pattern.compile(" *$");
 
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '\n';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         index++; // assume we're at a \n
 
         final Node previous = block.getLastChild();
 
         // Check previous text for trailing spaces.
         // The "endsWith" is an optimization to avoid an RE match in the common case.
-        if (previous instanceof Text && ((Text) previous).getLiteral().endsWith(" ")) {
+        if (previous instanceof Text && ((Text) previous).getLiteral().endsWith(" "))
+        {
             Text text = (Text) previous;
             String literal = text.getLiteral();
             Matcher matcher = FINAL_SPACE.matcher(literal);
             int spaces = matcher.find() ? matcher.end() - matcher.start() : 0;
-            if (spaces > 0) {
+            if (spaces > 0)
+            {
                 text.setLiteral(literal.substring(0, literal.length() - spaces));
             }
-            if (spaces >= 2) {
+            if (spaces >= 2)
+            {
                 return new HardLineBreak();
-            } else {
+            } else
+            {
                 return new SoftLineBreak();
             }
-        } else {
+        } else
+        {
             return new SoftLineBreak();
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/OpenBracketInlineProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/OpenBracketInlineProcessor.java
@@ -9,14 +9,17 @@ import org.commonmark.node.Text;
  *
  * @since 4.2.0
  */
-public class OpenBracketInlineProcessor extends InlineProcessor {
+public class OpenBracketInlineProcessor extends InlineProcessor
+{
     @Override
-    public char specialCharacter() {
+    public char specialCharacter()
+    {
         return '[';
     }
 
     @Override
-    protected Node parse() {
+    protected Node parse()
+    {
         int startIndex = index;
         index++;
 

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/StaggeredDelimiterProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/StaggeredDelimiterProcessor.java
@@ -7,56 +7,69 @@ import org.commonmark.parser.delimiter.DelimiterRun;
 import java.util.LinkedList;
 import java.util.ListIterator;
 
-class StaggeredDelimiterProcessor implements DelimiterProcessor {
+class StaggeredDelimiterProcessor implements DelimiterProcessor
+{
 
     private final char delim;
     private int minLength = 0;
     private LinkedList<DelimiterProcessor> processors = new LinkedList<>(); // in reverse getMinLength order
 
-    StaggeredDelimiterProcessor(char delim) {
+    StaggeredDelimiterProcessor(char delim)
+    {
         this.delim = delim;
     }
 
     @Override
-    public char getOpeningCharacter() {
+    public char getOpeningCharacter()
+    {
         return delim;
     }
 
     @Override
-    public char getClosingCharacter() {
+    public char getClosingCharacter()
+    {
         return delim;
     }
 
     @Override
-    public int getMinLength() {
+    public int getMinLength()
+    {
         return minLength;
     }
 
-    void add(DelimiterProcessor dp) {
+    void add(DelimiterProcessor dp)
+    {
         final int len = dp.getMinLength();
         ListIterator<DelimiterProcessor> it = processors.listIterator();
         boolean added = false;
-        while (it.hasNext()) {
+        while (it.hasNext())
+        {
             DelimiterProcessor p = it.next();
             int pLen = p.getMinLength();
-            if (len > pLen) {
+            if (len > pLen)
+            {
                 it.previous();
                 it.add(dp);
                 added = true;
                 break;
-            } else if (len == pLen) {
+            } else if (len == pLen)
+            {
                 throw new IllegalArgumentException("Cannot add two delimiter processors for char '" + delim + "' and minimum length " + len);
             }
         }
-        if (!added) {
+        if (!added)
+        {
             processors.add(dp);
             this.minLength = len;
         }
     }
 
-    private DelimiterProcessor findProcessor(int len) {
-        for (DelimiterProcessor p : processors) {
-            if (p.getMinLength() <= len) {
+    private DelimiterProcessor findProcessor(int len)
+    {
+        for (DelimiterProcessor p : processors)
+        {
+            if (p.getMinLength() <= len)
+            {
                 return p;
             }
         }
@@ -64,12 +77,14 @@ class StaggeredDelimiterProcessor implements DelimiterProcessor {
     }
 
     @Override
-    public int getDelimiterUse(DelimiterRun opener, DelimiterRun closer) {
+    public int getDelimiterUse(DelimiterRun opener, DelimiterRun closer)
+    {
         return findProcessor(opener.length()).getDelimiterUse(opener, closer);
     }
 
     @Override
-    public void process(Text opener, Text closer, int delimiterUse) {
+    public void process(Text opener, Text closer, int delimiterUse)
+    {
         findProcessor(delimiterUse).process(opener, closer, delimiterUse);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/StylarInlineParser.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/StylarInlineParser.java
@@ -39,8 +39,715 @@ import static com.zeoflow.stylar.inlineparser.InlineParserUtils.mergeTextNodesBe
 public class StylarInlineParser implements InlineParser, StylarInlineParserContext
 {
 
+    static final Pattern ESCAPABLE = Pattern.compile('^' + Escaping.ESCAPABLE);
+    static final Pattern WHITESPACE = Pattern.compile("\\s+");
+    private static final String ASCII_PUNCTUATION = "!\"#\\$%&'\\(\\)\\*\\+,\\-\\./:;<=>\\?@\\[\\\\\\]\\^_`\\{\\|\\}~";
+    private static final Pattern PUNCTUATION = Pattern
+        .compile("^[" + ASCII_PUNCTUATION + "\\p{Pc}\\p{Pd}\\p{Pe}\\p{Pf}\\p{Pi}\\p{Po}\\p{Ps}]");
+    private static final Pattern SPNL = Pattern.compile("^ *(?:\n *)?");
+    private static final Pattern UNICODE_WHITESPACE_CHAR = Pattern.compile("^[\\p{Zs}\t\r\n\f]");
+    private final InlineParserContext inlineParserContext;
+    private final boolean referencesEnabled;
+    private final BitSet specialCharacters;
+    private final Map<Character, List<InlineProcessor>> inlineProcessors;
+    private final Map<Character, DelimiterProcessor> delimiterProcessors;
+    // currently we still hold a reference to it because we decided not to
+    //  pass previous node argument to inline-processors (current usage is limited with NewLineInlineProcessor)
+    private Node block;
+    private String input;
+    private int index;
+    /**
+     * Top delimiter (emphasis, strong emphasis or custom emphasis). (Brackets are on a separate stack, different
+     * from the algorithm described in the spec.)
+     */
+    private Delimiter lastDelimiter;
+    /**
+     * Top opening bracket (<code>[</code> or <code>![)</code>).
+     */
+    private Bracket lastBracket;
+    // might we construct these in factory?
+    public StylarInlineParser(
+        @NonNull InlineParserContext inlineParserContext,
+        boolean referencesEnabled,
+        @NonNull List<InlineProcessor> inlineProcessors,
+        @NonNull List<DelimiterProcessor> delimiterProcessors)
+    {
+        this.inlineParserContext = inlineParserContext;
+        this.referencesEnabled = referencesEnabled;
+        this.inlineProcessors = calculateInlines(inlineProcessors);
+        this.delimiterProcessors = calculateDelimiterProcessors(delimiterProcessors);
+        this.specialCharacters = calculateSpecialCharacters(
+            this.inlineProcessors.keySet(),
+            this.delimiterProcessors.keySet());
+    }
+
+    /**
+     * Creates an instance of {@link FactoryBuilder} and includes all defaults.
+     *
+     * @see #factoryBuilderNoDefaults()
+     */
+    @NonNull
+    public static FactoryBuilder factoryBuilder()
+    {
+        return new FactoryBuilderImpl().includeDefaults();
+    }
+
+    /**
+     * NB, this return an <em>empty</em> builder, so if no {@link FactoryBuilderNoDefaults#includeDefaults()}
+     * is called, it means effectively <strong>no inline parsing</strong> (unless further calls
+     * to {@link FactoryBuilder#addInlineProcessor(InlineProcessor)} or {@link FactoryBuilder#addDelimiterProcessor(DelimiterProcessor)}).
+     */
+    @NonNull
+    public static FactoryBuilderNoDefaults factoryBuilderNoDefaults()
+    {
+        return new FactoryBuilderImpl();
+    }
+
+    @NonNull
+    private static Map<Character, List<InlineProcessor>> calculateInlines(@NonNull List<InlineProcessor> inlines)
+    {
+        final Map<Character, List<InlineProcessor>> map = new HashMap<>(inlines.size());
+        List<InlineProcessor> list;
+        for (InlineProcessor inlineProcessor : inlines)
+        {
+            final char character = inlineProcessor.specialCharacter();
+            list = map.get(character);
+            if (list == null)
+            {
+                list = new ArrayList<>(1);
+                map.put(character, list);
+            }
+            list.add(inlineProcessor);
+        }
+        return map;
+    }
+
+    @NonNull
+    private static BitSet calculateSpecialCharacters(Set<Character> inlineCharacters, Set<Character> delimiterCharacters)
+    {
+        final BitSet bitSet = new BitSet();
+        for (Character c : inlineCharacters)
+        {
+            bitSet.set(c);
+        }
+        for (Character c : delimiterCharacters)
+        {
+            bitSet.set(c);
+        }
+        return bitSet;
+    }
+
+    private static Map<Character, DelimiterProcessor> calculateDelimiterProcessors(List<DelimiterProcessor> delimiterProcessors)
+    {
+        Map<Character, DelimiterProcessor> map = new HashMap<>();
+        addDelimiterProcessors(delimiterProcessors, map);
+        return map;
+    }
+
+    private static void addDelimiterProcessors(Iterable<DelimiterProcessor> delimiterProcessors, Map<Character, DelimiterProcessor> map)
+    {
+        for (DelimiterProcessor delimiterProcessor : delimiterProcessors)
+        {
+            char opening = delimiterProcessor.getOpeningCharacter();
+            char closing = delimiterProcessor.getClosingCharacter();
+            if (opening == closing)
+            {
+                DelimiterProcessor old = map.get(opening);
+                if (old != null && old.getOpeningCharacter() == old.getClosingCharacter())
+                {
+                    StaggeredDelimiterProcessor s;
+                    if (old instanceof StaggeredDelimiterProcessor)
+                    {
+                        s = (StaggeredDelimiterProcessor) old;
+                    } else
+                    {
+                        s = new StaggeredDelimiterProcessor(opening);
+                        s.add(old);
+                    }
+                    s.add(delimiterProcessor);
+                    map.put(opening, s);
+                } else
+                {
+                    addDelimiterProcessorForChar(opening, delimiterProcessor, map);
+                }
+            } else
+            {
+                addDelimiterProcessorForChar(opening, delimiterProcessor, map);
+                addDelimiterProcessorForChar(closing, delimiterProcessor, map);
+            }
+        }
+    }
+
+    private static void addDelimiterProcessorForChar(char delimiterChar, DelimiterProcessor toAdd, Map<Character, DelimiterProcessor> delimiterProcessors)
+    {
+        DelimiterProcessor existing = delimiterProcessors.put(delimiterChar, toAdd);
+        if (existing != null)
+        {
+            throw new IllegalArgumentException("Delimiter processor conflict with delimiter char '" + delimiterChar + "'");
+        }
+    }
+
+    /**
+     * Parse content in block into inline children, using reference map to resolve references.
+     */
+    @Override
+    public void parse(String content, Node block)
+    {
+        reset(content.trim());
+
+        // we still reference it
+        this.block = block;
+
+        while (true)
+        {
+            Node node = parseInline();
+            if (node != null)
+            {
+                block.appendChild(node);
+            } else
+            {
+                break;
+            }
+        }
+
+        processDelimiters(null);
+        mergeChildTextNodes(block);
+    }
+
+    private void reset(String content)
+    {
+        this.input = content;
+        this.index = 0;
+        this.lastDelimiter = null;
+        this.lastBracket = null;
+    }
+
+    /**
+     * Parse the next inline element in subject, advancing input index.
+     * On success, add the result to block's children and return true.
+     * On failure, return false.
+     */
+    @Nullable
+    private Node parseInline()
+    {
+
+        final char c = peek();
+
+        if (c == '\0')
+        {
+            return null;
+        }
+
+        Node node = null;
+
+        final List<InlineProcessor> inlines = this.inlineProcessors.get(c);
+
+        if (inlines != null)
+        {
+            // @since 4.6.0 index must not be advanced if inline-processor returned null
+            //  so, further processors can be called at the _same_ position (and thus char)
+            final int startIndex = index;
+
+            for (InlineProcessor inline : inlines)
+            {
+                node = inline.parse(this);
+                if (node != null)
+                {
+                    break;
+                }
+
+                // reset after each iteration (happens only when node is null)
+                index = startIndex;
+            }
+        } else
+        {
+            final DelimiterProcessor delimiterProcessor = delimiterProcessors.get(c);
+            if (delimiterProcessor != null)
+            {
+                node = parseDelimiters(delimiterProcessor, c);
+            } else
+            {
+                node = parseString();
+            }
+        }
+
+        if (node != null)
+        {
+            return node;
+        } else
+        {
+            index++;
+            // When we get here, it's only for a single special character that turned out to not have a special meaning.
+            // So we shouldn't have a single surrogate here, hence it should be ok to turn it into a String.
+            String literal = String.valueOf(c);
+            return text(literal);
+        }
+    }
+
+    /**
+     * If RE matches at current index in the input, advance index and return the match; otherwise return null.
+     */
+    @Override
+    @Nullable
+    public String match(@NonNull Pattern re)
+    {
+        if (index >= input.length())
+        {
+            return null;
+        }
+        Matcher matcher = re.matcher(input);
+        matcher.region(index, input.length());
+        boolean m = matcher.find();
+        if (m)
+        {
+            index = matcher.end();
+            return matcher.group();
+        } else
+        {
+            return null;
+        }
+    }
+
+    @NonNull
+    @Override
+    public Text text(@NonNull String text)
+    {
+        return new Text(text);
+    }
+
+    @NonNull
+    @Override
+    public Text text(@NonNull String text, int beginIndex, int endIndex)
+    {
+        return new Text(text.substring(beginIndex, endIndex));
+    }
+
+    @Nullable
+    @Override
+    public LinkReferenceDefinition getLinkReferenceDefinition(String label)
+    {
+        return referencesEnabled
+            ? inlineParserContext.getLinkReferenceDefinition(label)
+            : null;
+    }
+
+    /**
+     * Returns the char at the current input index, or {@code '\0'} in case there are no more characters.
+     */
+    @Override
+    public char peek()
+    {
+        if (index < input.length())
+        {
+            return input.charAt(index);
+        } else
+        {
+            return '\0';
+        }
+    }
+
+    @NonNull
+    @Override
+    public Node block()
+    {
+        return block;
+    }
+
+    @NonNull
+    @Override
+    public String input()
+    {
+        return input;
+    }
+
+    @Override
+    public int index()
+    {
+        return index;
+    }
+
+    @Override
+    public void setIndex(int index)
+    {
+        this.index = index;
+    }
+
+    @Override
+    public Bracket lastBracket()
+    {
+        return lastBracket;
+    }
+
+    @Override
+    public Delimiter lastDelimiter()
+    {
+        return lastDelimiter;
+    }
+
+    @Override
+    public void addBracket(Bracket bracket)
+    {
+        if (lastBracket != null)
+        {
+            lastBracket.bracketAfter = true;
+        }
+        lastBracket = bracket;
+    }
+
+    @Override
+    public void removeLastBracket()
+    {
+        lastBracket = lastBracket.previous;
+    }
+
+    /**
+     * Parse zero or more space characters, including at most one newline.
+     */
+    @Override
+    public void spnl()
+    {
+        match(SPNL);
+    }
+
+    /**
+     * Attempt to parse delimiters like emphasis, strong emphasis or custom delimiters.
+     */
+    @Nullable
+    private Node parseDelimiters(DelimiterProcessor delimiterProcessor, char delimiterChar)
+    {
+        DelimiterData res = scanDelimiters(delimiterProcessor, delimiterChar);
+        if (res == null)
+        {
+            return null;
+        }
+        int length = res.count;
+        int startIndex = index;
+
+        index += length;
+        Text node = text(input, startIndex, index);
+
+        // Add entry to stack for this opener
+        lastDelimiter = new Delimiter(node, delimiterChar, res.canOpen, res.canClose, lastDelimiter);
+        lastDelimiter.length = length;
+        lastDelimiter.originalLength = length;
+        if (lastDelimiter.previous != null)
+        {
+            lastDelimiter.previous.next = lastDelimiter;
+        }
+
+        return node;
+    }
+
+    /**
+     * Attempt to parse link destination, returning the string or null if no match.
+     */
+    @Override
+    @Nullable
+    public String parseLinkDestination()
+    {
+        int afterDest = LinkScanner.scanLinkDestination(input, index);
+        if (afterDest == -1)
+        {
+            return null;
+        }
+
+        String dest;
+        if (peek() == '<')
+        {
+            // chop off surrounding <..>:
+            dest = input.substring(index + 1, afterDest - 1);
+        } else
+        {
+            dest = input.substring(index, afterDest);
+        }
+
+        index = afterDest;
+        return Escaping.unescapeString(dest);
+    }
+
+    /**
+     * Attempt to parse link title (sans quotes), returning the string or null if no match.
+     */
+    @Override
+    @Nullable
+    public String parseLinkTitle()
+    {
+        int afterTitle = LinkScanner.scanLinkTitle(input, index);
+        if (afterTitle == -1)
+        {
+            return null;
+        }
+
+        // chop off ', " or parens
+        String title = input.substring(index + 1, afterTitle - 1);
+        index = afterTitle;
+        return Escaping.unescapeString(title);
+    }
+
+    /**
+     * Attempt to parse a link label, returning number of characters parsed.
+     */
+    @Override
+    public int parseLinkLabel()
+    {
+        if (index >= input.length() || input.charAt(index) != '[')
+        {
+            return 0;
+        }
+
+        int startContent = index + 1;
+        int endContent = LinkScanner.scanLinkLabelContent(input, startContent);
+        // spec: A link label can have at most 999 characters inside the square brackets.
+        int contentLength = endContent - startContent;
+        if (endContent == -1 || contentLength > 999)
+        {
+            return 0;
+        }
+        if (endContent >= input.length() || input.charAt(endContent) != ']')
+        {
+            return 0;
+        }
+        index = endContent + 1;
+        return contentLength + 2;
+    }
+
+    /**
+     * Parse a run of ordinary characters, or a single character with a special meaning in markdown, as a plain string.
+     */
+    private Node parseString()
+    {
+        int begin = index;
+        int length = input.length();
+        while (index != length)
+        {
+            if (specialCharacters.get(input.charAt(index)))
+            {
+                break;
+            }
+            index++;
+        }
+        if (begin != index)
+        {
+            return text(input, begin, index);
+        } else
+        {
+            return null;
+        }
+    }
+
+    /**
+     * Scan a sequence of characters with code delimiterChar, and return information about the number of delimiters
+     * and whether they are positioned such that they can open and/or close emphasis or strong emphasis.
+     *
+     * @return information about delimiter run, or {@code null}
+     */
+    private DelimiterData scanDelimiters(DelimiterProcessor delimiterProcessor, char delimiterChar)
+    {
+        int startIndex = index;
+
+        int delimiterCount = 0;
+        while (peek() == delimiterChar)
+        {
+            delimiterCount++;
+            index++;
+        }
+
+        if (delimiterCount < delimiterProcessor.getMinLength())
+        {
+            index = startIndex;
+            return null;
+        }
+
+        String before = startIndex == 0 ? "\n" :
+            input.substring(startIndex - 1, startIndex);
+
+        char charAfter = peek();
+        String after = charAfter == '\0' ? "\n" :
+            String.valueOf(charAfter);
+
+        // We could be more lazy here, in most cases we don't need to do every match case.
+        boolean beforeIsPunctuation = PUNCTUATION.matcher(before).matches();
+        boolean beforeIsWhitespace = UNICODE_WHITESPACE_CHAR.matcher(before).matches();
+        boolean afterIsPunctuation = PUNCTUATION.matcher(after).matches();
+        boolean afterIsWhitespace = UNICODE_WHITESPACE_CHAR.matcher(after).matches();
+
+        boolean leftFlanking = !afterIsWhitespace &&
+            (!afterIsPunctuation || beforeIsWhitespace || beforeIsPunctuation);
+        boolean rightFlanking = !beforeIsWhitespace &&
+            (!beforeIsPunctuation || afterIsWhitespace || afterIsPunctuation);
+        boolean canOpen;
+        boolean canClose;
+        if (delimiterChar == '_')
+        {
+            canOpen = leftFlanking && (!rightFlanking || beforeIsPunctuation);
+            canClose = rightFlanking && (!leftFlanking || afterIsPunctuation);
+        } else
+        {
+            canOpen = leftFlanking && delimiterChar == delimiterProcessor.getOpeningCharacter();
+            canClose = rightFlanking && delimiterChar == delimiterProcessor.getClosingCharacter();
+        }
+
+        index = startIndex;
+        return new DelimiterData(delimiterCount, canOpen, canClose);
+    }
+
+    @Override
+    public void processDelimiters(Delimiter stackBottom)
+    {
+
+        Map<Character, Delimiter> openersBottom = new HashMap<>();
+
+        // find first closer above stackBottom:
+        Delimiter closer = lastDelimiter;
+        while (closer != null && closer.previous != stackBottom)
+        {
+            closer = closer.previous;
+        }
+        // move forward, looking for closers, and handling each
+        while (closer != null)
+        {
+            char delimiterChar = closer.delimiterChar;
+
+            DelimiterProcessor delimiterProcessor = delimiterProcessors.get(delimiterChar);
+            if (!closer.canClose || delimiterProcessor == null)
+            {
+                closer = closer.next;
+                continue;
+            }
+
+            char openingDelimiterChar = delimiterProcessor.getOpeningCharacter();
+
+            // Found delimiter closer. Now look back for first matching opener.
+            int useDelims = 0;
+            boolean openerFound = false;
+            boolean potentialOpenerFound = false;
+            Delimiter opener = closer.previous;
+            while (opener != null && opener != stackBottom && opener != openersBottom.get(delimiterChar))
+            {
+                if (opener.canOpen && opener.delimiterChar == openingDelimiterChar)
+                {
+                    potentialOpenerFound = true;
+                    useDelims = delimiterProcessor.getDelimiterUse(opener, closer);
+                    if (useDelims > 0)
+                    {
+                        openerFound = true;
+                        break;
+                    }
+                }
+                opener = opener.previous;
+            }
+
+            if (!openerFound)
+            {
+                if (!potentialOpenerFound)
+                {
+                    // Set lower bound for future searches for openers.
+                    // Only do this when we didn't even have a potential
+                    // opener (one that matches the character and can open).
+                    // If an opener was rejected because of the number of
+                    // delimiters (e.g. because of the "multiple of 3" rule),
+                    // we want to consider it next time because the number
+                    // of delimiters can change as we continue processing.
+                    openersBottom.put(delimiterChar, closer.previous);
+                    if (!closer.canOpen)
+                    {
+                        // We can remove a closer that can't be an opener,
+                        // once we've seen there's no matching opener:
+                        removeDelimiterKeepNode(closer);
+                    }
+                }
+                closer = closer.next;
+                continue;
+            }
+
+            Text openerNode = opener.node;
+            Text closerNode = closer.node;
+
+            // Remove number of used delimiters from stack and inline nodes.
+            opener.length -= useDelims;
+            closer.length -= useDelims;
+            openerNode.setLiteral(
+                openerNode.getLiteral().substring(0,
+                    openerNode.getLiteral().length() - useDelims));
+            closerNode.setLiteral(
+                closerNode.getLiteral().substring(0,
+                    closerNode.getLiteral().length() - useDelims));
+
+            removeDelimitersBetween(opener, closer);
+            // The delimiter processor can re-parent the nodes between opener and closer,
+            // so make sure they're contiguous already. Exclusive because we want to keep opener/closer themselves.
+            mergeTextNodesBetweenExclusive(openerNode, closerNode);
+            delimiterProcessor.process(openerNode, closerNode, useDelims);
+
+            // No delimiter characters left to process, so we can remove delimiter and the now empty node.
+            if (opener.length == 0)
+            {
+                removeDelimiterAndNode(opener);
+            }
+
+            if (closer.length == 0)
+            {
+                Delimiter next = closer.next;
+                removeDelimiterAndNode(closer);
+                closer = next;
+            }
+        }
+
+        // remove all delimiters
+        while (lastDelimiter != null && lastDelimiter != stackBottom)
+        {
+            removeDelimiterKeepNode(lastDelimiter);
+        }
+    }
+
+    private void removeDelimitersBetween(Delimiter opener, Delimiter closer)
+    {
+        Delimiter delimiter = closer.previous;
+        while (delimiter != null && delimiter != opener)
+        {
+            Delimiter previousDelimiter = delimiter.previous;
+            removeDelimiterKeepNode(delimiter);
+            delimiter = previousDelimiter;
+        }
+    }
+
+    /**
+     * Remove the delimiter and the corresponding text node. For used delimiters, e.g. `*` in `*foo*`.
+     */
+    private void removeDelimiterAndNode(Delimiter delim)
+    {
+        Text node = delim.node;
+        node.unlink();
+        removeDelimiter(delim);
+    }
+
+    /**
+     * Remove the delimiter but keep the corresponding node as text. For unused delimiters such as `_` in `foo_bar`.
+     */
+    private void removeDelimiterKeepNode(Delimiter delim)
+    {
+        removeDelimiter(delim);
+    }
+
+    private void removeDelimiter(Delimiter delim)
+    {
+        if (delim.previous != null)
+        {
+            delim.previous.next = delim.next;
+        }
+        if (delim.next == null)
+        {
+            // top of stack
+            lastDelimiter = delim.previous;
+        } else
+        {
+            delim.next.previous = delim.previous;
+        }
+    }
+
     @SuppressWarnings("unused")
-    public interface FactoryBuilder {
+    public interface FactoryBuilder
+    {
 
         /**
          * @see InlineProcessor
@@ -71,7 +778,8 @@ public class StylarInlineParser implements InlineParser, StylarInlineParserConte
         InlineParserFactory build();
     }
 
-    public interface FactoryBuilderNoDefaults extends FactoryBuilder {
+    public interface FactoryBuilderNoDefaults extends FactoryBuilder
+    {
         /**
          * Includes all default delimiter and inline processors, and sets {@code referencesEnabled=true}.
          * Useful with subsequent calls to {@link #excludeInlineProcessor(Class)} or {@link #excludeDelimiterProcessor(Class)}
@@ -80,637 +788,23 @@ public class StylarInlineParser implements InlineParser, StylarInlineParserConte
         FactoryBuilder includeDefaults();
     }
 
-    /**
-     * Creates an instance of {@link FactoryBuilder} and includes all defaults.
-     *
-     * @see #factoryBuilderNoDefaults()
-     */
-    @NonNull
-    public static FactoryBuilder factoryBuilder() {
-        return new FactoryBuilderImpl().includeDefaults();
-    }
-
-    /**
-     * NB, this return an <em>empty</em> builder, so if no {@link FactoryBuilderNoDefaults#includeDefaults()}
-     * is called, it means effectively <strong>no inline parsing</strong> (unless further calls
-     * to {@link FactoryBuilder#addInlineProcessor(InlineProcessor)} or {@link FactoryBuilder#addDelimiterProcessor(DelimiterProcessor)}).
-     */
-    @NonNull
-    public static FactoryBuilderNoDefaults factoryBuilderNoDefaults() {
-        return new FactoryBuilderImpl();
-    }
-
-    private static final String ASCII_PUNCTUATION = "!\"#\\$%&'\\(\\)\\*\\+,\\-\\./:;<=>\\?@\\[\\\\\\]\\^_`\\{\\|\\}~";
-    private static final Pattern PUNCTUATION = Pattern
-            .compile("^[" + ASCII_PUNCTUATION + "\\p{Pc}\\p{Pd}\\p{Pe}\\p{Pf}\\p{Pi}\\p{Po}\\p{Ps}]");
-
-    private static final Pattern SPNL = Pattern.compile("^ *(?:\n *)?");
-
-    private static final Pattern UNICODE_WHITESPACE_CHAR = Pattern.compile("^[\\p{Zs}\t\r\n\f]");
-
-    static final Pattern ESCAPABLE = Pattern.compile('^' + Escaping.ESCAPABLE);
-    static final Pattern WHITESPACE = Pattern.compile("\\s+");
-
-    private final InlineParserContext inlineParserContext;
-
-    private final boolean referencesEnabled;
-
-    private final BitSet specialCharacters;
-    private final Map<Character, List<InlineProcessor>> inlineProcessors;
-    private final Map<Character, DelimiterProcessor> delimiterProcessors;
-
-    // currently we still hold a reference to it because we decided not to
-    //  pass previous node argument to inline-processors (current usage is limited with NewLineInlineProcessor)
-    private Node block;
-    private String input;
-    private int index;
-
-    /**
-     * Top delimiter (emphasis, strong emphasis or custom emphasis). (Brackets are on a separate stack, different
-     * from the algorithm described in the spec.)
-     */
-    private Delimiter lastDelimiter;
-
-    /**
-     * Top opening bracket (<code>[</code> or <code>![)</code>).
-     */
-    private Bracket lastBracket;
-
-    // might we construct these in factory?
-    public StylarInlineParser(
-            @NonNull InlineParserContext inlineParserContext,
-            boolean referencesEnabled,
-            @NonNull List<InlineProcessor> inlineProcessors,
-            @NonNull List<DelimiterProcessor> delimiterProcessors) {
-        this.inlineParserContext = inlineParserContext;
-        this.referencesEnabled = referencesEnabled;
-        this.inlineProcessors = calculateInlines(inlineProcessors);
-        this.delimiterProcessors = calculateDelimiterProcessors(delimiterProcessors);
-        this.specialCharacters = calculateSpecialCharacters(
-                this.inlineProcessors.keySet(),
-                this.delimiterProcessors.keySet());
-    }
-
-    @NonNull
-    private static Map<Character, List<InlineProcessor>> calculateInlines(@NonNull List<InlineProcessor> inlines) {
-        final Map<Character, List<InlineProcessor>> map = new HashMap<>(inlines.size());
-        List<InlineProcessor> list;
-        for (InlineProcessor inlineProcessor : inlines) {
-            final char character = inlineProcessor.specialCharacter();
-            list = map.get(character);
-            if (list == null) {
-                list = new ArrayList<>(1);
-                map.put(character, list);
-            }
-            list.add(inlineProcessor);
-        }
-        return map;
-    }
-
-    @NonNull
-    private static BitSet calculateSpecialCharacters(Set<Character> inlineCharacters, Set<Character> delimiterCharacters) {
-        final BitSet bitSet = new BitSet();
-        for (Character c : inlineCharacters) {
-            bitSet.set(c);
-        }
-        for (Character c : delimiterCharacters) {
-            bitSet.set(c);
-        }
-        return bitSet;
-    }
-
-    private static Map<Character, DelimiterProcessor> calculateDelimiterProcessors(List<DelimiterProcessor> delimiterProcessors) {
-        Map<Character, DelimiterProcessor> map = new HashMap<>();
-        addDelimiterProcessors(delimiterProcessors, map);
-        return map;
-    }
-
-    private static void addDelimiterProcessors(Iterable<DelimiterProcessor> delimiterProcessors, Map<Character, DelimiterProcessor> map) {
-        for (DelimiterProcessor delimiterProcessor : delimiterProcessors) {
-            char opening = delimiterProcessor.getOpeningCharacter();
-            char closing = delimiterProcessor.getClosingCharacter();
-            if (opening == closing) {
-                DelimiterProcessor old = map.get(opening);
-                if (old != null && old.getOpeningCharacter() == old.getClosingCharacter()) {
-                    StaggeredDelimiterProcessor s;
-                    if (old instanceof StaggeredDelimiterProcessor) {
-                        s = (StaggeredDelimiterProcessor) old;
-                    } else {
-                        s = new StaggeredDelimiterProcessor(opening);
-                        s.add(old);
-                    }
-                    s.add(delimiterProcessor);
-                    map.put(opening, s);
-                } else {
-                    addDelimiterProcessorForChar(opening, delimiterProcessor, map);
-                }
-            } else {
-                addDelimiterProcessorForChar(opening, delimiterProcessor, map);
-                addDelimiterProcessorForChar(closing, delimiterProcessor, map);
-            }
-        }
-    }
-
-    private static void addDelimiterProcessorForChar(char delimiterChar, DelimiterProcessor toAdd, Map<Character, DelimiterProcessor> delimiterProcessors) {
-        DelimiterProcessor existing = delimiterProcessors.put(delimiterChar, toAdd);
-        if (existing != null) {
-            throw new IllegalArgumentException("Delimiter processor conflict with delimiter char '" + delimiterChar + "'");
-        }
-    }
-
-    /**
-     * Parse content in block into inline children, using reference map to resolve references.
-     */
-    @Override
-    public void parse(String content, Node block) {
-        reset(content.trim());
-
-        // we still reference it
-        this.block = block;
-
-        while (true) {
-            Node node = parseInline();
-            if (node != null) {
-                block.appendChild(node);
-            } else {
-                break;
-            }
-        }
-
-        processDelimiters(null);
-        mergeChildTextNodes(block);
-    }
-
-    private void reset(String content) {
-        this.input = content;
-        this.index = 0;
-        this.lastDelimiter = null;
-        this.lastBracket = null;
-    }
-
-    /**
-     * Parse the next inline element in subject, advancing input index.
-     * On success, add the result to block's children and return true.
-     * On failure, return false.
-     */
-    @Nullable
-    private Node parseInline() {
-
-        final char c = peek();
-
-        if (c == '\0') {
-            return null;
-        }
-
-        Node node = null;
-
-        final List<InlineProcessor> inlines = this.inlineProcessors.get(c);
-
-        if (inlines != null) {
-            // @since 4.6.0 index must not be advanced if inline-processor returned null
-            //  so, further processors can be called at the _same_ position (and thus char)
-            final int startIndex = index;
-
-            for (InlineProcessor inline : inlines) {
-                node = inline.parse(this);
-                if (node != null) {
-                    break;
-                }
-
-                // reset after each iteration (happens only when node is null)
-                index = startIndex;
-            }
-        } else {
-            final DelimiterProcessor delimiterProcessor = delimiterProcessors.get(c);
-            if (delimiterProcessor != null) {
-                node = parseDelimiters(delimiterProcessor, c);
-            } else {
-                node = parseString();
-            }
-        }
-
-        if (node != null) {
-            return node;
-        } else {
-            index++;
-            // When we get here, it's only for a single special character that turned out to not have a special meaning.
-            // So we shouldn't have a single surrogate here, hence it should be ok to turn it into a String.
-            String literal = String.valueOf(c);
-            return text(literal);
-        }
-    }
-
-    /**
-     * If RE matches at current index in the input, advance index and return the match; otherwise return null.
-     */
-    @Override
-    @Nullable
-    public String match(@NonNull Pattern re) {
-        if (index >= input.length()) {
-            return null;
-        }
-        Matcher matcher = re.matcher(input);
-        matcher.region(index, input.length());
-        boolean m = matcher.find();
-        if (m) {
-            index = matcher.end();
-            return matcher.group();
-        } else {
-            return null;
-        }
-    }
-
-    @NonNull
-    @Override
-    public Text text(@NonNull String text) {
-        return new Text(text);
-    }
-
-    @NonNull
-    @Override
-    public Text text(@NonNull String text, int beginIndex, int endIndex) {
-        return new Text(text.substring(beginIndex, endIndex));
-    }
-
-    @Nullable
-    @Override
-    public LinkReferenceDefinition getLinkReferenceDefinition(String label) {
-        return referencesEnabled
-                ? inlineParserContext.getLinkReferenceDefinition(label)
-                : null;
-    }
-
-    /**
-     * Returns the char at the current input index, or {@code '\0'} in case there are no more characters.
-     */
-    @Override
-    public char peek() {
-        if (index < input.length()) {
-            return input.charAt(index);
-        } else {
-            return '\0';
-        }
-    }
-
-    @NonNull
-    @Override
-    public Node block() {
-        return block;
-    }
-
-    @NonNull
-    @Override
-    public String input() {
-        return input;
-    }
-
-    @Override
-    public int index() {
-        return index;
-    }
-
-    @Override
-    public void setIndex(int index) {
-        this.index = index;
-    }
-
-    @Override
-    public Bracket lastBracket() {
-        return lastBracket;
-    }
-
-    @Override
-    public Delimiter lastDelimiter() {
-        return lastDelimiter;
-    }
-
-    @Override
-    public void addBracket(Bracket bracket) {
-        if (lastBracket != null) {
-            lastBracket.bracketAfter = true;
-        }
-        lastBracket = bracket;
-    }
-
-    @Override
-    public void removeLastBracket() {
-        lastBracket = lastBracket.previous;
-    }
-
-    /**
-     * Parse zero or more space characters, including at most one newline.
-     */
-    @Override
-    public void spnl() {
-        match(SPNL);
-    }
-
-    /**
-     * Attempt to parse delimiters like emphasis, strong emphasis or custom delimiters.
-     */
-    @Nullable
-    private Node parseDelimiters(DelimiterProcessor delimiterProcessor, char delimiterChar) {
-        DelimiterData res = scanDelimiters(delimiterProcessor, delimiterChar);
-        if (res == null) {
-            return null;
-        }
-        int length = res.count;
-        int startIndex = index;
-
-        index += length;
-        Text node = text(input, startIndex, index);
-
-        // Add entry to stack for this opener
-        lastDelimiter = new Delimiter(node, delimiterChar, res.canOpen, res.canClose, lastDelimiter);
-        lastDelimiter.length = length;
-        lastDelimiter.originalLength = length;
-        if (lastDelimiter.previous != null) {
-            lastDelimiter.previous.next = lastDelimiter;
-        }
-
-        return node;
-    }
-
-    /**
-     * Attempt to parse link destination, returning the string or null if no match.
-     */
-    @Override
-    @Nullable
-    public String parseLinkDestination() {
-        int afterDest = LinkScanner.scanLinkDestination(input, index);
-        if (afterDest == -1) {
-            return null;
-        }
-
-        String dest;
-        if (peek() == '<') {
-            // chop off surrounding <..>:
-            dest = input.substring(index + 1, afterDest - 1);
-        } else {
-            dest = input.substring(index, afterDest);
-        }
-
-        index = afterDest;
-        return Escaping.unescapeString(dest);
-    }
-
-    /**
-     * Attempt to parse link title (sans quotes), returning the string or null if no match.
-     */
-    @Override
-    @Nullable
-    public String parseLinkTitle() {
-        int afterTitle = LinkScanner.scanLinkTitle(input, index);
-        if (afterTitle == -1) {
-            return null;
-        }
-
-        // chop off ', " or parens
-        String title = input.substring(index + 1, afterTitle - 1);
-        index = afterTitle;
-        return Escaping.unescapeString(title);
-    }
-
-    /**
-     * Attempt to parse a link label, returning number of characters parsed.
-     */
-    @Override
-    public int parseLinkLabel() {
-        if (index >= input.length() || input.charAt(index) != '[') {
-            return 0;
-        }
-
-        int startContent = index + 1;
-        int endContent = LinkScanner.scanLinkLabelContent(input, startContent);
-        // spec: A link label can have at most 999 characters inside the square brackets.
-        int contentLength = endContent - startContent;
-        if (endContent == -1 || contentLength > 999) {
-            return 0;
-        }
-        if (endContent >= input.length() || input.charAt(endContent) != ']') {
-            return 0;
-        }
-        index = endContent + 1;
-        return contentLength + 2;
-    }
-
-    /**
-     * Parse a run of ordinary characters, or a single character with a special meaning in markdown, as a plain string.
-     */
-    private Node parseString() {
-        int begin = index;
-        int length = input.length();
-        while (index != length) {
-            if (specialCharacters.get(input.charAt(index))) {
-                break;
-            }
-            index++;
-        }
-        if (begin != index) {
-            return text(input, begin, index);
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Scan a sequence of characters with code delimiterChar, and return information about the number of delimiters
-     * and whether they are positioned such that they can open and/or close emphasis or strong emphasis.
-     *
-     * @return information about delimiter run, or {@code null}
-     */
-    private DelimiterData scanDelimiters(DelimiterProcessor delimiterProcessor, char delimiterChar) {
-        int startIndex = index;
-
-        int delimiterCount = 0;
-        while (peek() == delimiterChar) {
-            delimiterCount++;
-            index++;
-        }
-
-        if (delimiterCount < delimiterProcessor.getMinLength()) {
-            index = startIndex;
-            return null;
-        }
-
-        String before = startIndex == 0 ? "\n" :
-                input.substring(startIndex - 1, startIndex);
-
-        char charAfter = peek();
-        String after = charAfter == '\0' ? "\n" :
-                String.valueOf(charAfter);
-
-        // We could be more lazy here, in most cases we don't need to do every match case.
-        boolean beforeIsPunctuation = PUNCTUATION.matcher(before).matches();
-        boolean beforeIsWhitespace = UNICODE_WHITESPACE_CHAR.matcher(before).matches();
-        boolean afterIsPunctuation = PUNCTUATION.matcher(after).matches();
-        boolean afterIsWhitespace = UNICODE_WHITESPACE_CHAR.matcher(after).matches();
-
-        boolean leftFlanking = !afterIsWhitespace &&
-                (!afterIsPunctuation || beforeIsWhitespace || beforeIsPunctuation);
-        boolean rightFlanking = !beforeIsWhitespace &&
-                (!beforeIsPunctuation || afterIsWhitespace || afterIsPunctuation);
-        boolean canOpen;
-        boolean canClose;
-        if (delimiterChar == '_') {
-            canOpen = leftFlanking && (!rightFlanking || beforeIsPunctuation);
-            canClose = rightFlanking && (!leftFlanking || afterIsPunctuation);
-        } else {
-            canOpen = leftFlanking && delimiterChar == delimiterProcessor.getOpeningCharacter();
-            canClose = rightFlanking && delimiterChar == delimiterProcessor.getClosingCharacter();
-        }
-
-        index = startIndex;
-        return new DelimiterData(delimiterCount, canOpen, canClose);
-    }
-
-    @Override
-    public void processDelimiters(Delimiter stackBottom) {
-
-        Map<Character, Delimiter> openersBottom = new HashMap<>();
-
-        // find first closer above stackBottom:
-        Delimiter closer = lastDelimiter;
-        while (closer != null && closer.previous != stackBottom) {
-            closer = closer.previous;
-        }
-        // move forward, looking for closers, and handling each
-        while (closer != null) {
-            char delimiterChar = closer.delimiterChar;
-
-            DelimiterProcessor delimiterProcessor = delimiterProcessors.get(delimiterChar);
-            if (!closer.canClose || delimiterProcessor == null) {
-                closer = closer.next;
-                continue;
-            }
-
-            char openingDelimiterChar = delimiterProcessor.getOpeningCharacter();
-
-            // Found delimiter closer. Now look back for first matching opener.
-            int useDelims = 0;
-            boolean openerFound = false;
-            boolean potentialOpenerFound = false;
-            Delimiter opener = closer.previous;
-            while (opener != null && opener != stackBottom && opener != openersBottom.get(delimiterChar)) {
-                if (opener.canOpen && opener.delimiterChar == openingDelimiterChar) {
-                    potentialOpenerFound = true;
-                    useDelims = delimiterProcessor.getDelimiterUse(opener, closer);
-                    if (useDelims > 0) {
-                        openerFound = true;
-                        break;
-                    }
-                }
-                opener = opener.previous;
-            }
-
-            if (!openerFound) {
-                if (!potentialOpenerFound) {
-                    // Set lower bound for future searches for openers.
-                    // Only do this when we didn't even have a potential
-                    // opener (one that matches the character and can open).
-                    // If an opener was rejected because of the number of
-                    // delimiters (e.g. because of the "multiple of 3" rule),
-                    // we want to consider it next time because the number
-                    // of delimiters can change as we continue processing.
-                    openersBottom.put(delimiterChar, closer.previous);
-                    if (!closer.canOpen) {
-                        // We can remove a closer that can't be an opener,
-                        // once we've seen there's no matching opener:
-                        removeDelimiterKeepNode(closer);
-                    }
-                }
-                closer = closer.next;
-                continue;
-            }
-
-            Text openerNode = opener.node;
-            Text closerNode = closer.node;
-
-            // Remove number of used delimiters from stack and inline nodes.
-            opener.length -= useDelims;
-            closer.length -= useDelims;
-            openerNode.setLiteral(
-                    openerNode.getLiteral().substring(0,
-                            openerNode.getLiteral().length() - useDelims));
-            closerNode.setLiteral(
-                    closerNode.getLiteral().substring(0,
-                            closerNode.getLiteral().length() - useDelims));
-
-            removeDelimitersBetween(opener, closer);
-            // The delimiter processor can re-parent the nodes between opener and closer,
-            // so make sure they're contiguous already. Exclusive because we want to keep opener/closer themselves.
-            mergeTextNodesBetweenExclusive(openerNode, closerNode);
-            delimiterProcessor.process(openerNode, closerNode, useDelims);
-
-            // No delimiter characters left to process, so we can remove delimiter and the now empty node.
-            if (opener.length == 0) {
-                removeDelimiterAndNode(opener);
-            }
-
-            if (closer.length == 0) {
-                Delimiter next = closer.next;
-                removeDelimiterAndNode(closer);
-                closer = next;
-            }
-        }
-
-        // remove all delimiters
-        while (lastDelimiter != null && lastDelimiter != stackBottom) {
-            removeDelimiterKeepNode(lastDelimiter);
-        }
-    }
-
-    private void removeDelimitersBetween(Delimiter opener, Delimiter closer) {
-        Delimiter delimiter = closer.previous;
-        while (delimiter != null && delimiter != opener) {
-            Delimiter previousDelimiter = delimiter.previous;
-            removeDelimiterKeepNode(delimiter);
-            delimiter = previousDelimiter;
-        }
-    }
-
-    /**
-     * Remove the delimiter and the corresponding text node. For used delimiters, e.g. `*` in `*foo*`.
-     */
-    private void removeDelimiterAndNode(Delimiter delim) {
-        Text node = delim.node;
-        node.unlink();
-        removeDelimiter(delim);
-    }
-
-    /**
-     * Remove the delimiter but keep the corresponding node as text. For unused delimiters such as `_` in `foo_bar`.
-     */
-    private void removeDelimiterKeepNode(Delimiter delim) {
-        removeDelimiter(delim);
-    }
-
-    private void removeDelimiter(Delimiter delim) {
-        if (delim.previous != null) {
-            delim.previous.next = delim.next;
-        }
-        if (delim.next == null) {
-            // top of stack
-            lastDelimiter = delim.previous;
-        } else {
-            delim.next.previous = delim.previous;
-        }
-    }
-
-    private static class DelimiterData {
+    private static class DelimiterData
+    {
 
         final int count;
         final boolean canClose;
         final boolean canOpen;
 
-        DelimiterData(int count, boolean canOpen, boolean canClose) {
+        DelimiterData(int count, boolean canOpen, boolean canClose)
+        {
             this.count = count;
             this.canOpen = canOpen;
             this.canClose = canClose;
         }
     }
 
-    static class FactoryBuilderImpl implements FactoryBuilder, FactoryBuilderNoDefaults {
+    static class FactoryBuilderImpl implements FactoryBuilder, FactoryBuilderNoDefaults
+    {
 
         private final List<InlineProcessor> inlineProcessors = new ArrayList<>(3);
         private final List<DelimiterProcessor> delimiterProcessors = new ArrayList<>(3);
@@ -718,55 +812,62 @@ public class StylarInlineParser implements InlineParser, StylarInlineParserConte
 
         @NonNull
         @Override
-        public FactoryBuilder addInlineProcessor(@NonNull InlineProcessor processor) {
+        public FactoryBuilder addInlineProcessor(@NonNull InlineProcessor processor)
+        {
             this.inlineProcessors.add(processor);
             return this;
         }
 
         @NonNull
         @Override
-        public FactoryBuilder addDelimiterProcessor(@NonNull DelimiterProcessor processor) {
+        public FactoryBuilder addDelimiterProcessor(@NonNull DelimiterProcessor processor)
+        {
             this.delimiterProcessors.add(processor);
             return this;
         }
 
         @NonNull
         @Override
-        public FactoryBuilder referencesEnabled(boolean referencesEnabled) {
+        public FactoryBuilder referencesEnabled(boolean referencesEnabled)
+        {
             this.referencesEnabled = referencesEnabled;
             return this;
         }
 
         @NonNull
         @Override
-        public FactoryBuilder includeDefaults() {
+        public FactoryBuilder includeDefaults()
+        {
 
             // by default enabled
             this.referencesEnabled = true;
 
             this.inlineProcessors.addAll(Arrays.asList(
-                    new AutolinkInlineProcessor(),
-                    new BackslashInlineProcessor(),
-                    new BackticksInlineProcessor(),
-                    new BangInlineProcessor(),
-                    new CloseBracketInlineProcessor(),
-                    new EntityInlineProcessor(),
-                    new HtmlInlineProcessor(),
-                    new NewLineInlineProcessor(),
-                    new OpenBracketInlineProcessor()));
+                new AutolinkInlineProcessor(),
+                new BackslashInlineProcessor(),
+                new BackticksInlineProcessor(),
+                new BangInlineProcessor(),
+                new CloseBracketInlineProcessor(),
+                new EntityInlineProcessor(),
+                new HtmlInlineProcessor(),
+                new NewLineInlineProcessor(),
+                new OpenBracketInlineProcessor()));
 
             this.delimiterProcessors.addAll(Arrays.asList(
-                    new AsteriskDelimiterProcessor(),
-                    new UnderscoreDelimiterProcessor()));
+                new AsteriskDelimiterProcessor(),
+                new UnderscoreDelimiterProcessor()));
 
             return this;
         }
 
         @NonNull
         @Override
-        public FactoryBuilder excludeInlineProcessor(@NonNull Class<? extends InlineProcessor> type) {
-            for (int i = 0, size = inlineProcessors.size(); i < size; i++) {
-                if (type.equals(inlineProcessors.get(i).getClass())) {
+        public FactoryBuilder excludeInlineProcessor(@NonNull Class<? extends InlineProcessor> type)
+        {
+            for (int i = 0, size = inlineProcessors.size(); i < size; i++)
+            {
+                if (type.equals(inlineProcessors.get(i).getClass()))
+                {
                     inlineProcessors.remove(i);
                     break;
                 }
@@ -776,9 +877,12 @@ public class StylarInlineParser implements InlineParser, StylarInlineParserConte
 
         @NonNull
         @Override
-        public FactoryBuilder excludeDelimiterProcessor(@NonNull Class<? extends DelimiterProcessor> type) {
-            for (int i = 0, size = delimiterProcessors.size(); i < size; i++) {
-                if (type.equals(delimiterProcessors.get(i).getClass())) {
+        public FactoryBuilder excludeDelimiterProcessor(@NonNull Class<? extends DelimiterProcessor> type)
+        {
+            for (int i = 0, size = delimiterProcessors.size(); i < size; i++)
+            {
+                if (type.equals(delimiterProcessors.get(i).getClass()))
+                {
                     delimiterProcessors.remove(i);
                     break;
                 }
@@ -788,45 +892,51 @@ public class StylarInlineParser implements InlineParser, StylarInlineParserConte
 
         @NonNull
         @Override
-        public InlineParserFactory build() {
+        public InlineParserFactory build()
+        {
             return new InlineParserFactoryImpl(referencesEnabled, inlineProcessors, delimiterProcessors);
         }
     }
 
-    static class InlineParserFactoryImpl implements InlineParserFactory {
+    static class InlineParserFactoryImpl implements InlineParserFactory
+    {
 
         private final boolean referencesEnabled;
         private final List<InlineProcessor> inlineProcessors;
         private final List<DelimiterProcessor> delimiterProcessors;
 
         InlineParserFactoryImpl(
-                boolean referencesEnabled,
-                @NonNull List<InlineProcessor> inlineProcessors,
-                @NonNull List<DelimiterProcessor> delimiterProcessors) {
+            boolean referencesEnabled,
+            @NonNull List<InlineProcessor> inlineProcessors,
+            @NonNull List<DelimiterProcessor> delimiterProcessors)
+        {
             this.referencesEnabled = referencesEnabled;
             this.inlineProcessors = inlineProcessors;
             this.delimiterProcessors = delimiterProcessors;
         }
 
         @Override
-        public InlineParser create(InlineParserContext inlineParserContext) {
+        public InlineParser create(InlineParserContext inlineParserContext)
+        {
             final List<DelimiterProcessor> delimiterProcessors;
             final List<DelimiterProcessor> customDelimiterProcessors = inlineParserContext.getCustomDelimiterProcessors();
             final int size = customDelimiterProcessors != null
-                    ? customDelimiterProcessors.size()
-                    : 0;
-            if (size > 0) {
+                ? customDelimiterProcessors.size()
+                : 0;
+            if (size > 0)
+            {
                 delimiterProcessors = new ArrayList<>(size + this.delimiterProcessors.size());
                 delimiterProcessors.addAll(this.delimiterProcessors);
                 delimiterProcessors.addAll(customDelimiterProcessors);
-            } else {
+            } else
+            {
                 delimiterProcessors = this.delimiterProcessors;
             }
             return new StylarInlineParser(
-                    inlineParserContext,
-                    referencesEnabled,
-                    inlineProcessors,
-                    delimiterProcessors);
+                inlineParserContext,
+                referencesEnabled,
+                inlineProcessors,
+                delimiterProcessors);
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/inlineparser/StylarInlineParserPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/inlineparser/StylarInlineParserPlugin.java
@@ -12,49 +12,57 @@ import org.commonmark.parser.Parser;
 public class StylarInlineParserPlugin extends AbstractStylarPlugin
 {
 
-    public interface BuilderConfigure<B extends StylarInlineParser.FactoryBuilder> {
-        void configureBuilder(@NonNull B factoryBuilder);
+    private final StylarInlineParser.FactoryBuilder factoryBuilder;
+
+    @SuppressWarnings("WeakerAccess")
+    StylarInlineParserPlugin(@NonNull StylarInlineParser.FactoryBuilder factoryBuilder)
+    {
+        this.factoryBuilder = factoryBuilder;
     }
 
     @NonNull
-    public static StylarInlineParserPlugin create() {
+    public static StylarInlineParserPlugin create()
+    {
         return create(StylarInlineParser.factoryBuilder());
     }
 
     @NonNull
-    public static StylarInlineParserPlugin create(@NonNull BuilderConfigure<StylarInlineParser.FactoryBuilder> configure) {
+    public static StylarInlineParserPlugin create(@NonNull BuilderConfigure<StylarInlineParser.FactoryBuilder> configure)
+    {
         final StylarInlineParser.FactoryBuilder factoryBuilder = StylarInlineParser.factoryBuilder();
         configure.configureBuilder(factoryBuilder);
         return new StylarInlineParserPlugin(factoryBuilder);
     }
 
     @NonNull
-    public static StylarInlineParserPlugin create(@NonNull StylarInlineParser.FactoryBuilder factoryBuilder) {
+    public static StylarInlineParserPlugin create(@NonNull StylarInlineParser.FactoryBuilder factoryBuilder)
+    {
         return new StylarInlineParserPlugin(factoryBuilder);
     }
 
     @NonNull
     public static <B extends StylarInlineParser.FactoryBuilder> StylarInlineParserPlugin create(
-            @NonNull B factoryBuilder,
-            @NonNull BuilderConfigure<B> configure) {
+        @NonNull B factoryBuilder,
+        @NonNull BuilderConfigure<B> configure)
+    {
         configure.configureBuilder(factoryBuilder);
         return new StylarInlineParserPlugin(factoryBuilder);
     }
 
-    private final StylarInlineParser.FactoryBuilder factoryBuilder;
-
-    @SuppressWarnings("WeakerAccess")
-    StylarInlineParserPlugin(@NonNull StylarInlineParser.FactoryBuilder factoryBuilder) {
-        this.factoryBuilder = factoryBuilder;
-    }
-
     @Override
-    public void configureParser(@NonNull Parser.Builder builder) {
+    public void configureParser(@NonNull Parser.Builder builder)
+    {
         builder.inlineParserFactory(factoryBuilder.build());
     }
 
     @NonNull
-    public StylarInlineParser.FactoryBuilder factoryBuilder() {
+    public StylarInlineParser.FactoryBuilder factoryBuilder()
+    {
         return factoryBuilder;
+    }
+
+    public interface BuilderConfigure<B extends StylarInlineParser.FactoryBuilder>
+    {
+        void configureBuilder(@NonNull B factoryBuilder);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/movement/MovementMethodPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/movement/MovementMethodPlugin.java
@@ -17,6 +17,18 @@ import com.zeoflow.stylar.core.CorePlugin;
 public class MovementMethodPlugin extends AbstractStylarPlugin
 {
 
+    @Nullable
+    private final MovementMethod movementMethod;
+
+    /**
+     * Since 4.5.0 change to be <em>nullable</em>
+     */
+    @SuppressWarnings("WeakerAccess")
+    MovementMethodPlugin(@Nullable MovementMethod movementMethod)
+    {
+        this.movementMethod = movementMethod;
+    }
+
     /**
      * Creates plugin that will ensure that there is movement method registered on a TextView.
      * Uses Android system LinkMovementMethod as default
@@ -27,7 +39,8 @@ public class MovementMethodPlugin extends AbstractStylarPlugin
      */
     @NonNull
     @Deprecated
-    public static MovementMethodPlugin create() {
+    public static MovementMethodPlugin create()
+    {
         return create(LinkMovementMethod.getInstance());
     }
 
@@ -35,7 +48,8 @@ public class MovementMethodPlugin extends AbstractStylarPlugin
      * @since 4.5.0
      */
     @NonNull
-    public static MovementMethodPlugin link() {
+    public static MovementMethodPlugin link()
+    {
         return create(LinkMovementMethod.getInstance());
     }
 
@@ -46,37 +60,31 @@ public class MovementMethodPlugin extends AbstractStylarPlugin
      * @since 4.5.0
      */
     @NonNull
-    public static MovementMethodPlugin none() {
+    public static MovementMethodPlugin none()
+    {
         return new MovementMethodPlugin(null);
     }
 
     @NonNull
-    public static MovementMethodPlugin create(@NonNull MovementMethod movementMethod) {
+    public static MovementMethodPlugin create(@NonNull MovementMethod movementMethod)
+    {
         return new MovementMethodPlugin(movementMethod);
     }
 
-    @Nullable
-    private final MovementMethod movementMethod;
-
-    /**
-     * Since 4.5.0 change to be <em>nullable</em>
-     */
-    @SuppressWarnings("WeakerAccess")
-    MovementMethodPlugin(@Nullable MovementMethod movementMethod) {
-        this.movementMethod = movementMethod;
-    }
-
     @Override
-    public void configure(@NonNull Registry registry) {
+    public void configure(@NonNull Registry registry)
+    {
         registry.require(CorePlugin.class)
-                .hasExplicitMovementMethod(true);
+            .hasExplicitMovementMethod(true);
     }
 
     @Override
-    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown) {
+    public void beforeSetText(@NonNull TextView textView, @NonNull Spanned markdown)
+    {
         // @since 4.5.0 check for equality
         final MovementMethod current = textView.getMovementMethod();
-        if (current != movementMethod) {
+        if (current != movementMethod)
+        {
             textView.setMovementMethod(movementMethod);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/plugins/AnchorHeadingPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/plugins/AnchorHeadingPlugin.java
@@ -3,7 +3,6 @@ package com.zeoflow.stylar.plugins;
 import android.graphics.Color;
 import android.text.Spannable;
 import android.text.Spanned;
-import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
@@ -18,11 +17,7 @@ import com.zeoflow.stylar.core.spans.HeadingSpan;
 
 public class AnchorHeadingPlugin extends AbstractStylarPlugin
 {
-    public interface ScrollTo
-    {
-        void scrollTo(@NonNull TextView view, int top);
-    }
-
+    private static ClickEvent clickEvent;
     private final AnchorHeadingPlugin.ScrollTo scrollTo;
 
     public AnchorHeadingPlugin(@NonNull AnchorHeadingPlugin.ScrollTo scrollTo)
@@ -30,8 +25,16 @@ public class AnchorHeadingPlugin extends AbstractStylarPlugin
         this.scrollTo = scrollTo;
     }
 
-    private static ClickEvent clickEvent;
-    public AbstractStylarPlugin withClickEvent(ClickEvent clickEventN) {
+    @NonNull
+    public static String createAnchor(@NonNull CharSequence content)
+    {
+        return String.valueOf(content)
+            .replaceAll("[^\\w]", "")
+            .toLowerCase();
+    }
+
+    public AbstractStylarPlugin withClickEvent(ClickEvent clickEventN)
+    {
         clickEvent = clickEventN;
         return this;
     }
@@ -71,6 +74,11 @@ public class AnchorHeadingPlugin extends AbstractStylarPlugin
                 );
             }
         }
+    }
+
+    public interface ScrollTo
+    {
+        void scrollTo(@NonNull TextView view, int top);
     }
 
     private static class AnchorLinkResolver extends LinkResolverDef
@@ -114,7 +122,8 @@ public class AnchorHeadingPlugin extends AbstractStylarPlugin
                 if (spans != null)
                 {
                     final String anchor = link.substring(1);
-                    if (clickEvent != null) {
+                    if (clickEvent != null)
+                    {
                         clickEvent.onClick(anchor);
                     }
                     return;
@@ -132,13 +141,5 @@ public class AnchorHeadingPlugin extends AbstractStylarPlugin
         {
             this.anchor = anchor;
         }
-    }
-
-    @NonNull
-    public static String createAnchor(@NonNull CharSequence content)
-    {
-        return String.valueOf(content)
-            .replaceAll("[^\\w]", "")
-            .toLowerCase();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/plugins/GifGlideStorePlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/plugins/GifGlideStorePlugin.java
@@ -15,31 +15,38 @@ import com.bumptech.glide.request.target.Target;
 import com.zeoflow.stylar.image.AsyncDrawable;
 import com.zeoflow.stylar.image.glide.GlideImagesPlugin;
 
-public class GifGlideStorePlugin implements GlideImagesPlugin.GlideStore {
+public class GifGlideStorePlugin implements GlideImagesPlugin.GlideStore
+{
     private final RequestManager requestManager;
 
-    public GifGlideStorePlugin(RequestManager requestManager) {
+    public GifGlideStorePlugin(RequestManager requestManager)
+    {
         this.requestManager = requestManager;
     }
 
     @NonNull
     @Override
-    public RequestBuilder<Drawable> load(@NonNull AsyncDrawable drawable) {
+    public RequestBuilder<Drawable> load(@NonNull AsyncDrawable drawable)
+    {
         // NB! Strange behaviour: First time a resource is requested - it fails, the next time it loads fine
         final String destination = drawable.getDestination();
         return requestManager
             // it is enough to call this (in order to load GIF and non-GIF)
             .asDrawable()
-            .addListener(new RequestListener<Drawable>() {
+            .addListener(new RequestListener<Drawable>()
+            {
                 @Override
-                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
+                public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource)
+                {
                     return false;
                 }
 
                 @Override
-                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource) {
+                public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target, DataSource dataSource, boolean isFirstResource)
+                {
                     // we must start GIF animation manually
-                    if (resource instanceof Animatable) {
+                    if (resource instanceof Animatable)
+                    {
                         ((Animatable) resource).start();
                     }
                     return false;
@@ -49,7 +56,8 @@ public class GifGlideStorePlugin implements GlideImagesPlugin.GlideStore {
     }
 
     @Override
-    public void cancel(@NonNull Target<?> target) {
+    public void cancel(@NonNull Target<?> target)
+    {
         requestManager.clear(target);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/recycler/SimpleEntry.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/recycler/SimpleEntry.java
@@ -11,55 +11,60 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.Stylar;
+import com.zeoflow.stylar.utils.NoCopySpannableFactory;
 
 import org.commonmark.node.Node;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import com.zeoflow.stylar.utils.NoCopySpannableFactory;
-
 /**
  * @since 3.0.0
  */
 @SuppressWarnings("WeakerAccess")
-public class SimpleEntry extends StylarAdapter.Entry<Node, SimpleEntry.Holder> {
+public class SimpleEntry extends StylarAdapter.Entry<Node, SimpleEntry.Holder>
+{
+
+    // small cache for already rendered nodes
+    private final Map<Node, Spanned> cache = new HashMap<>();
+    private final int layoutResId;
+    private final int textViewIdRes;
+
+    public SimpleEntry(@LayoutRes int layoutResId, @IdRes int textViewIdRes)
+    {
+        this.layoutResId = layoutResId;
+        this.textViewIdRes = textViewIdRes;
+    }
 
     /**
      * Create {@link SimpleEntry} that has TextView as the root view of
      * specified layout.
      */
     @NonNull
-    public static SimpleEntry createTextViewIsRoot(@LayoutRes int layoutResId) {
+    public static SimpleEntry createTextViewIsRoot(@LayoutRes int layoutResId)
+    {
         return new SimpleEntry(layoutResId, 0);
     }
 
     @NonNull
-    public static SimpleEntry create(@LayoutRes int layoutResId, @IdRes int textViewIdRes) {
+    public static SimpleEntry create(@LayoutRes int layoutResId, @IdRes int textViewIdRes)
+    {
         return new SimpleEntry(layoutResId, textViewIdRes);
-    }
-
-    // small cache for already rendered nodes
-    private final Map<Node, Spanned> cache = new HashMap<>();
-
-    private final int layoutResId;
-    private final int textViewIdRes;
-
-    public SimpleEntry(@LayoutRes int layoutResId, @IdRes int textViewIdRes) {
-        this.layoutResId = layoutResId;
-        this.textViewIdRes = textViewIdRes;
     }
 
     @NonNull
     @Override
-    public Holder createHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent) {
+    public Holder createHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent)
+    {
         return new Holder(textViewIdRes, inflater.inflate(layoutResId, parent, false));
     }
 
     @Override
-    public void bindHolder(@NonNull Stylar stylar, @NonNull Holder holder, @NonNull Node node) {
+    public void bindHolder(@NonNull Stylar stylar, @NonNull Holder holder, @NonNull Node node)
+    {
         Spanned spanned = cache.get(node);
-        if (spanned == null) {
+        if (spanned == null)
+        {
             spanned = stylar.render(node);
             cache.put(node, spanned);
         }
@@ -67,25 +72,31 @@ public class SimpleEntry extends StylarAdapter.Entry<Node, SimpleEntry.Holder> {
     }
 
     @Override
-    public void clear() {
+    public void clear()
+    {
         cache.clear();
     }
 
-    public static class Holder extends StylarAdapter.Holder {
+    public static class Holder extends StylarAdapter.Holder
+    {
 
         final TextView textView;
 
-        protected Holder(@IdRes int textViewIdRes, @NonNull View itemView) {
+        protected Holder(@IdRes int textViewIdRes, @NonNull View itemView)
+        {
             super(itemView);
 
             final TextView textView;
-            if (textViewIdRes == 0) {
-                if (!(itemView instanceof TextView)) {
+            if (textViewIdRes == 0)
+            {
+                if (!(itemView instanceof TextView))
+                {
                     throw new IllegalStateException("TextView is not root of layout " +
-                            "(specify TextView ID explicitly): " + itemView);
+                        "(specify TextView ID explicitly): " + itemView);
                 }
                 textView = (TextView) itemView;
-            } else {
+            } else
+            {
                 textView = requireView(textViewIdRes);
             }
             this.textView = textView;

--- a/stylar/src/main/java/com/zeoflow/stylar/recycler/StylarAdapter.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/recycler/StylarAdapter.java
@@ -32,10 +32,12 @@ import java.util.List;
  * @see #setParsedMarkdown(Stylar, List)
  * @since 3.0.0
  */
-public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.Holder> {
+public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.Holder>
+{
 
     @NonNull
-    public static Builder builderTextViewIsRoot(@LayoutRes int defaultEntryLayoutResId) {
+    public static Builder builderTextViewIsRoot(@LayoutRes int defaultEntryLayoutResId)
+    {
         return builder(SimpleEntry.createTextViewIsRoot(defaultEntryLayoutResId));
     }
 
@@ -46,22 +48,25 @@ public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.H
      */
     @NonNull
     public static Builder builder(
-            @LayoutRes int defaultEntryLayoutResId,
-            @IdRes int defaultEntryTextViewResId
-    ) {
+        @LayoutRes int defaultEntryLayoutResId,
+        @IdRes int defaultEntryTextViewResId
+    )
+    {
         return builder(SimpleEntry.create(defaultEntryLayoutResId, defaultEntryTextViewResId));
     }
 
     @NonNull
-    public static Builder builder(@NonNull Entry<? extends Node, ? extends Holder> defaultEntry) {
+    public static Builder builder(@NonNull Entry<? extends Node, ? extends Holder> defaultEntry)
+    {
         //noinspection unchecked
         return new StylarAdapterImpl.BuilderImpl((Entry<Node, Holder>) defaultEntry);
     }
 
     @NonNull
-    public static StylarAdapter createTextViewIsRoot(@LayoutRes int defaultEntryLayoutResId) {
+    public static StylarAdapter createTextViewIsRoot(@LayoutRes int defaultEntryLayoutResId)
+    {
         return builderTextViewIsRoot(defaultEntryLayoutResId)
-                .build();
+            .build();
     }
 
     /**
@@ -75,9 +80,10 @@ public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.H
      */
     @NonNull
     public static StylarAdapter create(
-            @LayoutRes int defaultEntryLayoutResId,
-            @IdRes int defaultEntryTextViewResId
-    ) {
+        @LayoutRes int defaultEntryLayoutResId,
+        @IdRes int defaultEntryTextViewResId
+    )
+    {
         return builder(defaultEntryLayoutResId, defaultEntryTextViewResId).build();
     }
 
@@ -89,9 +95,18 @@ public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.H
      * @see #builder(Entry)
      */
     @NonNull
-    public static StylarAdapter create(@NonNull Entry<? extends Node, ? extends Holder> defaultEntry) {
+    public static StylarAdapter create(@NonNull Entry<? extends Node, ? extends Holder> defaultEntry)
+    {
         return builder(defaultEntry).build();
     }
+
+    public abstract void setMarkdown(@NonNull Stylar stylar, @NonNull String markdown);
+
+    public abstract void setParsedMarkdown(@NonNull Stylar stylar, @NonNull Node document);
+
+    public abstract void setParsedMarkdown(@NonNull Stylar stylar, @NonNull List<Node> nodes);
+
+    public abstract int getNodeViewType(@NonNull Class<? extends Node> node);
 
     /**
      * Builder to create an instance of {@link StylarAdapter}
@@ -100,7 +115,8 @@ public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.H
      * @see #reducer(StylarReducer)
      * @see #build()
      */
-    public interface Builder {
+    public interface Builder
+    {
 
         /**
          * Include a custom {@link Entry} rendering for a Node. Please note that `node` argument
@@ -114,8 +130,8 @@ public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.H
          */
         @NonNull
         <N extends Node> Builder include(
-                @NonNull Class<N> node,
-                @NonNull Entry<? super N, ? extends Holder> entry);
+            @NonNull Class<N> node,
+            @NonNull Entry<? super N, ? extends Holder> entry);
 
         /**
          * Specify how root Node will be <em>reduced</em> to a list of nodes. There is a default
@@ -139,7 +155,8 @@ public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.H
     /**
      * @see SimpleEntry
      */
-    public static abstract class Entry<N extends Node, H extends Holder> {
+    public static abstract class Entry<N extends Node, H extends Holder>
+    {
 
         @NonNull
         public abstract H createHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent);
@@ -149,54 +166,56 @@ public abstract class StylarAdapter extends RecyclerView.Adapter<StylarAdapter.H
         /**
          * Will be called when new content is available (clear internal cache if any)
          */
-        public void clear() {
+        public void clear()
+        {
 
         }
 
-        public long id(@NonNull N node) {
+        public long id(@NonNull N node)
+        {
             return node.hashCode();
         }
 
-        public void onViewRecycled(@NonNull H holder) {
+        public void onViewRecycled(@NonNull H holder)
+        {
 
         }
     }
 
-    public abstract void setMarkdown(@NonNull Stylar stylar, @NonNull String markdown);
-
-    public abstract void setParsedMarkdown(@NonNull Stylar stylar, @NonNull Node document);
-
-    public abstract void setParsedMarkdown(@NonNull Stylar stylar, @NonNull List<Node> nodes);
-
-    public abstract int getNodeViewType(@NonNull Class<? extends Node> node);
-
     @SuppressWarnings("WeakerAccess")
-    public static class Holder extends RecyclerView.ViewHolder {
+    public static class Holder extends RecyclerView.ViewHolder
+    {
 
-        public Holder(@NonNull View itemView) {
+        public Holder(@NonNull View itemView)
+        {
             super(itemView);
         }
 
         // please note that this method should be called after constructor
         @Nullable
-        protected <V extends View> V findView(@IdRes int id) {
+        protected <V extends View> V findView(@IdRes int id)
+        {
             return itemView.findViewById(id);
         }
 
         // please note that this method should be called after constructor
         @NonNull
-        protected <V extends View> V requireView(@IdRes int id) {
+        protected <V extends View> V requireView(@IdRes int id)
+        {
             final V v = itemView.findViewById(id);
-            if (v == null) {
+            if (v == null)
+            {
                 final String name;
                 if (id == 0
-                        || id == View.NO_ID) {
+                    || id == View.NO_ID)
+                {
                     name = String.valueOf(id);
-                } else {
+                } else
+                {
                     name = "R.id." + itemView.getResources().getResourceName(id);
                 }
                 throw new NullPointerException(String.format("No view with id(R.id.%s) is found " +
-                        "in layout: %s", name, itemView));
+                    "in layout: %s", name, itemView));
             }
             return v;
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/recycler/StylarAdapterImpl.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/recycler/StylarAdapterImpl.java
@@ -28,9 +28,10 @@ class StylarAdapterImpl extends StylarAdapter
 
     @SuppressWarnings("WeakerAccess")
     StylarAdapterImpl(
-            @NonNull SparseArray<Entry<Node, Holder>> entries,
-            @NonNull Entry<Node, Holder> defaultEntry,
-            @NonNull StylarReducer reducer) {
+        @NonNull SparseArray<Entry<Node, Holder>> entries,
+        @NonNull Entry<Node, Holder> defaultEntry,
+        @NonNull StylarReducer reducer)
+    {
         this.entries = entries;
         this.defaultEntry = defaultEntry;
         this.reducer = reducer;
@@ -39,22 +40,26 @@ class StylarAdapterImpl extends StylarAdapter
     }
 
     @Override
-    public void setMarkdown(@NonNull Stylar stylar, @NonNull String markdown) {
+    public void setMarkdown(@NonNull Stylar stylar, @NonNull String markdown)
+    {
         setParsedMarkdown(stylar, stylar.parse(markdown));
     }
 
     @Override
-    public void setParsedMarkdown(@NonNull Stylar stylar, @NonNull Node document) {
+    public void setParsedMarkdown(@NonNull Stylar stylar, @NonNull Node document)
+    {
         setParsedMarkdown(stylar, reducer.reduce(document));
     }
 
     @Override
-    public void setParsedMarkdown(@NonNull Stylar stylar, @NonNull List<Node> nodes) {
+    public void setParsedMarkdown(@NonNull Stylar stylar, @NonNull List<Node> nodes)
+    {
         // clear all entries before applying
 
         defaultEntry.clear();
 
-        for (int i = 0, size = entries.size(); i < size; i++) {
+        for (int i = 0, size = entries.size(); i < size; i++)
+        {
             entries.valueAt(i).clear();
         }
 
@@ -64,9 +69,11 @@ class StylarAdapterImpl extends StylarAdapter
 
     @NonNull
     @Override
-    public Holder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+    public Holder onCreateViewHolder(@NonNull ViewGroup parent, int viewType)
+    {
 
-        if (layoutInflater == null) {
+        if (layoutInflater == null)
+        {
             layoutInflater = LayoutInflater.from(parent.getContext());
         }
 
@@ -76,7 +83,8 @@ class StylarAdapterImpl extends StylarAdapter
     }
 
     @Override
-    public void onBindViewHolder(@NonNull Holder holder, int position) {
+    public void onBindViewHolder(@NonNull Holder holder, int position)
+    {
 
         final Node node = nodes.get(position);
         final int viewType = getNodeViewType(node.getClass());
@@ -87,14 +95,16 @@ class StylarAdapterImpl extends StylarAdapter
     }
 
     @Override
-    public int getItemCount() {
+    public int getItemCount()
+    {
         return nodes != null
-                ? nodes.size()
-                : 0;
+            ? nodes.size()
+            : 0;
     }
 
     @Override
-    public void onViewRecycled(@NonNull Holder holder) {
+    public void onViewRecycled(@NonNull Holder holder)
+    {
         super.onViewRecycled(holder);
 
         final Entry<Node, Holder> entry = getEntry(holder.getItemViewType());
@@ -103,19 +113,22 @@ class StylarAdapterImpl extends StylarAdapter
 
     @SuppressWarnings("unused")
     @NonNull
-    public List<Node> getItems() {
+    public List<Node> getItems()
+    {
         return nodes != null
-                ? Collections.unmodifiableList(nodes)
-                : Collections.<Node>emptyList();
+            ? Collections.unmodifiableList(nodes)
+            : Collections.<Node>emptyList();
     }
 
     @Override
-    public int getItemViewType(int position) {
+    public int getItemViewType(int position)
+    {
         return getNodeViewType(nodes.get(position).getClass());
     }
 
     @Override
-    public long getItemId(int position) {
+    public long getItemId(int position)
+    {
         final Node node = nodes.get(position);
         final int type = getNodeViewType(node.getClass());
         final Entry<Node, Holder> entry = getEntry(type);
@@ -123,23 +136,27 @@ class StylarAdapterImpl extends StylarAdapter
     }
 
     @Override
-    public int getNodeViewType(@NonNull Class<? extends Node> node) {
+    public int getNodeViewType(@NonNull Class<? extends Node> node)
+    {
         // if has registered -> then return it, else 0
         final int hash = node.hashCode();
-        if (entries.indexOfKey(hash) > -1) {
+        if (entries.indexOfKey(hash) > -1)
+        {
             return hash;
         }
         return 0;
     }
 
     @NonNull
-    private Entry<Node, Holder> getEntry(int viewType) {
+    private Entry<Node, Holder> getEntry(int viewType)
+    {
         return viewType == 0
-                ? defaultEntry
-                : entries.get(viewType);
+            ? defaultEntry
+            : entries.get(viewType);
     }
 
-    static class BuilderImpl implements Builder {
+    static class BuilderImpl implements Builder
+    {
 
         private final SparseArray<Entry<Node, Holder>> entries = new SparseArray<>(3);
 
@@ -147,15 +164,17 @@ class StylarAdapterImpl extends StylarAdapter
 
         private StylarReducer reducer;
 
-        BuilderImpl(@NonNull Entry<Node, Holder> defaultEntry) {
+        BuilderImpl(@NonNull Entry<Node, Holder> defaultEntry)
+        {
             this.defaultEntry = defaultEntry;
         }
 
         @NonNull
         @Override
         public <N extends Node> Builder include(
-                @NonNull Class<N> node,
-                @NonNull Entry<? super N, ? extends Holder> entry) {
+            @NonNull Class<N> node,
+            @NonNull Entry<? super N, ? extends Holder> entry)
+        {
             //noinspection unchecked
             entries.append(node.hashCode(), (Entry<Node, Holder>) entry);
             return this;
@@ -163,16 +182,19 @@ class StylarAdapterImpl extends StylarAdapter
 
         @NonNull
         @Override
-        public Builder reducer(@NonNull StylarReducer reducer) {
+        public Builder reducer(@NonNull StylarReducer reducer)
+        {
             this.reducer = reducer;
             return this;
         }
 
         @NonNull
         @Override
-        public StylarAdapter build() {
+        public StylarAdapter build()
+        {
 
-            if (reducer == null) {
+            if (reducer == null)
+            {
                 reducer = StylarReducer.directChildren();
             }
 

--- a/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableBorderDrawable.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableBorderDrawable.java
@@ -11,37 +11,45 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
 
-class TableBorderDrawable extends Drawable {
+class TableBorderDrawable extends Drawable
+{
 
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
-    TableBorderDrawable() {
+    TableBorderDrawable()
+    {
         paint.setStyle(Paint.Style.STROKE);
     }
 
     @Override
-    public void draw(@NonNull Canvas canvas) {
-        if (paint.getStrokeWidth() > 0) {
+    public void draw(@NonNull Canvas canvas)
+    {
+        if (paint.getStrokeWidth() > 0)
+        {
             canvas.drawRect(getBounds(), paint);
         }
     }
 
     @Override
-    public void setAlpha(int alpha) {
+    public void setAlpha(int alpha)
+    {
         // no op
     }
 
     @Override
-    public void setColorFilter(@Nullable ColorFilter colorFilter) {
+    public void setColorFilter(@Nullable ColorFilter colorFilter)
+    {
         // no op
     }
 
     @Override
-    public int getOpacity() {
+    public int getOpacity()
+    {
         return PixelFormat.OPAQUE;
     }
 
-    void update(@Px int borderWidth, @ColorInt int color) {
+    void update(@Px int borderWidth, @ColorInt int color)
+    {
         paint.setStrokeWidth(borderWidth);
         paint.setColor(color);
         invalidateSelf();

--- a/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableEntry.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableEntry.java
@@ -20,6 +20,9 @@ import androidx.annotation.Px;
 import androidx.annotation.VisibleForTesting;
 
 import com.zeoflow.stylar.Stylar;
+import com.zeoflow.stylar.ext.tables.Table;
+import com.zeoflow.stylar.recycler.StylarAdapter;
+import com.zeoflow.stylar.utils.NoCopySpannableFactory;
 
 import org.commonmark.ext.gfm.tables.TableBlock;
 
@@ -27,16 +30,393 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.zeoflow.stylar.ext.tables.Table;
-import com.zeoflow.stylar.recycler.StylarAdapter;
-import com.zeoflow.stylar.utils.NoCopySpannableFactory;
-
 /**
  * @since 3.0.0
  */
-public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holder> {
+public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holder>
+{
 
-    public interface Builder {
+    private final int tableLayoutResId;
+    private final int tableIdRes;
+    private final int textLayoutResId;
+    private final int textIdRes;
+    private final boolean isRecyclable;
+    private final boolean cellTextCenterVertical; // by default true
+    private final Map<TableBlock, Table> map = new HashMap<>(3);
+    private LayoutInflater inflater;
+
+    TableEntry(
+        @LayoutRes int tableLayoutResId,
+        @IdRes int tableIdRes,
+        @LayoutRes int textLayoutResId,
+        @IdRes int textIdRes,
+        boolean isRecyclable,
+        boolean cellTextCenterVertical)
+    {
+        this.tableLayoutResId = tableLayoutResId;
+        this.tableIdRes = tableIdRes;
+        this.textLayoutResId = textLayoutResId;
+        this.textIdRes = textIdRes;
+        this.isRecyclable = isRecyclable;
+        this.cellTextCenterVertical = cellTextCenterVertical;
+    }
+
+    @NonNull
+    public static Builder builder()
+    {
+        return new BuilderImpl();
+    }
+
+    @NonNull
+    public static TableEntry create(@NonNull BuilderConfigure configure)
+    {
+        final Builder builder = builder();
+        configure.configure(builder);
+        return builder.build();
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    @VisibleForTesting
+    static void removeUnused(@NonNull TableLayout layout, int usedRows, int usedColumns)
+    {
+
+        // clean up rows
+        final int rowsCount = layout.getChildCount();
+        if (rowsCount > usedRows)
+        {
+            layout.removeViews(usedRows, (rowsCount - usedRows));
+        }
+
+        // validate columns
+        // here we can use usedRows as children count
+
+        TableRow tableRow;
+        int columnCount;
+
+        for (int i = 0; i < usedRows; i++)
+        {
+            tableRow = (TableRow) layout.getChildAt(i);
+            columnCount = tableRow.getChildCount();
+            if (columnCount > usedColumns)
+            {
+                tableRow.removeViews(usedColumns, (columnCount - usedColumns));
+            }
+        }
+    }
+
+    // we will use gravity instead of textAlignment because min sdk is 16 (textAlignment starts at 17)
+    @SuppressWarnings("WeakerAccess")
+    @SuppressLint("RtlHardcoded")
+    @VisibleForTesting
+    static int textGravity(@NonNull Table.Alignment alignment, boolean cellTextCenterVertical)
+    {
+
+        final int gravity;
+
+        switch (alignment)
+        {
+
+            case LEFT:
+                gravity = Gravity.LEFT;
+                break;
+
+            case CENTER:
+                gravity = Gravity.CENTER_HORIZONTAL;
+                break;
+
+            case RIGHT:
+                gravity = Gravity.RIGHT;
+                break;
+
+            default:
+                throw new IllegalStateException("Unknown table alignment: " + alignment);
+        }
+
+        if (cellTextCenterVertical)
+        {
+            return gravity | Gravity.CENTER_VERTICAL;
+        }
+
+        // do not center vertically
+        return gravity;
+    }
+
+    @NonNull
+    @Override
+    public Holder createHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent)
+    {
+        return new Holder(
+            isRecyclable,
+            tableIdRes,
+            inflater.inflate(tableLayoutResId, parent, false));
+    }
+
+    @Override
+    public void bindHolder(@NonNull Stylar stylar, @NonNull Holder holder, @NonNull TableBlock node)
+    {
+
+        Table table = map.get(node);
+        if (table == null)
+        {
+            table = Table.parse(stylar, node);
+            map.put(node, table);
+        }
+
+        // check if this exact TableBlock was already applied
+        // set tag of tableLayoutResId as it's 100% to be present (we still allow 0 as
+        // tableIdRes if tableLayoutResId has TableLayout as root view)
+        final TableLayout layout = holder.tableLayout;
+        if (table == null
+            || table == layout.getTag(tableLayoutResId))
+        {
+            return;
+        }
+
+        // set this flag to indicate what table instance we current display
+        layout.setTag(tableLayoutResId, table);
+
+        final TableEntryPlugin plugin = stylar.getPlugin(TableEntryPlugin.class);
+        if (plugin == null)
+        {
+            throw new IllegalStateException("No TableEntryPlugin is found. Make sure that it " +
+                "is _used_ whilst configuring Markwon instance");
+        }
+
+        // we must remove unwanted ones (rows and columns)
+
+        final TableEntryTheme theme = plugin.theme();
+        final int borderWidth;
+        final int borderColor;
+        final int cellPadding;
+        {
+            final TextView textView = ensureTextView(layout, 0, 0);
+            borderWidth = theme.tableBorderWidth(textView.getPaint());
+            borderColor = theme.tableBorderColor(textView.getPaint());
+            cellPadding = theme.tableCellPadding();
+        }
+
+        ensureTableBorderBackground(layout, borderWidth, borderColor);
+
+        //noinspection SuspiciousNameCombination
+//        layout.setPadding(borderWidth, borderWidth, borderWidth, borderWidth);
+//        layout.setClipToPadding(borderWidth == 0);
+
+        final List<Table.Row> rows = table.rows();
+
+        final int rowsSize = rows.size();
+
+        // all rows should have equal number of columns
+        final int columnsSize = rowsSize > 0
+            ? rows.get(0).columns().size()
+            : 0;
+
+        Table.Row row;
+        Table.Column column;
+
+        TableRow tableRow;
+
+        for (int y = 0; y < rowsSize; y++)
+        {
+
+            row = rows.get(y);
+            tableRow = ensureRow(layout, y);
+
+            for (int x = 0; x < columnsSize; x++)
+            {
+
+                column = row.columns().get(x);
+
+                final TextView textView = ensureTextView(layout, y, x);
+                textView.setGravity(textGravity(column.alignment(), cellTextCenterVertical));
+                textView.getPaint().setFakeBoldText(row.header());
+
+                // apply padding only if not specified in theme (otherwise just use the value from layout)
+                if (cellPadding > 0)
+                {
+                    textView.setPadding(cellPadding, cellPadding, cellPadding, cellPadding);
+                }
+
+                ensureTableBorderBackground(textView, borderWidth, borderColor);
+                stylar.setParsedMarkdown(textView, column.content());
+            }
+
+            // row appearance
+            if (row.header())
+            {
+                tableRow.setBackgroundColor(theme.tableHeaderRowBackgroundColor());
+            } else
+            {
+                // as we currently have no support for tables without head
+                // we shift even/odd calculation a bit (head should not be included in even/odd calculation)
+                final boolean isEven = (y % 2) == 1;
+                if (isEven)
+                {
+                    tableRow.setBackgroundColor(theme.tableEvenRowBackgroundColor());
+                } else
+                {
+                    // just take first
+                    final TextView textView = ensureTextView(layout, y, 0);
+                    tableRow.setBackgroundColor(
+                        theme.tableOddRowBackgroundColor(textView.getPaint()));
+                }
+            }
+        }
+
+        // clean up here of un-used rows and columns
+        removeUnused(layout, rowsSize, columnsSize);
+    }
+
+    @NonNull
+    private TableRow ensureRow(@NonNull TableLayout layout, int row)
+    {
+
+        final int count = layout.getChildCount();
+
+        // fill the requested views until we have added the `row` one
+        if (row >= count)
+        {
+
+            final Context context = layout.getContext();
+
+            int diff = row - count + 1;
+            while (diff > 0)
+            {
+                layout.addView(new TableRow(context));
+                diff -= 1;
+            }
+        }
+
+        // return requested child (here it always should be the last one)
+        return (TableRow) layout.getChildAt(row);
+    }
+
+    @NonNull
+    private TextView ensureTextView(@NonNull TableLayout layout, int row, int column)
+    {
+
+        final TableRow tableRow = ensureRow(layout, row);
+        final int count = tableRow.getChildCount();
+
+        if (column >= count)
+        {
+
+            final LayoutInflater inflater = ensureInflater(layout.getContext());
+
+            boolean textViewChecked = false;
+
+            View view;
+            TextView textView;
+            ViewGroup.LayoutParams layoutParams;
+
+            int diff = column - count + 1;
+
+            while (diff > 0)
+            {
+
+                view = inflater.inflate(textLayoutResId, tableRow, false);
+
+                // we should have `match_parent` as height (important for borders and text-vertical-align)
+                layoutParams = view.getLayoutParams();
+                if (layoutParams.height != ViewGroup.LayoutParams.MATCH_PARENT)
+                {
+                    layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT;
+                }
+
+                // it will be enough to check only once
+                if (!textViewChecked)
+                {
+
+                    if (textIdRes == 0)
+                    {
+                        if (!(view instanceof TextView))
+                        {
+                            final String name = layout.getContext().getResources().getResourceName(textLayoutResId);
+                            throw new IllegalStateException(String.format("textLayoutResId(R.layout.%s) " +
+                                "has other than TextView root view. Specify TextView ID explicitly", name));
+                        }
+                        textView = (TextView) view;
+                    } else
+                    {
+                        textView = view.findViewById(textIdRes);
+                        if (textView == null)
+                        {
+                            final Resources r = layout.getContext().getResources();
+                            final String layoutName = r.getResourceName(textLayoutResId);
+                            final String idName = r.getResourceName(textIdRes);
+                            throw new NullPointerException(String.format("textLayoutResId(R.layout.%s) " +
+                                "has no TextView found by id(R.id.%s): %s", layoutName, idName, view));
+                        }
+                    }
+                    // mark as checked
+                    textViewChecked = true;
+                } else
+                {
+                    if (textIdRes == 0)
+                    {
+                        textView = (TextView) view;
+                    } else
+                    {
+                        textView = view.findViewById(textIdRes);
+                    }
+                }
+
+                // we should set SpannableFactory during creation (to avoid another setText method)
+                textView.setSpannableFactory(NoCopySpannableFactory.getInstance());
+                tableRow.addView(textView);
+
+                diff -= 1;
+            }
+        }
+
+        // we can skip all the validation here as we have validated our views whilst inflating them
+        final View last = tableRow.getChildAt(column);
+        if (textIdRes == 0)
+        {
+            return (TextView) last;
+        } else
+        {
+            return last.findViewById(textIdRes);
+        }
+    }
+
+    private void ensureTableBorderBackground(@NonNull View view, @Px int borderWidth, @ColorInt int borderColor)
+    {
+        if (borderWidth == 0)
+        {
+            view.setBackground(null);
+        } else
+        {
+            final Drawable drawable = view.getBackground();
+            if (!(drawable instanceof TableBorderDrawable))
+            {
+                final TableBorderDrawable borderDrawable = new TableBorderDrawable();
+                borderDrawable.update(borderWidth, borderColor);
+                view.setBackground(borderDrawable);
+            } else
+            {
+                ((TableBorderDrawable) drawable).update(borderWidth, borderColor);
+            }
+        }
+    }
+
+    @NonNull
+    private LayoutInflater ensureInflater(@NonNull Context context)
+    {
+        if (inflater == null)
+        {
+            inflater = LayoutInflater.from(context);
+        }
+        return inflater;
+    }
+
+    @Override
+    public void clear()
+    {
+        map.clear();
+    }
+
+    public interface Builder
+    {
 
         /**
          * @param tableLayoutResId layout with TableLayout
@@ -85,317 +465,18 @@ public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holde
         TableEntry build();
     }
 
-    public interface BuilderConfigure {
+    public interface BuilderConfigure
+    {
         void configure(@NonNull Builder builder);
     }
 
-    @NonNull
-    public static Builder builder() {
-        return new BuilderImpl();
-    }
-
-    @NonNull
-    public static TableEntry create(@NonNull BuilderConfigure configure) {
-        final Builder builder = builder();
-        configure.configure(builder);
-        return builder.build();
-    }
-
-    private final int tableLayoutResId;
-    private final int tableIdRes;
-
-    private final int textLayoutResId;
-    private final int textIdRes;
-
-    private final boolean isRecyclable;
-    private final boolean cellTextCenterVertical; // by default true
-
-    private LayoutInflater inflater;
-
-    private final Map<TableBlock, Table> map = new HashMap<>(3);
-
-    TableEntry(
-            @LayoutRes int tableLayoutResId,
-            @IdRes int tableIdRes,
-            @LayoutRes int textLayoutResId,
-            @IdRes int textIdRes,
-            boolean isRecyclable,
-            boolean cellTextCenterVertical) {
-        this.tableLayoutResId = tableLayoutResId;
-        this.tableIdRes = tableIdRes;
-        this.textLayoutResId = textLayoutResId;
-        this.textIdRes = textIdRes;
-        this.isRecyclable = isRecyclable;
-        this.cellTextCenterVertical = cellTextCenterVertical;
-    }
-
-    @NonNull
-    @Override
-    public Holder createHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent) {
-        return new Holder(
-                isRecyclable,
-                tableIdRes,
-                inflater.inflate(tableLayoutResId, parent, false));
-    }
-
-    @Override
-    public void bindHolder(@NonNull Stylar stylar, @NonNull Holder holder, @NonNull TableBlock node) {
-
-        Table table = map.get(node);
-        if (table == null) {
-            table = Table.parse(stylar, node);
-            map.put(node, table);
-        }
-
-        // check if this exact TableBlock was already applied
-        // set tag of tableLayoutResId as it's 100% to be present (we still allow 0 as
-        // tableIdRes if tableLayoutResId has TableLayout as root view)
-        final TableLayout layout = holder.tableLayout;
-        if (table == null
-                || table == layout.getTag(tableLayoutResId)) {
-            return;
-        }
-
-        // set this flag to indicate what table instance we current display
-        layout.setTag(tableLayoutResId, table);
-
-        final TableEntryPlugin plugin = stylar.getPlugin(TableEntryPlugin.class);
-        if (plugin == null) {
-            throw new IllegalStateException("No TableEntryPlugin is found. Make sure that it " +
-                    "is _used_ whilst configuring Markwon instance");
-        }
-
-        // we must remove unwanted ones (rows and columns)
-
-        final TableEntryTheme theme = plugin.theme();
-        final int borderWidth;
-        final int borderColor;
-        final int cellPadding;
-        {
-            final TextView textView = ensureTextView(layout, 0, 0);
-            borderWidth = theme.tableBorderWidth(textView.getPaint());
-            borderColor = theme.tableBorderColor(textView.getPaint());
-            cellPadding = theme.tableCellPadding();
-        }
-
-        ensureTableBorderBackground(layout, borderWidth, borderColor);
-
-        //noinspection SuspiciousNameCombination
-//        layout.setPadding(borderWidth, borderWidth, borderWidth, borderWidth);
-//        layout.setClipToPadding(borderWidth == 0);
-
-        final List<Table.Row> rows = table.rows();
-
-        final int rowsSize = rows.size();
-
-        // all rows should have equal number of columns
-        final int columnsSize = rowsSize > 0
-                ? rows.get(0).columns().size()
-                : 0;
-
-        Table.Row row;
-        Table.Column column;
-
-        TableRow tableRow;
-
-        for (int y = 0; y < rowsSize; y++) {
-
-            row = rows.get(y);
-            tableRow = ensureRow(layout, y);
-
-            for (int x = 0; x < columnsSize; x++) {
-
-                column = row.columns().get(x);
-
-                final TextView textView = ensureTextView(layout, y, x);
-                textView.setGravity(textGravity(column.alignment(), cellTextCenterVertical));
-                textView.getPaint().setFakeBoldText(row.header());
-
-                // apply padding only if not specified in theme (otherwise just use the value from layout)
-                if (cellPadding > 0) {
-                    textView.setPadding(cellPadding, cellPadding, cellPadding, cellPadding);
-                }
-
-                ensureTableBorderBackground(textView, borderWidth, borderColor);
-                stylar.setParsedMarkdown(textView, column.content());
-            }
-
-            // row appearance
-            if (row.header()) {
-                tableRow.setBackgroundColor(theme.tableHeaderRowBackgroundColor());
-            } else {
-                // as we currently have no support for tables without head
-                // we shift even/odd calculation a bit (head should not be included in even/odd calculation)
-                final boolean isEven = (y % 2) == 1;
-                if (isEven) {
-                    tableRow.setBackgroundColor(theme.tableEvenRowBackgroundColor());
-                } else {
-                    // just take first
-                    final TextView textView = ensureTextView(layout, y, 0);
-                    tableRow.setBackgroundColor(
-                            theme.tableOddRowBackgroundColor(textView.getPaint()));
-                }
-            }
-        }
-
-        // clean up here of un-used rows and columns
-        removeUnused(layout, rowsSize, columnsSize);
-    }
-
-    @NonNull
-    private TableRow ensureRow(@NonNull TableLayout layout, int row) {
-
-        final int count = layout.getChildCount();
-
-        // fill the requested views until we have added the `row` one
-        if (row >= count) {
-
-            final Context context = layout.getContext();
-
-            int diff = row - count + 1;
-            while (diff > 0) {
-                layout.addView(new TableRow(context));
-                diff -= 1;
-            }
-        }
-
-        // return requested child (here it always should be the last one)
-        return (TableRow) layout.getChildAt(row);
-    }
-
-    @NonNull
-    private TextView ensureTextView(@NonNull TableLayout layout, int row, int column) {
-
-        final TableRow tableRow = ensureRow(layout, row);
-        final int count = tableRow.getChildCount();
-
-        if (column >= count) {
-
-            final LayoutInflater inflater = ensureInflater(layout.getContext());
-
-            boolean textViewChecked = false;
-
-            View view;
-            TextView textView;
-            ViewGroup.LayoutParams layoutParams;
-
-            int diff = column - count + 1;
-
-            while (diff > 0) {
-
-                view = inflater.inflate(textLayoutResId, tableRow, false);
-
-                // we should have `match_parent` as height (important for borders and text-vertical-align)
-                layoutParams = view.getLayoutParams();
-                if (layoutParams.height != ViewGroup.LayoutParams.MATCH_PARENT) {
-                    layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT;
-                }
-
-                // it will be enough to check only once
-                if (!textViewChecked) {
-
-                    if (textIdRes == 0) {
-                        if (!(view instanceof TextView)) {
-                            final String name = layout.getContext().getResources().getResourceName(textLayoutResId);
-                            throw new IllegalStateException(String.format("textLayoutResId(R.layout.%s) " +
-                                    "has other than TextView root view. Specify TextView ID explicitly", name));
-                        }
-                        textView = (TextView) view;
-                    } else {
-                        textView = view.findViewById(textIdRes);
-                        if (textView == null) {
-                            final Resources r = layout.getContext().getResources();
-                            final String layoutName = r.getResourceName(textLayoutResId);
-                            final String idName = r.getResourceName(textIdRes);
-                            throw new NullPointerException(String.format("textLayoutResId(R.layout.%s) " +
-                                    "has no TextView found by id(R.id.%s): %s", layoutName, idName, view));
-                        }
-                    }
-                    // mark as checked
-                    textViewChecked = true;
-                } else {
-                    if (textIdRes == 0) {
-                        textView = (TextView) view;
-                    } else {
-                        textView = view.findViewById(textIdRes);
-                    }
-                }
-
-                // we should set SpannableFactory during creation (to avoid another setText method)
-                textView.setSpannableFactory(NoCopySpannableFactory.getInstance());
-                tableRow.addView(textView);
-
-                diff -= 1;
-            }
-        }
-
-        // we can skip all the validation here as we have validated our views whilst inflating them
-        final View last = tableRow.getChildAt(column);
-        if (textIdRes == 0) {
-            return (TextView) last;
-        } else {
-            return last.findViewById(textIdRes);
-        }
-    }
-
-    private void ensureTableBorderBackground(@NonNull View view, @Px int borderWidth, @ColorInt int borderColor) {
-        if (borderWidth == 0) {
-            view.setBackground(null);
-        } else {
-            final Drawable drawable = view.getBackground();
-            if (!(drawable instanceof TableBorderDrawable)) {
-                final TableBorderDrawable borderDrawable = new TableBorderDrawable();
-                borderDrawable.update(borderWidth, borderColor);
-                view.setBackground(borderDrawable);
-            } else {
-                ((TableBorderDrawable) drawable).update(borderWidth, borderColor);
-            }
-        }
-    }
-
-    @NonNull
-    private LayoutInflater ensureInflater(@NonNull Context context) {
-        if (inflater == null) {
-            inflater = LayoutInflater.from(context);
-        }
-        return inflater;
-    }
-
-    @SuppressWarnings("WeakerAccess")
-    @VisibleForTesting
-    static void removeUnused(@NonNull TableLayout layout, int usedRows, int usedColumns) {
-
-        // clean up rows
-        final int rowsCount = layout.getChildCount();
-        if (rowsCount > usedRows) {
-            layout.removeViews(usedRows, (rowsCount - usedRows));
-        }
-
-        // validate columns
-        // here we can use usedRows as children count
-
-        TableRow tableRow;
-        int columnCount;
-
-        for (int i = 0; i < usedRows; i++) {
-            tableRow = (TableRow) layout.getChildAt(i);
-            columnCount = tableRow.getChildCount();
-            if (columnCount > usedColumns) {
-                tableRow.removeViews(usedColumns, (columnCount - usedColumns));
-            }
-        }
-    }
-
-    @Override
-    public void clear() {
-        map.clear();
-    }
-
-    public static class Holder extends StylarAdapter.Holder {
+    public static class Holder extends StylarAdapter.Holder
+    {
 
         final TableLayout tableLayout;
 
-        public Holder(boolean isRecyclable, @IdRes int tableLayoutIdRes, @NonNull View itemView) {
+        public Holder(boolean isRecyclable, @IdRes int tableLayoutIdRes, @NonNull View itemView)
+        {
             super(itemView);
 
             // we must call this method only once (it's somehow _paired_ inside, so
@@ -404,55 +485,25 @@ public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holde
             setIsRecyclable(isRecyclable);
 
             final TableLayout tableLayout;
-            if (tableLayoutIdRes == 0) {
+            if (tableLayoutIdRes == 0)
+            {
                 // try to cast directly
-                if (!(itemView instanceof TableLayout)) {
+                if (!(itemView instanceof TableLayout))
+                {
                     throw new IllegalStateException("Root view is not TableLayout. Please provide " +
-                            "TableLayout ID explicitly");
+                        "TableLayout ID explicitly");
                 }
                 tableLayout = (TableLayout) itemView;
-            } else {
+            } else
+            {
                 tableLayout = requireView(tableLayoutIdRes);
             }
             this.tableLayout = tableLayout;
         }
     }
 
-    // we will use gravity instead of textAlignment because min sdk is 16 (textAlignment starts at 17)
-    @SuppressWarnings("WeakerAccess")
-    @SuppressLint("RtlHardcoded")
-    @VisibleForTesting
-    static int textGravity(@NonNull Table.Alignment alignment, boolean cellTextCenterVertical) {
-
-        final int gravity;
-
-        switch (alignment) {
-
-            case LEFT:
-                gravity = Gravity.LEFT;
-                break;
-
-            case CENTER:
-                gravity = Gravity.CENTER_HORIZONTAL;
-                break;
-
-            case RIGHT:
-                gravity = Gravity.RIGHT;
-                break;
-
-            default:
-                throw new IllegalStateException("Unknown table alignment: " + alignment);
-        }
-
-        if (cellTextCenterVertical) {
-            return gravity | Gravity.CENTER_VERTICAL;
-        }
-
-        // do not center vertically
-        return gravity;
-    }
-
-    static class BuilderImpl implements Builder {
+    static class BuilderImpl implements Builder
+    {
 
         private int tableLayoutResId;
         private int tableIdRes;
@@ -466,7 +517,8 @@ public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holde
 
         @NonNull
         @Override
-        public Builder tableLayout(int tableLayoutResId, int tableIdRes) {
+        public Builder tableLayout(int tableLayoutResId, int tableIdRes)
+        {
             this.tableLayoutResId = tableLayoutResId;
             this.tableIdRes = tableIdRes;
             return this;
@@ -474,7 +526,8 @@ public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holde
 
         @NonNull
         @Override
-        public Builder tableLayoutIsRoot(int tableLayoutResId) {
+        public Builder tableLayoutIsRoot(int tableLayoutResId)
+        {
             this.tableLayoutResId = tableLayoutResId;
             this.tableIdRes = 0;
             return this;
@@ -482,7 +535,8 @@ public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holde
 
         @NonNull
         @Override
-        public Builder textLayout(int textLayoutResId, int textIdRes) {
+        public Builder textLayout(int textLayoutResId, int textIdRes)
+        {
             this.textLayoutResId = textLayoutResId;
             this.textIdRes = textIdRes;
             return this;
@@ -490,7 +544,8 @@ public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holde
 
         @NonNull
         @Override
-        public Builder textLayoutIsRoot(int textLayoutResId) {
+        public Builder textLayoutIsRoot(int textLayoutResId)
+        {
             this.textLayoutResId = textLayoutResId;
             this.textIdRes = 0;
             return this;
@@ -498,34 +553,39 @@ public class TableEntry extends StylarAdapter.Entry<TableBlock, TableEntry.Holde
 
         @NonNull
         @Override
-        public Builder cellTextCenterVertical(boolean cellTextCenterVertical) {
+        public Builder cellTextCenterVertical(boolean cellTextCenterVertical)
+        {
             this.cellTextCenterVertical = cellTextCenterVertical;
             return this;
         }
 
         @NonNull
         @Override
-        public Builder isRecyclable(boolean isRecyclable) {
+        public Builder isRecyclable(boolean isRecyclable)
+        {
             this.isRecyclable = isRecyclable;
             return this;
         }
 
         @NonNull
         @Override
-        public TableEntry build() {
+        public TableEntry build()
+        {
 
-            if (tableLayoutResId == 0) {
+            if (tableLayoutResId == 0)
+            {
                 throw new IllegalStateException("`tableLayoutResId` argument is required");
             }
 
-            if (textLayoutResId == 0) {
+            if (textLayoutResId == 0)
+            {
                 throw new IllegalStateException("`textLayoutResId` argument is required");
             }
 
             return new TableEntry(
-                    tableLayoutResId, tableIdRes,
-                    textLayoutResId, textIdRes,
-                    isRecyclable, cellTextCenterVertical
+                tableLayoutResId, tableIdRes,
+                textLayoutResId, textIdRes,
+                isRecyclable, cellTextCenterVertical
             );
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableEntryPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableEntryPlugin.java
@@ -5,14 +5,13 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.AbstractStylarPlugin;
+import com.zeoflow.stylar.ext.tables.TablePlugin;
+import com.zeoflow.stylar.ext.tables.TableTheme;
 
 import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.parser.Parser;
 
 import java.util.Collections;
-
-import com.zeoflow.stylar.ext.tables.TablePlugin;
-import com.zeoflow.stylar.ext.tables.TableTheme;
 
 /**
  * This plugin must be used instead of {@link TablePlugin} when a markdown
@@ -26,43 +25,50 @@ import com.zeoflow.stylar.ext.tables.TableTheme;
 public class TableEntryPlugin extends AbstractStylarPlugin
 {
 
+    private final TableEntryTheme theme;
+
+    @SuppressWarnings("WeakerAccess")
+    TableEntryPlugin(@NonNull TableEntryTheme tableTheme)
+    {
+        this.theme = tableTheme;
+    }
+
     @NonNull
-    public static TableEntryPlugin create(@NonNull Context context) {
+    public static TableEntryPlugin create(@NonNull Context context)
+    {
         final TableTheme tableTheme = TableTheme.create(context);
         return create(tableTheme);
     }
 
     @NonNull
-    public static TableEntryPlugin create(@NonNull TableTheme tableTheme) {
+    public static TableEntryPlugin create(@NonNull TableTheme tableTheme)
+    {
         return new TableEntryPlugin(TableEntryTheme.create(tableTheme));
     }
 
     @NonNull
-    public static TableEntryPlugin create(@NonNull TablePlugin.ThemeConfigure themeConfigure) {
+    public static TableEntryPlugin create(@NonNull TablePlugin.ThemeConfigure themeConfigure)
+    {
         final TableTheme.Builder builder = new TableTheme.Builder();
         themeConfigure.configureTheme(builder);
         return new TableEntryPlugin(new TableEntryTheme(builder));
     }
 
     @NonNull
-    public static TableEntryPlugin create(@NonNull TablePlugin plugin) {
+    public static TableEntryPlugin create(@NonNull TablePlugin plugin)
+    {
         return create(plugin.theme());
     }
 
-    private final TableEntryTheme theme;
-
-    @SuppressWarnings("WeakerAccess")
-    TableEntryPlugin(@NonNull TableEntryTheme tableTheme) {
-        this.theme = tableTheme;
-    }
-
     @NonNull
-    public TableEntryTheme theme() {
+    public TableEntryTheme theme()
+    {
         return theme;
     }
 
     @Override
-    public void configureParser(@NonNull Parser.Builder builder) {
+    public void configureParser(@NonNull Parser.Builder builder)
+    {
         builder.extensions(Collections.singleton(TablesExtension.create()));
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableEntryTheme.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/recycler/table/TableEntryTheme.java
@@ -17,52 +17,61 @@ import com.zeoflow.stylar.utils.ColorUtils;
  * @since 3.0.0
  */
 @SuppressWarnings("WeakerAccess")
-public class TableEntryTheme extends TableTheme {
+public class TableEntryTheme extends TableTheme
+{
 
-    @NonNull
-    public static TableEntryTheme create(@NonNull TableTheme tableTheme) {
-        return new TableEntryTheme(tableTheme.asBuilder());
+    protected TableEntryTheme(@NonNull Builder builder)
+    {
+        super(builder);
     }
 
-    protected TableEntryTheme(@NonNull Builder builder) {
-        super(builder);
+    @NonNull
+    public static TableEntryTheme create(@NonNull TableTheme tableTheme)
+    {
+        return new TableEntryTheme(tableTheme.asBuilder());
     }
 
     @Px
     @Override
-    public int tableCellPadding() {
+    public int tableCellPadding()
+    {
         return tableCellPadding;
     }
 
     @ColorInt
-    public int tableBorderColor(@NonNull Paint paint) {
+    public int tableBorderColor(@NonNull Paint paint)
+    {
         return tableBorderColor == 0
-                ? ColorUtils.applyAlpha(paint.getColor(), TABLE_BORDER_DEF_ALPHA)
-                : tableBorderColor;
+            ? ColorUtils.applyAlpha(paint.getColor(), TABLE_BORDER_DEF_ALPHA)
+            : tableBorderColor;
     }
 
     @Px
     @Override
-    public int tableBorderWidth(@NonNull Paint paint) {
+    public int tableBorderWidth(@NonNull Paint paint)
+    {
         return tableBorderWidth < 0
-                ? (int) (paint.getStrokeWidth() + .5F)
-                : tableBorderWidth;
+            ? (int) (paint.getStrokeWidth() + .5F)
+            : tableBorderWidth;
     }
 
     @ColorInt
-    public int tableOddRowBackgroundColor(@NonNull Paint paint) {
+    public int tableOddRowBackgroundColor(@NonNull Paint paint)
+    {
         return tableOddRowBackgroundColor == 0
-                ? ColorUtils.applyAlpha(paint.getColor(), TABLE_ODD_ROW_DEF_ALPHA)
-                : tableOddRowBackgroundColor;
+            ? ColorUtils.applyAlpha(paint.getColor(), TABLE_ODD_ROW_DEF_ALPHA)
+            : tableOddRowBackgroundColor;
     }
 
     @ColorInt
-    public int tableEvenRowBackgroundColor() {
+    public int tableEvenRowBackgroundColor()
+    {
         return tableEvenRowBackgroundColor;
     }
 
     @ColorInt
-    public int tableHeaderRowBackgroundColor() {
+    public int tableHeaderRowBackgroundColor()
+    {
         return tableHeaderRowBackgroundColor;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtBuilder.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtBuilder.java
@@ -2,51 +2,55 @@ package com.zeoflow.stylar.simple.ext;
 
 import androidx.annotation.NonNull;
 
+import com.zeoflow.stylar.SpanFactory;
+
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import com.zeoflow.stylar.SpanFactory;
-
 // @since 4.0.0
-class SimpleExtBuilder {
+class SimpleExtBuilder
+{
 
     private final List<DelimiterProcessor> extensions = new ArrayList<>(2);
 
     private boolean isBuilt;
 
     void addExtension(
-            int length,
-            char character,
-            @NonNull SpanFactory spanFactory) {
+        int length,
+        char character,
+        @NonNull SpanFactory spanFactory)
+    {
 
         checkState();
 
         extensions.add(new SimpleExtDelimiterProcessor(
-                character,
-                character,
-                length,
-                spanFactory));
+            character,
+            character,
+            length,
+            spanFactory));
     }
 
     void addExtension(
-            int length,
-            char openingCharacter,
-            char closingCharacter,
-            @NonNull SpanFactory spanFactory) {
+        int length,
+        char openingCharacter,
+        char closingCharacter,
+        @NonNull SpanFactory spanFactory)
+    {
 
         checkState();
 
         extensions.add(new SimpleExtDelimiterProcessor(
-                openingCharacter,
-                closingCharacter,
-                length,
-                spanFactory));
+            openingCharacter,
+            closingCharacter,
+            length,
+            spanFactory));
     }
 
     @NonNull
-    List<DelimiterProcessor> build() {
+    List<DelimiterProcessor> build()
+    {
 
         checkState();
 
@@ -55,10 +59,12 @@ class SimpleExtBuilder {
         return extensions;
     }
 
-    private void checkState() {
-        if (isBuilt) {
+    private void checkState()
+    {
+        if (isBuilt)
+        {
             throw new IllegalStateException("SimpleExtBuilder is already built, " +
-                    "do not mutate SimpleExtPlugin after configuration is finished");
+                "do not mutate SimpleExtPlugin after configuration is finished");
         }
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtDelimiterProcessor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtDelimiterProcessor.java
@@ -2,15 +2,16 @@ package com.zeoflow.stylar.simple.ext;
 
 import androidx.annotation.NonNull;
 
+import com.zeoflow.stylar.SpanFactory;
+
 import org.commonmark.node.Node;
 import org.commonmark.node.Text;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 import org.commonmark.parser.delimiter.DelimiterRun;
 
-import com.zeoflow.stylar.SpanFactory;
-
 // @since 4.0.0
-class SimpleExtDelimiterProcessor implements DelimiterProcessor {
+class SimpleExtDelimiterProcessor implements DelimiterProcessor
+{
 
     private final char open;
     private final char close;
@@ -18,10 +19,11 @@ class SimpleExtDelimiterProcessor implements DelimiterProcessor {
     private final SpanFactory spanFactory;
 
     SimpleExtDelimiterProcessor(
-            char open,
-            char close,
-            int length,
-            @NonNull SpanFactory spanFactory) {
+        char open,
+        char close,
+        int length,
+        @NonNull SpanFactory spanFactory)
+    {
         this.open = open;
         this.close = close;
         this.length = length;
@@ -29,37 +31,44 @@ class SimpleExtDelimiterProcessor implements DelimiterProcessor {
     }
 
     @Override
-    public char getOpeningCharacter() {
+    public char getOpeningCharacter()
+    {
         return open;
     }
 
     @Override
-    public char getClosingCharacter() {
+    public char getClosingCharacter()
+    {
         return close;
     }
 
     @Override
-    public int getMinLength() {
+    public int getMinLength()
+    {
         return length;
     }
 
     @Override
-    public int getDelimiterUse(DelimiterRun opener, DelimiterRun closer) {
-        if (opener.length() >= length && closer.length() >= length) {
+    public int getDelimiterUse(DelimiterRun opener, DelimiterRun closer)
+    {
+        if (opener.length() >= length && closer.length() >= length)
+        {
             return length;
         }
         return 0;
     }
 
     @Override
-    public void process(Text opener, Text closer, int delimiterUse) {
+    public void process(Text opener, Text closer, int delimiterUse)
+    {
 
         final Node node = new SimpleExtNode(spanFactory);
 
         Node tmp = opener.getNext();
         Node next;
 
-        while (tmp != null && tmp != closer) {
+        while (tmp != null && tmp != closer)
+        {
             next = tmp.getNext();
             node.appendChild(tmp);
             tmp = next;

--- a/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtNode.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtNode.java
@@ -2,27 +2,31 @@ package com.zeoflow.stylar.simple.ext;
 
 import androidx.annotation.NonNull;
 
+import com.zeoflow.stylar.SpanFactory;
+
 import org.commonmark.node.CustomNode;
 import org.commonmark.node.Visitor;
 
-import com.zeoflow.stylar.SpanFactory;
-
 // @since 4.0.0
-class SimpleExtNode extends CustomNode {
+class SimpleExtNode extends CustomNode
+{
 
     private final SpanFactory spanFactory;
 
-    SimpleExtNode(@NonNull SpanFactory spanFactory) {
+    SimpleExtNode(@NonNull SpanFactory spanFactory)
+    {
         this.spanFactory = spanFactory;
     }
 
     @Override
-    public void accept(Visitor visitor) {
+    public void accept(Visitor visitor)
+    {
         visitor.visit(this);
     }
 
     @NonNull
-    SpanFactory spanFactory() {
+    SpanFactory spanFactory()
+    {
         return spanFactory;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/simple/ext/SimpleExtPlugin.java
@@ -3,13 +3,12 @@ package com.zeoflow.stylar.simple.ext;
 import androidx.annotation.NonNull;
 
 import com.zeoflow.stylar.AbstractStylarPlugin;
+import com.zeoflow.stylar.SpanFactory;
+import com.zeoflow.stylar.SpannableBuilder;
 import com.zeoflow.stylar.StylarVisitor;
 
 import org.commonmark.parser.Parser;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
-
-import com.zeoflow.stylar.SpanFactory;
-import com.zeoflow.stylar.SpannableBuilder;
 
 /**
  * @since 4.0.0
@@ -17,71 +16,82 @@ import com.zeoflow.stylar.SpannableBuilder;
 public class SimpleExtPlugin extends AbstractStylarPlugin
 {
 
-    public interface SimpleExtConfigure {
-        void configure(@NonNull SimpleExtPlugin plugin);
+    private final SimpleExtBuilder builder = new SimpleExtBuilder();
+
+    @SuppressWarnings("WeakerAccess")
+    SimpleExtPlugin()
+    {
     }
 
     @NonNull
-    public static SimpleExtPlugin create() {
+    public static SimpleExtPlugin create()
+    {
         return new SimpleExtPlugin();
     }
 
     @NonNull
-    public static SimpleExtPlugin create(@NonNull SimpleExtConfigure configure) {
+    public static SimpleExtPlugin create(@NonNull SimpleExtConfigure configure)
+    {
         final SimpleExtPlugin plugin = new SimpleExtPlugin();
         configure.configure(plugin);
         return plugin;
     }
 
-    private final SimpleExtBuilder builder = new SimpleExtBuilder();
-
-    @SuppressWarnings("WeakerAccess")
-    SimpleExtPlugin() {
-    }
-
     @NonNull
     public SimpleExtPlugin addExtension(
-            int length,
-            char character,
-            @NonNull SpanFactory spanFactory) {
+        int length,
+        char character,
+        @NonNull SpanFactory spanFactory)
+    {
         builder.addExtension(length, character, spanFactory);
         return this;
     }
 
     @NonNull
     public SimpleExtPlugin addExtension(
-            int length,
-            char openingCharacter,
-            char closingCharacter,
-            @NonNull SpanFactory spanFactory) {
+        int length,
+        char openingCharacter,
+        char closingCharacter,
+        @NonNull SpanFactory spanFactory)
+    {
         builder.addExtension(length, openingCharacter, closingCharacter, spanFactory);
         return this;
     }
 
     @Override
-    public void configureParser(@NonNull Parser.Builder builder) {
-        for (DelimiterProcessor processor : this.builder.build()) {
+    public void configureParser(@NonNull Parser.Builder builder)
+    {
+        for (DelimiterProcessor processor : this.builder.build())
+        {
             builder.customDelimiterProcessor(processor);
         }
     }
 
     @Override
-    public void configureVisitor(@NonNull StylarVisitor.Builder builder) {
-        builder.on(SimpleExtNode.class, new StylarVisitor.NodeVisitor<SimpleExtNode>() {
+    public void configureVisitor(@NonNull StylarVisitor.Builder builder)
+    {
+        builder.on(SimpleExtNode.class, new StylarVisitor.NodeVisitor<SimpleExtNode>()
+        {
             @Override
-            public void visit(@NonNull StylarVisitor visitor, @NonNull SimpleExtNode simpleExtNode) {
+            public void visit(@NonNull StylarVisitor visitor, @NonNull SimpleExtNode simpleExtNode)
+            {
 
                 final int length = visitor.length();
 
                 visitor.visitChildren(simpleExtNode);
 
                 SpannableBuilder.setSpans(
-                        visitor.builder(),
-                        simpleExtNode.spanFactory().getSpans(visitor.configuration(), visitor.renderProps()),
-                        length,
-                        visitor.length()
+                    visitor.builder(),
+                    simpleExtNode.spanFactory().getSpans(visitor.configuration(), visitor.renderProps()),
+                    length,
+                    visitor.length()
                 );
             }
         });
+    }
+
+    public interface SimpleExtConfigure
+    {
+        void configure(@NonNull SimpleExtPlugin plugin);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleSyntaxHighlight.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleSyntaxHighlight.java
@@ -2,67 +2,73 @@ package com.zeoflow.stylar.syntax;
 
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.zeoflow.stylar.codestyle.CodeStyle;
 
-public class CodeStyleSyntaxHighlight implements SyntaxHighlight {
-
-    @NonNull
-    public static CodeStyleSyntaxHighlight create(
-            @NonNull CodeStyle codeStyle,
-            @NonNull CodeStyleTheme theme) {
-        return new CodeStyleSyntaxHighlight(codeStyle, theme, null);
-    }
-
-    @NonNull
-    public static CodeStyleSyntaxHighlight create(
-            @NonNull CodeStyle codeStyle,
-            @NonNull CodeStyleTheme theme,
-            @Nullable String fallback) {
-        return new CodeStyleSyntaxHighlight(codeStyle, theme, fallback);
-    }
+public class CodeStyleSyntaxHighlight implements SyntaxHighlight
+{
 
     private final CodeStyle codeStyle;
     private final CodeStyleTheme theme;
     private final String fallback;
-
     protected CodeStyleSyntaxHighlight(
-            @NonNull CodeStyle codeStyle,
-            @NonNull CodeStyleTheme theme,
-            @Nullable String fallback) {
+        @NonNull CodeStyle codeStyle,
+        @NonNull CodeStyleTheme theme,
+        @Nullable String fallback)
+    {
         this.codeStyle = codeStyle;
         this.theme = theme;
         this.fallback = fallback;
     }
 
     @NonNull
+    public static CodeStyleSyntaxHighlight create(
+        @NonNull CodeStyle codeStyle,
+        @NonNull CodeStyleTheme theme)
+    {
+        return new CodeStyleSyntaxHighlight(codeStyle, theme, null);
+    }
+
+    @NonNull
+    public static CodeStyleSyntaxHighlight create(
+        @NonNull CodeStyle codeStyle,
+        @NonNull CodeStyleTheme theme,
+        @Nullable String fallback)
+    {
+        return new CodeStyleSyntaxHighlight(codeStyle, theme, fallback);
+    }
+
+    @NonNull
     @Override
-    public CharSequence highlight(@Nullable String info, @NonNull String code) {
+    public CharSequence highlight(@Nullable String info, @NonNull String code)
+    {
 
         // @since 4.2.2
         // although not null, but still is empty
-        if (code.isEmpty()) {
+        if (code.isEmpty())
+        {
             return code;
         }
 
         // if info is null, do not highlight -> LICENCE footer very commonly wrapped inside code
         // block without syntax name specified (so, do not highlight)
         return info == null
-                ? highlightNoLanguageInfo(code)
-                : highlightWithLanguageInfo(info, code);
+            ? highlightNoLanguageInfo(code)
+            : highlightWithLanguageInfo(info, code);
     }
 
     @NonNull
-    protected CharSequence highlightNoLanguageInfo(@NonNull String code) {
+    protected CharSequence highlightNoLanguageInfo(@NonNull String code)
+    {
         return code;
     }
 
     @NonNull
-    protected CharSequence highlightWithLanguageInfo(@NonNull String info, @NonNull String code) {
+    protected CharSequence highlightWithLanguageInfo(@NonNull String info, @NonNull String code)
+    {
 
         final CharSequence out;
 
@@ -71,7 +77,8 @@ public class CodeStyleSyntaxHighlight implements SyntaxHighlight {
         {
             String _language = info;
             CodeStyle.Grammar _grammar = codeStyle.grammar(info);
-            if (_grammar == null && !TextUtils.isEmpty(fallback)) {
+            if (_grammar == null && !TextUtils.isEmpty(fallback))
+            {
                 _language = fallback;
                 assert fallback != null;
                 _grammar = codeStyle.grammar(fallback);
@@ -80,9 +87,11 @@ public class CodeStyleSyntaxHighlight implements SyntaxHighlight {
             grammar = _grammar;
         }
 
-        if (grammar != null) {
+        if (grammar != null)
+        {
             out = highlight(language, grammar, code);
-        } else {
+        } else
+        {
             out = code;
         }
 
@@ -90,7 +99,8 @@ public class CodeStyleSyntaxHighlight implements SyntaxHighlight {
     }
 
     @NonNull
-    protected CharSequence highlight(@NonNull String language, @NonNull CodeStyle.Grammar grammar, @NonNull String code) {
+    protected CharSequence highlight(@NonNull String language, @NonNull CodeStyle.Grammar grammar, @NonNull String code)
+    {
         final SpannableStringBuilder builder = new SpannableStringBuilder();
         final CodeStyleSyntaxVisitor visitor = new CodeStyleSyntaxVisitor(language, theme, builder);
         visitor.visit(codeStyle.tokenize(code, grammar));
@@ -98,17 +108,20 @@ public class CodeStyleSyntaxHighlight implements SyntaxHighlight {
     }
 
     @NonNull
-    protected CodeStyle codestyle() {
+    protected CodeStyle codestyle()
+    {
         return codeStyle;
     }
 
     @NonNull
-    protected CodeStyleTheme theme() {
+    protected CodeStyleTheme theme()
+    {
         return theme;
     }
 
     @Nullable
-    protected String fallback() {
+    protected String fallback()
+    {
         return fallback;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleSyntaxVisitor.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleSyntaxVisitor.java
@@ -7,34 +7,39 @@ import androidx.annotation.NonNull;
 import com.zeoflow.stylar.codestyle.AbsVisitor;
 import com.zeoflow.stylar.codestyle.CodeStyle;
 
-class CodeStyleSyntaxVisitor extends AbsVisitor {
+class CodeStyleSyntaxVisitor extends AbsVisitor
+{
 
     private final String language;
     private final CodeStyleTheme theme;
     private final SpannableStringBuilder builder;
 
     CodeStyleSyntaxVisitor(
-            @NonNull String language,
-            @NonNull CodeStyleTheme theme,
-            @NonNull SpannableStringBuilder builder) {
+        @NonNull String language,
+        @NonNull CodeStyleTheme theme,
+        @NonNull SpannableStringBuilder builder)
+    {
         this.language = language;
         this.theme = theme;
         this.builder = builder;
     }
 
     @Override
-    protected void visitText(@NonNull CodeStyle.Text text) {
+    protected void visitText(@NonNull CodeStyle.Text text)
+    {
         builder.append(text.literal());
     }
 
     @Override
-    protected void visitSyntax(@NonNull CodeStyle.Syntax syntax) {
+    protected void visitSyntax(@NonNull CodeStyle.Syntax syntax)
+    {
 
         final int start = builder.length();
         visit(syntax.children());
         final int end = builder.length();
 
-        if (end != start) {
+        if (end != start)
+        {
             theme.apply(language, syntax, builder, start, end);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleTheme.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleTheme.java
@@ -17,10 +17,10 @@ public interface CodeStyleTheme
     int textColor();
 
     void apply(
-            @NonNull String language,
-            @NonNull CodeStyle.Syntax syntax,
-            @NonNull SpannableStringBuilder builder,
-            int start,
-            int end
+        @NonNull String language,
+        @NonNull CodeStyle.Syntax syntax,
+        @NonNull SpannableStringBuilder builder,
+        int start,
+        int end
     );
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleThemeBase.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleThemeBase.java
@@ -10,107 +10,122 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.util.HashMap;
-
 import com.zeoflow.stylar.codestyle.CodeStyle;
+
+import java.util.HashMap;
 
 public abstract class CodeStyleThemeBase implements CodeStyleTheme
 {
 
+    private final ColorHashMap colorHashMap;
+
+    protected CodeStyleThemeBase()
+    {
+        this.colorHashMap = init();
+    }
+
     @ColorInt
-    protected static int applyAlpha(@IntRange(from = 0, to = 255) int alpha, @ColorInt int color) {
+    protected static int applyAlpha(@IntRange(from = 0, to = 255) int alpha, @ColorInt int color)
+    {
         return (color & 0x00FFFFFF) | (alpha << 24);
     }
 
     @ColorInt
-    protected static int applyAlpha(@FloatRange(from = .0F, to = 1.F) float alpha, @ColorInt int color) {
+    protected static int applyAlpha(@FloatRange(from = .0F, to = 1.F) float alpha, @ColorInt int color)
+    {
         return applyAlpha((int) (255 * alpha + .5F), color);
     }
 
-    protected static boolean isOfType(@NonNull String expected, @NonNull String type, @Nullable String alias) {
+    protected static boolean isOfType(@NonNull String expected, @NonNull String type, @Nullable String alias)
+    {
         return expected.equals(type) || expected.equals(alias);
-    }
-
-    private final ColorHashMap colorHashMap;
-
-    protected CodeStyleThemeBase() {
-        this.colorHashMap = init();
     }
 
     @NonNull
     protected abstract ColorHashMap init();
 
     @ColorInt
-    protected int color(@NonNull String language, @NonNull String type, @Nullable String alias) {
+    protected int color(@NonNull String language, @NonNull String type, @Nullable String alias)
+    {
 
         Color color = colorHashMap.get(type);
         if (color == null
-                && alias != null) {
+            && alias != null)
+        {
             color = colorHashMap.get(alias);
         }
 
         return color != null
-                ? color.color
-                : 0;
+            ? color.color
+            : 0;
     }
 
     @Override
     public void apply(
-            @NonNull String language,
-            @NonNull CodeStyle.Syntax syntax,
-            @NonNull SpannableStringBuilder builder,
-            int start,
-            int end) {
+        @NonNull String language,
+        @NonNull CodeStyle.Syntax syntax,
+        @NonNull SpannableStringBuilder builder,
+        int start,
+        int end)
+    {
 
         final String type = syntax.type();
         final String alias = syntax.alias();
 
         final int color = color(language, type, alias);
-        if (color != 0) {
+        if (color != 0)
+        {
             applyColor(language, type, alias, color, builder, start, end);
         }
     }
 
     @SuppressWarnings("unused")
     protected void applyColor(
-            @NonNull String language,
-            @NonNull String type,
-            @Nullable String alias,
-            @ColorInt int color,
-            @NonNull SpannableStringBuilder builder,
-            int start,
-            int end) {
+        @NonNull String language,
+        @NonNull String type,
+        @Nullable String alias,
+        @ColorInt int color,
+        @NonNull SpannableStringBuilder builder,
+        int start,
+        int end)
+    {
         builder.setSpan(new ForegroundColorSpan(color), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     }
 
-    protected static class Color {
-
-        @NonNull
-        public static Color of(@ColorInt int color) {
-            return new Color(color);
-        }
+    protected static class Color
+    {
 
         @ColorInt
         protected final int color;
 
-        protected Color(@ColorInt int color) {
+        protected Color(@ColorInt int color)
+        {
             this.color = color;
+        }
+
+        @NonNull
+        public static Color of(@ColorInt int color)
+        {
+            return new Color(color);
         }
     }
 
-    protected static class ColorHashMap extends HashMap<String, Color> {
+    protected static class ColorHashMap extends HashMap<String, Color>
+    {
 
         @NonNull
-        protected ColorHashMap add(@ColorInt int color, String name) {
+        protected ColorHashMap add(@ColorInt int color, String name)
+        {
             put(name, Color.of(color));
             return this;
         }
 
         @NonNull
         protected ColorHashMap add(
-                @ColorInt int color,
-                @NonNull String name1,
-                @NonNull String name2) {
+            @ColorInt int color,
+            @NonNull String name1,
+            @NonNull String name2)
+        {
             final Color c = Color.of(color);
             put(name1, c);
             put(name2, c);
@@ -119,10 +134,11 @@ public abstract class CodeStyleThemeBase implements CodeStyleTheme
 
         @NonNull
         protected ColorHashMap add(
-                @ColorInt int color,
-                @NonNull String name1,
-                @NonNull String name2,
-                @NonNull String name3) {
+            @ColorInt int color,
+            @NonNull String name1,
+            @NonNull String name2,
+            @NonNull String name3)
+        {
             final Color c = Color.of(color);
             put(name1, c);
             put(name2, c);
@@ -131,9 +147,11 @@ public abstract class CodeStyleThemeBase implements CodeStyleTheme
         }
 
         @NonNull
-        protected ColorHashMap add(@ColorInt int color, String... names) {
+        protected ColorHashMap add(@ColorInt int color, String... names)
+        {
             final Color c = Color.of(color);
-            for (String name : names) {
+            for (String name : names)
+            {
                 put(name, c);
             }
             return this;

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleThemeDarkula.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleThemeDarkula.java
@@ -13,8 +13,16 @@ import com.zeoflow.stylar.core.spans.StrongEmphasisSpan;
 public class CodeStyleThemeDarkula extends CodeStyleThemeBase
 {
 
+    private final int background;
+
+    public CodeStyleThemeDarkula(@ColorInt int background)
+    {
+        this.background = background;
+    }
+
     @NonNull
-    public static CodeStyleThemeDarkula create() {
+    public static CodeStyleThemeDarkula create()
+    {
         return new CodeStyleThemeDarkula(0xFF2d2d2d);
     }
 
@@ -23,56 +31,57 @@ public class CodeStyleThemeDarkula extends CodeStyleThemeBase
      * @since 3.0.0
      */
     @NonNull
-    public static CodeStyleThemeDarkula create(@ColorInt int background) {
+    public static CodeStyleThemeDarkula create(@ColorInt int background)
+    {
         return new CodeStyleThemeDarkula(background);
     }
 
-    private final int background;
-
-    public CodeStyleThemeDarkula(@ColorInt int background) {
-        this.background = background;
-    }
-
     @Override
-    public int background() {
+    public int background()
+    {
         return background;
     }
 
     @Override
-    public int textColor() {
+    public int textColor()
+    {
         return 0xFFa9b7c6;
     }
 
     @NonNull
     @Override
-    protected ColorHashMap init() {
+    protected ColorHashMap init()
+    {
         return new ColorHashMap()
-                .add(0xFF808080, "comment", "prolog", "cdata")
-                .add(0xFFcc7832, "delimiter", "boolean", "keyword", "selector", "important", "atrule")
-                .add(0xFFa9b7c6, "operator", "punctuation", "attr-name")
-                .add(0xFFe8bf6a, "tag", "doctype", "builtin")
-                .add(0xFF6897bb, "entity", "number", "symbol")
-                .add(0xFF9876aa, "property", "constant", "variable")
-                .add(0xFF6a8759, "string", "char")
-                .add(0xFFbbb438, "annotation")
-                .add(0xFFa5c261, "attr-value")
-                .add(0xFF287bde, "url")
-                .add(0xFFffc66d, "function")
-                .add(0xFF364135, "regex")
-                .add(0xFF294436, "inserted")
-                .add(0xFF484a4a, "deleted");
+            .add(0xFF808080, "comment", "prolog", "cdata")
+            .add(0xFFcc7832, "delimiter", "boolean", "keyword", "selector", "important", "atrule")
+            .add(0xFFa9b7c6, "operator", "punctuation", "attr-name")
+            .add(0xFFe8bf6a, "tag", "doctype", "builtin")
+            .add(0xFF6897bb, "entity", "number", "symbol")
+            .add(0xFF9876aa, "property", "constant", "variable")
+            .add(0xFF6a8759, "string", "char")
+            .add(0xFFbbb438, "annotation")
+            .add(0xFFa5c261, "attr-value")
+            .add(0xFF287bde, "url")
+            .add(0xFFffc66d, "function")
+            .add(0xFF364135, "regex")
+            .add(0xFF294436, "inserted")
+            .add(0xFF484a4a, "deleted");
     }
 
     @Override
-    protected void applyColor(@NonNull String language, @NonNull String type, @Nullable String alias, int color, @NonNull SpannableStringBuilder builder, int start, int end) {
+    protected void applyColor(@NonNull String language, @NonNull String type, @Nullable String alias, int color, @NonNull SpannableStringBuilder builder, int start, int end)
+    {
         super.applyColor(language, type, alias, color, builder, start, end);
 
         if (isOfType("important", type, alias)
-                || isOfType("bold", type, alias)) {
+            || isOfType("bold", type, alias))
+        {
             builder.setSpan(new StrongEmphasisSpan(), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
-        if (isOfType("italic", type, alias)) {
+        if (isOfType("italic", type, alias))
+        {
             builder.setSpan(new EmphasisSpan(), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleThemeDefault.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/CodeStyleThemeDefault.java
@@ -14,8 +14,16 @@ import com.zeoflow.stylar.core.spans.StrongEmphasisSpan;
 public class CodeStyleThemeDefault extends CodeStyleThemeBase
 {
 
+    private final int background;
+
+    public CodeStyleThemeDefault(@ColorInt int background)
+    {
+        this.background = background;
+    }
+
     @NonNull
-    public static CodeStyleThemeDefault create() {
+    public static CodeStyleThemeDefault create()
+    {
         return new CodeStyleThemeDefault(0xFFf5f2f0);
     }
 
@@ -23,68 +31,71 @@ public class CodeStyleThemeDefault extends CodeStyleThemeBase
      * @since 3.0.0
      */
     @NonNull
-    public static CodeStyleThemeDefault create(@ColorInt int background) {
+    public static CodeStyleThemeDefault create(@ColorInt int background)
+    {
         return new CodeStyleThemeDefault(background);
     }
 
-    private final int background;
-
-    public CodeStyleThemeDefault(@ColorInt int background) {
-        this.background = background;
-    }
-
     @Override
-    public int background() {
+    public int background()
+    {
         return background;
     }
 
     @Override
-    public int textColor() {
+    public int textColor()
+    {
         return 0xdd000000;
     }
 
     @NonNull
     @Override
-    protected ColorHashMap init() {
+    protected ColorHashMap init()
+    {
         return new ColorHashMap()
-                .add(0xFF708090, "comment", "prolog", "doctype", "cdata")
-                .add(0xFF999999, "punctuation")
-                .add(0xFF990055, "property", "tag", "boolean", "number", "constant", "symbol", "deleted")
-                .add(0xFF669900, "selector", "attr-name", "string", "char", "builtin", "inserted")
-                .add(0xFF9a6e3a, "operator", "entity", "url")
-                .add(0xFF0077aa, "atrule", "attr-value", "keyword")
-                .add(0xFFDD4A68, "function", "class-name")
-                .add(0xFFee9900, "regex", "important", "variable");
+            .add(0xFF708090, "comment", "prolog", "doctype", "cdata")
+            .add(0xFF999999, "punctuation")
+            .add(0xFF990055, "property", "tag", "boolean", "number", "constant", "symbol", "deleted")
+            .add(0xFF669900, "selector", "attr-name", "string", "char", "builtin", "inserted")
+            .add(0xFF9a6e3a, "operator", "entity", "url")
+            .add(0xFF0077aa, "atrule", "attr-value", "keyword")
+            .add(0xFFDD4A68, "function", "class-name")
+            .add(0xFFee9900, "regex", "important", "variable");
     }
 
     @Override
     protected void applyColor(
-            @NonNull String language,
-            @NonNull String type,
-            @Nullable String alias,
-            @ColorInt int color,
-            @NonNull SpannableStringBuilder builder,
-            int start,
-            int end) {
+        @NonNull String language,
+        @NonNull String type,
+        @Nullable String alias,
+        @ColorInt int color,
+        @NonNull SpannableStringBuilder builder,
+        int start,
+        int end)
+    {
 
-        if ("css".equals(language) && isOfType("string", type, alias)) {
+        if ("css".equals(language) && isOfType("string", type, alias))
+        {
             super.applyColor(language, type, alias, 0xFF9a6e3a, builder, start, end);
             builder.setSpan(new BackgroundColorSpan(0x80ffffff), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
             return;
         }
 
-        if (isOfType("namespace", type, alias)) {
+        if (isOfType("namespace", type, alias))
+        {
             color = applyAlpha(.7F, color);
         }
 
         super.applyColor(language, type, alias, color, builder, start, end);
 
         if (isOfType("important", type, alias)
-                || isOfType("bold", type, alias)) {
+            || isOfType("bold", type, alias))
+        {
             builder.setSpan(new StrongEmphasisSpan(), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
-        if (isOfType("italic", type, alias)) {
+        if (isOfType("italic", type, alias))
+        {
             builder.setSpan(new EmphasisSpan(), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/SyntaxHighlight.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/SyntaxHighlight.java
@@ -4,7 +4,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 @SuppressWarnings("WeakerAccess")
-public interface SyntaxHighlight {
+public interface SyntaxHighlight
+{
 
     @NonNull
     CharSequence highlight(@Nullable String info, @NonNull String code);

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/SyntaxHighlightNoOp.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/SyntaxHighlightNoOp.java
@@ -3,10 +3,12 @@ package com.zeoflow.stylar.syntax;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-public class SyntaxHighlightNoOp implements SyntaxHighlight {
+public class SyntaxHighlightNoOp implements SyntaxHighlight
+{
     @NonNull
     @Override
-    public CharSequence highlight(@Nullable String info, @NonNull String code) {
+    public CharSequence highlight(@Nullable String info, @NonNull String code)
+    {
         return code;
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/syntax/SyntaxHighlightPlugin.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/syntax/SyntaxHighlightPlugin.java
@@ -11,43 +11,47 @@ import com.zeoflow.stylar.core.StylarTheme;
 public class SyntaxHighlightPlugin extends AbstractStylarPlugin
 {
 
-    @NonNull
-    public static SyntaxHighlightPlugin create(
-            @NonNull CodeStyle codeStyle,
-            @NonNull CodeStyleTheme theme) {
-        return create(codeStyle, theme, null);
-    }
-
-    @NonNull
-    public static SyntaxHighlightPlugin create(
-            @NonNull CodeStyle codeStyle,
-            @NonNull CodeStyleTheme theme,
-            @Nullable String fallbackLanguage) {
-        return new SyntaxHighlightPlugin(codeStyle, theme, fallbackLanguage);
-    }
-
     private final CodeStyle codeStyle;
     private final CodeStyleTheme theme;
     private final String fallbackLanguage;
-
     public SyntaxHighlightPlugin(
-            @NonNull CodeStyle codeStyle,
-            @NonNull CodeStyleTheme theme,
-            @Nullable String fallbackLanguage) {
+        @NonNull CodeStyle codeStyle,
+        @NonNull CodeStyleTheme theme,
+        @Nullable String fallbackLanguage)
+    {
         this.codeStyle = codeStyle;
         this.theme = theme;
         this.fallbackLanguage = fallbackLanguage;
     }
 
-    @Override
-    public void configureTheme(@NonNull StylarTheme.Builder builder) {
-        builder
-                .codeTextColor(theme.textColor())
-                .codeBackgroundColor(theme.background());
+    @NonNull
+    public static SyntaxHighlightPlugin create(
+        @NonNull CodeStyle codeStyle,
+        @NonNull CodeStyleTheme theme)
+    {
+        return create(codeStyle, theme, null);
+    }
+
+    @NonNull
+    public static SyntaxHighlightPlugin create(
+        @NonNull CodeStyle codeStyle,
+        @NonNull CodeStyleTheme theme,
+        @Nullable String fallbackLanguage)
+    {
+        return new SyntaxHighlightPlugin(codeStyle, theme, fallbackLanguage);
     }
 
     @Override
-    public void configureConfiguration(@NonNull StylarConfiguration.Builder builder) {
+    public void configureTheme(@NonNull StylarTheme.Builder builder)
+    {
+        builder
+            .codeTextColor(theme.textColor())
+            .codeBackgroundColor(theme.background());
+    }
+
+    @Override
+    public void configureConfiguration(@NonNull StylarConfiguration.Builder builder)
+    {
         builder.syntaxHighlight(CodeStyleSyntaxHighlight.create(codeStyle, theme, fallbackLanguage));
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/test/TestSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/test/TestSpan.java
@@ -13,37 +13,51 @@ import java.util.Map;
  *
  * @since 3.0.0
  */
-public abstract class TestSpan {
+public abstract class TestSpan
+{
+
+    // package-private constructor
+    TestSpan()
+    {
+    }
 
     @NonNull
-    public static TestSpan.Document document(TestSpan... children) {
+    public static TestSpan.Document document(TestSpan... children)
+    {
         return new TestSpanDocument(children(children));
     }
 
     @NonNull
-    public static TestSpan.Span span(@NonNull String name, TestSpan... children) {
+    public static TestSpan.Span span(@NonNull String name, TestSpan... children)
+    {
         return span(name, Collections.<String, Object>emptyMap(), children);
     }
 
     @NonNull
-    public static TestSpan.Span span(@NonNull String name, @NonNull Map<String, Object> arguments, TestSpan... children) {
+    public static TestSpan.Span span(@NonNull String name, @NonNull Map<String, Object> arguments, TestSpan... children)
+    {
         return new TestSpanSpan(name, children(children), arguments);
     }
 
     @NonNull
-    public static TestSpan.Text text(@NonNull String literal) {
+    public static TestSpan.Text text(@NonNull String literal)
+    {
         return new TestSpanText(literal);
     }
 
     @NonNull
-    public static List<TestSpan> children(TestSpan... children) {
+    public static List<TestSpan> children(TestSpan... children)
+    {
         final int length = children.length;
         final List<TestSpan> list;
-        if (length == 0) {
+        if (length == 0)
+        {
             list = Collections.emptyList();
-        } else if (length == 1) {
+        } else if (length == 1)
+        {
             list = Collections.singletonList(children[0]);
-        } else {
+        } else
+        {
             final List<TestSpan> spans = new ArrayList<>(length);
             Collections.addAll(spans, children);
             list = Collections.unmodifiableList(spans);
@@ -52,17 +66,20 @@ public abstract class TestSpan {
     }
 
     @NonNull
-    public static Map<String, Object> args(Object... args) {
+    public static Map<String, Object> args(Object... args)
+    {
 
         final int length = args.length;
-        if (length == 0) {
+        if (length == 0)
+        {
             return Collections.emptyMap();
         }
 
         // validate that length is even (k=v)
-        if ((length % 2) != 0) {
+        if ((length % 2) != 0)
+        {
             throw new IllegalStateException("Supplied key-values array must contain " +
-                    "even number of arguments");
+                "even number of arguments");
         }
 
         final Map<String, Object> map = new HashMap<>(length / 2 + 1);
@@ -70,7 +87,8 @@ public abstract class TestSpan {
         String key;
         Object value;
 
-        for (int i = 0; i < length; i += 2) {
+        for (int i = 0; i < length; i += 2)
+        {
             // possible class-cast exception
             key = (String) args[i];
             value = args[i + 1];
@@ -79,7 +97,6 @@ public abstract class TestSpan {
 
         return Collections.unmodifiableMap(map);
     }
-
 
     @NonNull
     public abstract List<TestSpan> children();
@@ -90,14 +107,15 @@ public abstract class TestSpan {
     @Override
     public abstract boolean equals(Object o);
 
-
-    public static abstract class Document extends TestSpan {
+    public static abstract class Document extends TestSpan
+    {
 
         @NonNull
         public abstract String wholeText();
     }
 
-    public static abstract class Text extends TestSpan {
+    public static abstract class Text extends TestSpan
+    {
 
         @NonNull
         public abstract String literal();
@@ -106,7 +124,8 @@ public abstract class TestSpan {
     }
 
     // important: children should not be included in equals...
-    public static abstract class Span extends TestSpan {
+    public static abstract class Span extends TestSpan
+    {
 
         @NonNull
         public abstract String name();
@@ -117,9 +136,5 @@ public abstract class TestSpan {
         @NonNull
         @Override
         public abstract List<TestSpan> children();
-    }
-
-    // package-private constructor
-    TestSpan() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanDocument.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanDocument.java
@@ -4,39 +4,49 @@ import androidx.annotation.NonNull;
 
 import java.util.List;
 
-class TestSpanDocument extends TestSpan.Document {
-
-    private static void fillWholeText(@NonNull StringBuilder builder, @NonNull TestSpan span) {
-        if (span instanceof Text) {
-            builder.append(((Text) span).literal());
-        } else if (span instanceof Span) {
-            for (TestSpan child : span.children()) {
-                fillWholeText(builder, child);
-            }
-        } else {
-            throw new IllegalStateException("Unexpected state. Found unexpected TestSpan " +
-                    "object of type `" + span.getClass().getName() + "`");
-        }
-    }
+class TestSpanDocument extends TestSpan.Document
+{
 
     private final List<TestSpan> children;
 
-    TestSpanDocument(@NonNull List<TestSpan> children) {
+    TestSpanDocument(@NonNull List<TestSpan> children)
+    {
         this.children = children;
+    }
+
+    private static void fillWholeText(@NonNull StringBuilder builder, @NonNull TestSpan span)
+    {
+        if (span instanceof Text)
+        {
+            builder.append(((Text) span).literal());
+        } else if (span instanceof Span)
+        {
+            for (TestSpan child : span.children())
+            {
+                fillWholeText(builder, child);
+            }
+        } else
+        {
+            throw new IllegalStateException("Unexpected state. Found unexpected TestSpan " +
+                "object of type `" + span.getClass().getName() + "`");
+        }
     }
 
     @NonNull
     @Override
-    public List<TestSpan> children() {
+    public List<TestSpan> children()
+    {
         return children;
     }
 
     @NonNull
     @Override
-    public String wholeText() {
+    public String wholeText()
+    {
         final StringBuilder builder = new StringBuilder();
 
-        for (TestSpan child : children) {
+        for (TestSpan child : children)
+        {
             fillWholeText(builder, child);
         }
 
@@ -44,7 +54,8 @@ class TestSpanDocument extends TestSpan.Document {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(Object o)
+    {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -54,7 +65,8 @@ class TestSpanDocument extends TestSpan.Document {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return children.hashCode();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanEnumerator.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanEnumerator.java
@@ -2,19 +2,19 @@ package com.zeoflow.stylar.test;
 
 import androidx.annotation.NonNull;
 
-public class TestSpanEnumerator {
+public class TestSpanEnumerator
+{
 
-    public interface Listener {
-        void onNext(int start, int end, @NonNull TestSpan span);
-    }
-
-    public void enumerate(@NonNull TestSpan.Document document, @NonNull Listener listener) {
+    public void enumerate(@NonNull TestSpan.Document document, @NonNull Listener listener)
+    {
         visit(0, document, listener);
     }
 
-    private int visit(int start, @NonNull TestSpan span, @NonNull Listener listener) {
+    private int visit(int start, @NonNull TestSpan span, @NonNull Listener listener)
+    {
 
-        if (span instanceof TestSpan.Text) {
+        if (span instanceof TestSpan.Text)
+        {
             final int end = start + ((TestSpan.Text) span).length();
             listener.onNext(start, end, span);
             return end;
@@ -23,12 +23,18 @@ public class TestSpanEnumerator {
         // yeah, we will need end... and from recursive call also -> children can have text inside
         int s = start;
 
-        for (TestSpan child : span.children()) {
+        for (TestSpan child : span.children())
+        {
             s = visit(s, child, listener);
         }
 
         listener.onNext(start, s, span);
 
         return s;
+    }
+
+    public interface Listener
+    {
+        void onNext(int start, int end, @NonNull TestSpan span);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanMatcher.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanMatcher.java
@@ -13,9 +13,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import ix.Ix;
 import ix.IxPredicate;
 
-public abstract class TestSpanMatcher {
+public abstract class TestSpanMatcher
+{
 
-    public static void matches(@NonNull final Spanned spanned, @NonNull TestSpan.Document document) {
+    private TestSpanMatcher()
+    {
+    }
+
+    public static void matches(@NonNull final Spanned spanned, @NonNull TestSpan.Document document)
+    {
 
         // assert number for spans
         // assert raw text
@@ -25,25 +31,31 @@ public abstract class TestSpanMatcher {
         // keep track of total spans encountered
         final AtomicInteger counter = new AtomicInteger();
 
-        enumerator.enumerate(document, new TestSpanEnumerator.Listener() {
+        enumerator.enumerate(document, new TestSpanEnumerator.Listener()
+        {
             @Override
-            public void onNext(final int start, final int end, @NonNull TestSpan span) {
-                if (span instanceof TestSpan.Document) {
+            public void onNext(final int start, final int end, @NonNull TestSpan span)
+            {
+                if (span instanceof TestSpan.Document)
+                {
 
                     TestSpanMatcher.documentMatches(spanned, (TestSpan.Document) span);
-                } else if (span instanceof TestSpan.Span) {
+                } else if (span instanceof TestSpan.Span)
+                {
 
                     // increment span count so after enumeration we match total number of spans
                     counter.incrementAndGet();
 
                     TestSpanMatcher.spanMatches(spanned, start, end, (TestSpan.Span) span);
 
-                } else if (span instanceof TestSpan.Text) {
+                } else if (span instanceof TestSpan.Text)
+                {
                     TestSpanMatcher.textMatches(spanned, start, end, (TestSpan.Text) span);
-                } else {
+                } else
+                {
                     // in case we add a new type
                     throw new IllegalStateException("Unexpected type of a TestSpan: `"
-                            + span.getClass().getName() + "`, " + span);
+                        + span.getClass().getName() + "`, " + span);
                 }
             }
         });
@@ -53,83 +65,90 @@ public abstract class TestSpanMatcher {
     }
 
     public static void documentMatches(
-            @NonNull Spanned spanned,
-            @NonNull TestSpan.Document document) {
+        @NonNull Spanned spanned,
+        @NonNull TestSpan.Document document)
+    {
 
         // match full text
 
         final String expected = document.wholeText();
         final String actual = spanned.toString();
 
-        if (!expected.equals(actual)) {
+        if (!expected.equals(actual))
+        {
             throw new ComparisonFailure(
-                    "Document text mismatch",
-                    expected,
-                    actual);
+                "Document text mismatch",
+                expected,
+                actual);
         }
     }
 
     public static void spanMatches(
-            @NonNull final Spanned spanned,
-            final int start,
-            final int end,
-            @NonNull final TestSpan.Span expected) {
+        @NonNull final Spanned spanned,
+        final int start,
+        final int end,
+        @NonNull final TestSpan.Span expected)
+    {
 
         // when queried multiple spans can be returned (for example if one span
         // wraps another one. so [0 1 [2 3] 4 5] where [] represents start/end of
         // a span of same type, when queried for spans at 2-3 position, both will be returned
         final TestSpan.Span actual = Ix.fromArray(spanned.getSpans(start, end, Object.class))
-                .cast(TestSpan.Span.class)
-                .filter(new IxPredicate<TestSpan.Span>() {
-                    @Override
-                    public boolean test(TestSpan.Span span) {
-                        return expected.name().equals(span.name())
-                                && start == spanned.getSpanStart(span)
-                                && end == spanned.getSpanEnd(span)
-                                && expected.arguments().equals(span.arguments());
-                    }
-                })
-                .first(null);
+            .cast(TestSpan.Span.class)
+            .filter(new IxPredicate<TestSpan.Span>()
+            {
+                @Override
+                public boolean test(TestSpan.Span span)
+                {
+                    return expected.name().equals(span.name())
+                        && start == spanned.getSpanStart(span)
+                        && end == spanned.getSpanEnd(span)
+                        && expected.arguments().equals(span.arguments());
+                }
+            })
+            .first(null);
 
-        if (!expected.equals(actual)) {
+        if (!expected.equals(actual))
+        {
 
             final String expectedSpan = expected.arguments().isEmpty()
-                    ? expected.name()
-                    : expected.name() + ": " + expected.arguments();
+                ? expected.name()
+                : expected.name() + ": " + expected.arguments();
 
             final String actualSpan;
-            if (actual == null) {
+            if (actual == null)
+            {
                 actualSpan = "null";
-            } else {
+            } else
+            {
                 actualSpan = actual.arguments().isEmpty()
-                        ? actual.name()
-                        : actual.name() + ": " + actual.arguments();
+                    ? actual.name()
+                    : actual.name() + ": " + actual.arguments();
             }
 
             throw new AssertionError(
-                    String.format(Locale.US, "Expected span{%s} at {start: %d, end: %d}, found: %s, text: \"%s\"",
-                            expectedSpan, start, end, actualSpan, spanned.subSequence(start, end)));
+                String.format(Locale.US, "Expected span{%s} at {start: %d, end: %d}, found: %s, text: \"%s\"",
+                    expectedSpan, start, end, actualSpan, spanned.subSequence(start, end)));
         }
     }
 
     public static void textMatches(
-            @NonNull Spanned spanned,
-            int start,
-            int end,
-            @NonNull TestSpan.Text text) {
+        @NonNull Spanned spanned,
+        int start,
+        int end,
+        @NonNull TestSpan.Text text)
+    {
 
         final String expected = text.literal();
         final String actual = spanned.subSequence(start, end).toString();
 
-        if (!expected.equals(actual)) {
+        if (!expected.equals(actual))
+        {
             throw new ComparisonFailure(
-                    String.format(Locale.US, "Text mismatch at {start: %d, end: %d}", start, end),
-                    expected,
-                    actual
+                String.format(Locale.US, "Text mismatch at {start: %d, end: %d}", start, end),
+                expected,
+                actual
             );
         }
-    }
-
-    private TestSpanMatcher() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanSpan.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanSpan.java
@@ -5,16 +5,18 @@ import androidx.annotation.NonNull;
 import java.util.List;
 import java.util.Map;
 
-class TestSpanSpan extends TestSpan.Span {
+class TestSpanSpan extends TestSpan.Span
+{
 
     private final String name;
     private final List<TestSpan> children;
     private final Map<String, Object> arguments;
 
     public TestSpanSpan(
-            @NonNull String name,
-            @NonNull List<TestSpan> children,
-            @NonNull Map<String, Object> arguments) {
+        @NonNull String name,
+        @NonNull List<TestSpan> children,
+        @NonNull Map<String, Object> arguments)
+    {
         this.name = name;
         this.children = children;
         this.arguments = arguments;
@@ -22,24 +24,28 @@ class TestSpanSpan extends TestSpan.Span {
 
     @NonNull
     @Override
-    public String name() {
+    public String name()
+    {
         return name;
     }
 
     @NonNull
     @Override
-    public Map<String, Object> arguments() {
+    public Map<String, Object> arguments()
+    {
         return arguments;
     }
 
     @NonNull
     @Override
-    public List<TestSpan> children() {
+    public List<TestSpan> children()
+    {
         return children;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(Object o)
+    {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -50,7 +56,8 @@ class TestSpanSpan extends TestSpan.Span {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         int result = name.hashCode();
         result = 31 * result + arguments.hashCode();
         return result;

--- a/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanText.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/test/TestSpanText.java
@@ -5,33 +5,39 @@ import androidx.annotation.NonNull;
 import java.util.Collections;
 import java.util.List;
 
-class TestSpanText extends TestSpan.Text {
+class TestSpanText extends TestSpan.Text
+{
 
     private final String literal;
 
-    TestSpanText(@NonNull String literal) {
+    TestSpanText(@NonNull String literal)
+    {
         this.literal = literal;
     }
 
     @NonNull
     @Override
-    public String literal() {
+    public String literal()
+    {
         return literal;
     }
 
     @Override
-    public int length() {
+    public int length()
+    {
         return literal.length();
     }
 
     @NonNull
     @Override
-    public List<TestSpan> children() {
+    public List<TestSpan> children()
+    {
         return Collections.emptyList();
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(Object o)
+    {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -41,7 +47,8 @@ class TestSpanText extends TestSpan.Text {
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return literal.hashCode();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/ColorUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/ColorUtils.java
@@ -6,28 +6,32 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.FloatRange;
 import androidx.annotation.IntRange;
 
-public abstract class ColorUtils {
+public abstract class ColorUtils
+{
+
+    private ColorUtils()
+    {
+    }
 
     @ColorInt
     public static int applyAlpha(
-            @ColorInt int color,
-            @IntRange(from = 0, to = 255) int alpha) {
+        @ColorInt int color,
+        @IntRange(from = 0, to = 255) int alpha)
+    {
         return (color & 0x00FFFFFF) | (alpha << 24);
     }
 
     // blend two colors w/ specified ratio, resulting color won't have alpha channel
     @ColorInt
     public static int blend(
-            @ColorInt int foreground,
-            @ColorInt int background,
-            @FloatRange(from = 0.0F, to = 1.0F) float ratio) {
+        @ColorInt int foreground,
+        @ColorInt int background,
+        @FloatRange(from = 0.0F, to = 1.0F) float ratio)
+    {
         return Color.rgb(
-                (int) (((1F - ratio) * Color.red(foreground)) + (ratio * Color.red(background))),
-                (int) (((1F - ratio) * Color.green(foreground)) + (ratio * Color.green(background))),
-                (int) (((1F - ratio) * Color.blue(foreground)) + (ratio * Color.blue(background)))
+            (int) (((1F - ratio) * Color.red(foreground)) + (ratio * Color.red(background))),
+            (int) (((1F - ratio) * Color.green(foreground)) + (ratio * Color.green(background))),
+            (int) (((1F - ratio) * Color.blue(foreground)) + (ratio * Color.blue(background)))
         );
-    }
-
-    private ColorUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/Dip.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/Dip.java
@@ -4,26 +4,31 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
-public class Dip {
-
-    @NonNull
-    public static Dip create(@NonNull Context context) {
-        return new Dip(context.getResources().getDisplayMetrics().density);
-    }
-
-    @NonNull
-    public static Dip create(float density) {
-        return new Dip(density);
-    }
+public class Dip
+{
 
     private final float density;
 
     @SuppressWarnings("WeakerAccess")
-    public Dip(float density) {
+    public Dip(float density)
+    {
         this.density = density;
     }
 
-    public int toPx(int dp) {
+    @NonNull
+    public static Dip create(@NonNull Context context)
+    {
+        return new Dip(context.getResources().getDisplayMetrics().density);
+    }
+
+    @NonNull
+    public static Dip create(float density)
+    {
+        return new Dip(density);
+    }
+
+    public int toPx(int dp)
+    {
         return (int) (dp * density + .5F);
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/DrawableUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/DrawableUtils.java
@@ -8,12 +8,15 @@ import androidx.annotation.NonNull;
  * @deprecated Please use {@link com.zeoflow.stylar.image.DrawableUtils}
  */
 @Deprecated
-public abstract class DrawableUtils {
+public abstract class DrawableUtils
+{
 
-    public static void intrinsicBounds(@NonNull Drawable drawable) {
-        drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
+    private DrawableUtils()
+    {
     }
 
-    private DrawableUtils() {
+    public static void intrinsicBounds(@NonNull Drawable drawable)
+    {
+        drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/DumpNodes.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/DumpNodes.java
@@ -13,94 +13,75 @@ import java.lang.reflect.Proxy;
 
 // utility class to print parsed Nodes hierarchy
 @SuppressWarnings({"unused", "WeakerAccess"})
-public abstract class DumpNodes {
+public abstract class DumpNodes
+{
 
-    /**
-     * Creates String representation of a node which will be used in output
-     */
-    public interface NodeProcessor {
-        @NonNull
-        String process(@NonNull Node node);
+    private DumpNodes()
+    {
     }
 
     @NonNull
     @CheckResult
-    public static String dump(@NonNull Node node) {
+    public static String dump(@NonNull Node node)
+    {
         return dump(node, null);
     }
 
     @NonNull
     @CheckResult
-    public static String dump(@NonNull Node node, @Nullable NodeProcessor nodeProcessor) {
+    public static String dump(@NonNull Node node, @Nullable NodeProcessor nodeProcessor)
+    {
 
         final NodeProcessor processor = nodeProcessor != null
-                ? nodeProcessor
-                : new NodeProcessorToString();
+            ? nodeProcessor
+            : new NodeProcessorToString();
 
         final Indent indent = new Indent();
         final StringBuilder builder = new StringBuilder();
         final Visitor visitor = (Visitor) Proxy.newProxyInstance(
-                Visitor.class.getClassLoader(),
-                new Class[]{Visitor.class},
-                new InvocationHandler() {
-                    @Override
-                    public Object invoke(Object proxy, Method method, Object[] args) {
+            Visitor.class.getClassLoader(),
+            new Class[]{Visitor.class},
+            new InvocationHandler()
+            {
+                @Override
+                public Object invoke(Object proxy, Method method, Object[] args)
+                {
 
-                        final Node argument = (Node) args[0];
+                    final Node argument = (Node) args[0];
 
-                        // initial indent
+                    // initial indent
+                    indent.appendTo(builder);
+
+                    // node info
+                    builder.append(processor.process(argument));
+
+                    // @since 4.6.0 check for first child instead of casting to Block
+                    //  (regular nodes can contain other nodes, for example Text)
+                    if (argument.getFirstChild() != null)
+                    {
+                        builder.append(" [\n");
+                        indent.increment();
+                        visitChildren((Visitor) proxy, argument);
+                        indent.decrement();
                         indent.appendTo(builder);
-
-                        // node info
-                        builder.append(processor.process(argument));
-
-                        // @since 4.6.0 check for first child instead of casting to Block
-                        //  (regular nodes can contain other nodes, for example Text)
-                        if (argument.getFirstChild() != null) {
-                            builder.append(" [\n");
-                            indent.increment();
-                            visitChildren((Visitor) proxy, argument);
-                            indent.decrement();
-                            indent.appendTo(builder);
-                            builder.append("]\n");
-                        } else {
-                            builder.append("\n");
-                        }
-
-                        return null;
+                        builder.append("]\n");
+                    } else
+                    {
+                        builder.append("\n");
                     }
-                });
+
+                    return null;
+                }
+            });
         node.accept(visitor);
         return builder.toString();
     }
 
-    private DumpNodes() {
-    }
-
-    private static class Indent {
-
-        private int count;
-
-        void increment() {
-            count += 1;
-        }
-
-        void decrement() {
-            count -= 1;
-        }
-
-        void appendTo(@NonNull StringBuilder builder) {
-            for (int i = 0; i < count; i++) {
-                builder
-                        .append(' ')
-                        .append(' ');
-            }
-        }
-    }
-
-    private static void visitChildren(@NonNull Visitor visitor, @NonNull Node parent) {
+    private static void visitChildren(@NonNull Visitor visitor, @NonNull Node parent)
+    {
         Node node = parent.getFirstChild();
-        while (node != null) {
+        while (node != null)
+        {
             // A subclass of this visitor might modify the node, resulting in getNext returning a different node or no
             // node after visiting it. So get the next node before visiting.
             Node next = node.getNext();
@@ -109,10 +90,47 @@ public abstract class DumpNodes {
         }
     }
 
-    private static class NodeProcessorToString implements NodeProcessor {
+    /**
+     * Creates String representation of a node which will be used in output
+     */
+    public interface NodeProcessor
+    {
+        @NonNull
+        String process(@NonNull Node node);
+    }
+
+    private static class Indent
+    {
+
+        private int count;
+
+        void increment()
+        {
+            count += 1;
+        }
+
+        void decrement()
+        {
+            count -= 1;
+        }
+
+        void appendTo(@NonNull StringBuilder builder)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                builder
+                    .append(' ')
+                    .append(' ');
+            }
+        }
+    }
+
+    private static class NodeProcessorToString implements NodeProcessor
+    {
         @NonNull
         @Override
-        public String process(@NonNull Node node) {
+        public String process(@NonNull Node node)
+        {
             return node.toString();
         }
     }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/LayoutUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/LayoutUtils.java
@@ -8,15 +8,21 @@ import androidx.annotation.NonNull;
 /**
  * @since 4.4.0
  */
-public abstract class LayoutUtils {
+public abstract class LayoutUtils
+{
 
     private static final float DEFAULT_EXTRA = 0F;
     private static final float DEFAULT_MULTIPLIER = 1F;
 
+    private LayoutUtils()
+    {
+    }
+
     public static int getLineBottomWithoutPaddingAndSpacing(
-            @NonNull Layout layout,
-            int line
-    ) {
+        @NonNull Layout layout,
+        int line
+    )
+    {
 
         final int bottom = layout.getLineBottom(line);
         final boolean lastLineSpacingNotAdded = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
@@ -28,18 +34,22 @@ public abstract class LayoutUtils {
 
         // simplified check
         final boolean hasLineSpacing = lineSpacingExtra != DEFAULT_EXTRA
-                || lineSpacingMultiplier != DEFAULT_MULTIPLIER;
+            || lineSpacingMultiplier != DEFAULT_MULTIPLIER;
 
         if (!hasLineSpacing
-                || (isSpanLastLine && lastLineSpacingNotAdded)) {
+            || (isSpanLastLine && lastLineSpacingNotAdded))
+        {
             lineBottom = bottom;
-        } else {
+        } else
+        {
             final float extra;
-            if (Float.compare(DEFAULT_MULTIPLIER, lineSpacingMultiplier) != 0) {
+            if (Float.compare(DEFAULT_MULTIPLIER, lineSpacingMultiplier) != 0)
+            {
                 final int lineHeight = getLineHeight(layout, line);
                 extra = lineHeight -
-                        ((lineHeight - lineSpacingExtra) / lineSpacingMultiplier);
-            } else {
+                    ((lineHeight - lineSpacingExtra) / lineSpacingMultiplier);
+            } else
+            {
                 extra = lineSpacingExtra;
             }
             lineBottom = (int) (bottom - extra + .5F);
@@ -48,25 +58,26 @@ public abstract class LayoutUtils {
         // check if it is the last line that span is occupying **and** that this line is the last
         //  one in TextView
         if (isSpanLastLine
-                && (line == layout.getLineCount() - 1)) {
+            && (line == layout.getLineCount() - 1))
+        {
             return lineBottom - layout.getBottomPadding();
         }
 
         return lineBottom;
     }
 
-    public static int getLineTopWithoutPadding(@NonNull Layout layout, int line) {
+    public static int getLineTopWithoutPadding(@NonNull Layout layout, int line)
+    {
         final int top = layout.getLineTop(line);
-        if (line == 0) {
+        if (line == 0)
+        {
             return top - layout.getTopPadding();
         }
         return top;
     }
 
-    public static int getLineHeight(@NonNull Layout layout, int line) {
+    public static int getLineHeight(@NonNull Layout layout, int line)
+    {
         return layout.getLineTop(line + 1) - layout.getLineTop(line);
-    }
-
-    private LayoutUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/LeadingMarginUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/LeadingMarginUtils.java
@@ -2,16 +2,20 @@ package com.zeoflow.stylar.utils;
 
 import android.text.Spanned;
 
-public abstract class LeadingMarginUtils {
+public abstract class LeadingMarginUtils
+{
 
-    public static boolean selfStart(int start, CharSequence text, Object span) {
+    private LeadingMarginUtils()
+    {
+    }
+
+    public static boolean selfStart(int start, CharSequence text, Object span)
+    {
         return text instanceof Spanned && ((Spanned) text).getSpanStart(span) == start;
     }
 
-    public static boolean selfEnd(int end, CharSequence text, Object span) {
+    public static boolean selfEnd(int end, CharSequence text, Object span)
+    {
         return text instanceof Spanned && ((Spanned) text).getSpanEnd(span) == end;
-    }
-
-    private LeadingMarginUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/NoCopySpannableFactory.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/NoCopySpannableFactory.java
@@ -11,21 +11,25 @@ import androidx.annotation.NonNull;
  *
  * @since 3.0.0
  */
-public class NoCopySpannableFactory extends Spannable.Factory {
+public class NoCopySpannableFactory extends Spannable.Factory
+{
 
     @NonNull
-    public static NoCopySpannableFactory getInstance() {
+    public static NoCopySpannableFactory getInstance()
+    {
         return Holder.INSTANCE;
     }
 
     @Override
-    public Spannable newSpannable(CharSequence source) {
+    public Spannable newSpannable(CharSequence source)
+    {
         return source instanceof Spannable
-                ? (Spannable) source
-                : new SpannableString(source);
+            ? (Spannable) source
+            : new SpannableString(source);
     }
 
-    static class Holder {
+    static class Holder
+    {
         private static final NoCopySpannableFactory INSTANCE = new NoCopySpannableFactory();
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/ParserUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/ParserUtils.java
@@ -7,19 +7,23 @@ import org.commonmark.node.Node;
 /**
  * @since 4.6.0
  */
-public abstract class ParserUtils {
+public abstract class ParserUtils
+{
 
-    public static void moveChildren(@NonNull Node to, @NonNull Node from) {
+    private ParserUtils()
+    {
+    }
+
+    public static void moveChildren(@NonNull Node to, @NonNull Node from)
+    {
         Node next = from.getNext();
         Node temp;
-        while (next != null) {
+        while (next != null)
+        {
             // appendChild would unlink passed node (thus making next info un-available)
             temp = next.getNext();
             to.appendChild(next);
             next = temp;
         }
-    }
-
-    private ParserUtils() {
     }
 }

--- a/stylar/src/main/java/com/zeoflow/stylar/utils/SpanUtils.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/utils/SpanUtils.java
@@ -13,25 +13,30 @@ import com.zeoflow.stylar.core.spans.TextViewSpan;
 /**
  * @since 4.4.0
  */
-public abstract class SpanUtils {
+public abstract class SpanUtils
+{
 
-    public static int width(@NonNull Canvas canvas, @NonNull CharSequence cs) {
+    public static int width(@NonNull Canvas canvas, @NonNull CharSequence cs)
+    {
         // Layout
         // TextView
         // canvas
 
-        if (cs instanceof Spanned) {
+        if (cs instanceof Spanned)
+        {
             final Spanned spanned = (Spanned) cs;
 
             // if we are displayed with layout information -> use it
             final Layout layout = TextLayoutSpan.layoutOf(spanned);
-            if (layout != null) {
+            if (layout != null)
+            {
                 return layout.getWidth();
             }
 
             // if we have TextView -> obtain width from it (exclude padding)
             final TextView textView = TextViewSpan.textViewOf(spanned);
-            if (textView != null) {
+            if (textView != null)
+            {
                 return textView.getWidth() - textView.getPaddingLeft() - textView.getPaddingRight();
             }
         }

--- a/stylar/src/main/java/com/zeoflow/stylar/view/StylarView.java
+++ b/stylar/src/main/java/com/zeoflow/stylar/view/StylarView.java
@@ -17,6 +17,8 @@ public class StylarView extends FrameLayout
 
     private Context zContext;
     private AttributeSet zAttrs;
+    private TextView mtvTextView;
+    private ScrollView mtvScrollView;
 
     public StylarView(@NonNull Context context)
     {
@@ -38,7 +40,6 @@ public class StylarView extends FrameLayout
         zAttrs = attrs;
         init();
     }
-
     public StylarView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes)
     {
         super(context, attrs, defStyleAttr, defStyleRes);
@@ -46,9 +47,6 @@ public class StylarView extends FrameLayout
         zAttrs = attrs;
         init();
     }
-
-    private TextView mtvTextView;
-    private ScrollView mtvScrollView;
 
     private void init()
     {

--- a/stylar/src/main/res/values/strings.xml
+++ b/stylar/src/main/res/values/strings.xml
@@ -1,2 +1,1 @@
-<resources>
-</resources>
+<resources></resources>


### PR DESCRIPTION
When `flow-kit` package was included into another application or library an error that contained the Flow class was thrown (see issue #6).

This was fixed by removing java5 annotations lib.

[Contributing](https://github.com/zeoflow/stylar/blob/master/docs/contributing.md)
has more information and tips for a great pull request.
